### PR TITLE
feat(attractor): convergence detection + checkpoints

### DIFF
--- a/internal/attractor/convergence.go
+++ b/internal/attractor/convergence.go
@@ -1,0 +1,167 @@
+package attractor
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Trend classifies the direction of score history.
+type Trend string
+
+// Trend constants for score trajectory classification.
+const (
+	TrendImproving  Trend = "improving"
+	TrendPlateau    Trend = "plateau"
+	TrendRegressing Trend = "regressing"
+	TrendConverged  Trend = "converged"
+)
+
+const checkpointFile = "checkpoint.json"
+
+var errNoCheckpoint = errors.New("attractor: no checkpoint found")
+
+// CheckpointMeta holds metadata about a saved checkpoint.
+type CheckpointMeta struct {
+	Iteration    int       `json:"iteration"`
+	Satisfaction float64   `json:"satisfaction"`
+	Trend        Trend     `json:"trend"`
+	Timestamp    time.Time `json:"timestamp"`
+}
+
+// DetectTrend classifies the trajectory of a score history.
+// threshold is the convergence threshold, stallLimit defines the lookback window size.
+func DetectTrend(history []float64, threshold float64, stallLimit int) Trend {
+	if len(history) <= 1 {
+		return TrendPlateau
+	}
+	if stallLimit < 2 {
+		stallLimit = 2
+	}
+
+	last := history[len(history)-1]
+	if last >= threshold {
+		return TrendConverged
+	}
+
+	// Window = last stallLimit entries (or all if fewer).
+	windowStart := len(history) - stallLimit
+	if windowStart < 0 {
+		windowStart = 0
+	}
+	window := history[windowStart:]
+
+	// All scores in window identical → plateau.
+	allEqual := true
+	for _, s := range window[1:] {
+		if s != window[0] {
+			allEqual = false
+			break
+		}
+	}
+	if allEqual {
+		return TrendPlateau
+	}
+
+	// Baseline = score just before window, or first in window if window covers all.
+	var baseline float64
+	if windowStart > 0 {
+		baseline = history[windowStart-1]
+	} else {
+		baseline = window[0]
+	}
+
+	// Check if last < max in window → regressing (peaked then dropped).
+	maxInWindow := window[0]
+	for _, s := range window[1:] {
+		if s > maxInWindow {
+			maxInWindow = s
+		}
+	}
+	if last < maxInWindow {
+		return TrendRegressing
+	}
+
+	if last > baseline {
+		return TrendImproving
+	}
+
+	return TrendPlateau
+}
+
+// SaveCheckpoint writes generated files and metadata to a checkpoint directory.
+func SaveCheckpoint(dir string, files map[string]string, meta CheckpointMeta) error {
+	if err := writeFiles(dir, files); err != nil {
+		return fmt.Errorf("attractor: save checkpoint files: %w", err)
+	}
+
+	data, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return fmt.Errorf("attractor: marshal checkpoint meta: %w", err)
+	}
+
+	metaPath := filepath.Join(dir, checkpointFile)
+	if err := os.WriteFile(metaPath, data, 0o600); err != nil {
+		return fmt.Errorf("attractor: write checkpoint meta: %w", err)
+	}
+
+	return nil
+}
+
+// LoadCheckpoint reads a checkpoint directory and returns the files and metadata.
+// Returns errNoCheckpoint if the checkpoint.json file does not exist.
+func LoadCheckpoint(dir string) (map[string]string, CheckpointMeta, error) {
+	metaPath := filepath.Join(dir, checkpointFile)
+
+	data, err := os.ReadFile(metaPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, CheckpointMeta{}, errNoCheckpoint
+		}
+		return nil, CheckpointMeta{}, fmt.Errorf("attractor: read checkpoint meta: %w", err)
+	}
+
+	var meta CheckpointMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return nil, CheckpointMeta{}, fmt.Errorf("attractor: unmarshal checkpoint meta: %w", err)
+	}
+
+	files := make(map[string]string)
+	err = filepath.WalkDir(dir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return fmt.Errorf("attractor: rel path: %w", err)
+		}
+
+		// Skip the checkpoint metadata file.
+		if rel == checkpointFile {
+			return nil
+		}
+
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("attractor: read file %s: %w", rel, err)
+		}
+
+		// Normalize path separators to forward slashes.
+		files[strings.ReplaceAll(rel, string(filepath.Separator), "/")] = string(content)
+		return nil
+	})
+	if err != nil {
+		return nil, CheckpointMeta{}, fmt.Errorf("attractor: walk checkpoint dir: %w", err)
+	}
+
+	return files, meta, nil
+}

--- a/internal/attractor/convergence_test.go
+++ b/internal/attractor/convergence_test.go
@@ -1,0 +1,269 @@
+package attractor
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestDetectTrend(t *testing.T) {
+	tests := []struct {
+		name       string
+		history    []float64
+		threshold  float64
+		stallLimit int
+		want       Trend
+	}{
+		{
+			name:       "empty history",
+			history:    nil,
+			threshold:  95,
+			stallLimit: 3,
+			want:       TrendPlateau,
+		},
+		{
+			name:       "single entry",
+			history:    []float64{50},
+			threshold:  95,
+			stallLimit: 3,
+			want:       TrendPlateau,
+		},
+		{
+			name:       "converged at threshold",
+			history:    []float64{50, 60, 95},
+			threshold:  95,
+			stallLimit: 3,
+			want:       TrendConverged,
+		},
+		{
+			name:       "converged above threshold",
+			history:    []float64{50, 60, 100},
+			threshold:  95,
+			stallLimit: 3,
+			want:       TrendConverged,
+		},
+		{
+			name:       "improving",
+			history:    []float64{40, 50, 60, 70},
+			threshold:  95,
+			stallLimit: 3,
+			want:       TrendImproving,
+		},
+		{
+			name:       "plateau flat scores",
+			history:    []float64{50, 50, 50},
+			threshold:  95,
+			stallLimit: 3,
+			want:       TrendPlateau,
+		},
+		{
+			name:       "regressing",
+			history:    []float64{40, 60, 80, 70},
+			threshold:  95,
+			stallLimit: 3,
+			want:       TrendRegressing,
+		},
+		{
+			name:       "improving then plateau within window",
+			history:    []float64{40, 60, 60, 60},
+			threshold:  95,
+			stallLimit: 3,
+			want:       TrendPlateau,
+		},
+		{
+			name:       "stall limit larger than history",
+			history:    []float64{40, 50},
+			threshold:  95,
+			stallLimit: 10,
+			want:       TrendImproving,
+		},
+		{
+			name:       "regressing from peak",
+			history:    []float64{40, 60, 80, 60, 50},
+			threshold:  95,
+			stallLimit: 3,
+			want:       TrendRegressing,
+		},
+		{
+			name:       "improving with baseline before window",
+			history:    []float64{30, 40, 50, 60, 70},
+			threshold:  95,
+			stallLimit: 3,
+			want:       TrendImproving,
+		},
+		{
+			name:       "stall limit zero clamped",
+			history:    []float64{40, 50, 60},
+			threshold:  95,
+			stallLimit: 0,
+			want:       TrendImproving,
+		},
+		{
+			name:       "stall limit one clamped",
+			history:    []float64{40, 50, 60},
+			threshold:  95,
+			stallLimit: 1,
+			want:       TrendImproving,
+		},
+		{
+			name:       "two entry regression",
+			history:    []float64{80, 70},
+			threshold:  95,
+			stallLimit: 3,
+			want:       TrendRegressing,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DetectTrend(tt.history, tt.threshold, tt.stallLimit)
+			if got != tt.want {
+				t.Errorf("DetectTrend(%v, %.0f, %d) = %q, want %q", tt.history, tt.threshold, tt.stallLimit, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSaveLoadCheckpoint(t *testing.T) {
+	dir := t.TempDir()
+
+	files := map[string]string{
+		"main.go":    "package main\n\nfunc main() {}\n",
+		"Dockerfile": "FROM scratch\n",
+	}
+	meta := CheckpointMeta{
+		Iteration:    3,
+		Satisfaction: 85.5,
+		Trend:        TrendImproving,
+		Timestamp:    time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC),
+	}
+
+	if err := SaveCheckpoint(dir, files, meta); err != nil {
+		t.Fatalf("SaveCheckpoint: %v", err)
+	}
+
+	gotFiles, gotMeta, err := LoadCheckpoint(dir)
+	if err != nil {
+		t.Fatalf("LoadCheckpoint: %v", err)
+	}
+
+	if gotMeta.Iteration != meta.Iteration {
+		t.Errorf("iteration = %d, want %d", gotMeta.Iteration, meta.Iteration)
+	}
+	if gotMeta.Satisfaction != meta.Satisfaction {
+		t.Errorf("satisfaction = %f, want %f", gotMeta.Satisfaction, meta.Satisfaction)
+	}
+	if gotMeta.Trend != meta.Trend {
+		t.Errorf("trend = %q, want %q", gotMeta.Trend, meta.Trend)
+	}
+	if !gotMeta.Timestamp.Equal(meta.Timestamp) {
+		t.Errorf("timestamp = %v, want %v", gotMeta.Timestamp, meta.Timestamp)
+	}
+
+	for path, content := range files {
+		got, ok := gotFiles[path]
+		if !ok {
+			t.Errorf("missing file %q in loaded checkpoint", path)
+			continue
+		}
+		if got != content {
+			t.Errorf("file %q content = %q, want %q", path, got, content)
+		}
+	}
+	if len(gotFiles) != len(files) {
+		t.Errorf("loaded %d files, want %d", len(gotFiles), len(files))
+	}
+}
+
+func TestLoadCheckpointNotFound(t *testing.T) {
+	dir := t.TempDir()
+
+	_, _, err := LoadCheckpoint(dir)
+	if !errors.Is(err, errNoCheckpoint) {
+		t.Fatalf("expected errNoCheckpoint, got %v", err)
+	}
+}
+
+func TestCheckpointWithSubdirectories(t *testing.T) {
+	dir := t.TempDir()
+
+	files := map[string]string{
+		"cmd/server/main.go":  "package main\n",
+		"internal/handler.go": "package internal\n",
+		"Dockerfile":          "FROM golang:1.22\n",
+	}
+	meta := CheckpointMeta{
+		Iteration:    5,
+		Satisfaction: 90,
+		Trend:        TrendPlateau,
+		Timestamp:    time.Date(2025, 2, 1, 12, 0, 0, 0, time.UTC),
+	}
+
+	if err := SaveCheckpoint(dir, files, meta); err != nil {
+		t.Fatalf("SaveCheckpoint: %v", err)
+	}
+
+	gotFiles, gotMeta, err := LoadCheckpoint(dir)
+	if err != nil {
+		t.Fatalf("LoadCheckpoint: %v", err)
+	}
+
+	if gotMeta.Iteration != meta.Iteration {
+		t.Errorf("iteration = %d, want %d", gotMeta.Iteration, meta.Iteration)
+	}
+
+	for path, content := range files {
+		got, ok := gotFiles[path]
+		if !ok {
+			t.Errorf("missing file %q in loaded checkpoint", path)
+			continue
+		}
+		if got != content {
+			t.Errorf("file %q content = %q, want %q", path, got, content)
+		}
+	}
+	if len(gotFiles) != len(files) {
+		t.Errorf("loaded %d files, want %d", len(gotFiles), len(files))
+	}
+}
+
+func TestSaveLoadCheckpointEmptyFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	meta := CheckpointMeta{
+		Iteration:    1,
+		Satisfaction: 0,
+		Trend:        TrendPlateau,
+		Timestamp:    time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	if err := SaveCheckpoint(dir, map[string]string{}, meta); err != nil {
+		t.Fatalf("SaveCheckpoint: %v", err)
+	}
+
+	gotFiles, gotMeta, err := LoadCheckpoint(dir)
+	if err != nil {
+		t.Fatalf("LoadCheckpoint: %v", err)
+	}
+	if len(gotFiles) != 0 {
+		t.Errorf("expected 0 files, got %d", len(gotFiles))
+	}
+	if gotMeta.Iteration != 1 {
+		t.Errorf("iteration = %d, want 1", gotMeta.Iteration)
+	}
+}
+
+func TestLoadCheckpointCorrupt(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "checkpoint.json"), []byte("{invalid"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := LoadCheckpoint(dir)
+	if err == nil {
+		t.Fatal("expected error for corrupt checkpoint")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `DetectTrend()` to classify score history as improving/plateau/regressing/converged using a sliding window over the last `stallLimit` entries
- Add `SaveCheckpoint`/`LoadCheckpoint` for persisting generated files + metadata (iteration, satisfaction, trend, timestamp) as JSON — reuses existing `writeFiles` for path traversal protection
- Standalone utilities with no modifications to existing `attractor.go` or its 12 tests — ready for future integration into the convergence loop

## Test plan
- [x] `TestDetectTrend` — 14 table-driven cases: empty, single, converged, improving, plateau, regressing, window edge cases, stallLimit clamping
- [x] `TestSaveLoadCheckpoint` — round-trip save/load with file content and metadata equality
- [x] `TestLoadCheckpointNotFound` — empty dir returns `errNoCheckpoint` sentinel
- [x] `TestCheckpointWithSubdirectories` — nested paths like `cmd/server/main.go` round-trip correctly
- [x] `TestSaveLoadCheckpointEmptyFiles` — empty files map round-trips correctly
- [x] `TestLoadCheckpointCorrupt` — invalid JSON returns error
- [x] `make test` — all existing + new tests pass
- [x] `make lint` — no violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)