### PR TITLE
feat: todo-app demo spec and 13 holdout scenarios

### DIFF
--- a/internal/scenario/todo_app_test.go
+++ b/internal/scenario/todo_app_test.go
@@ -1,0 +1,59 @@
+package scenario
+
+import (
+	"testing"
+)
+
+func TestLoadTodoAppScenarios(t *testing.T) {
+	scenarios, err := LoadDir("../../scenarios/examples/todo-app")
+	if err != nil {
+		t.Fatalf("LoadDir: %v", err)
+	}
+
+	if got := len(scenarios); got != 13 {
+		t.Fatalf("expected 13 scenarios, got %d", got)
+	}
+
+	ids := make(map[string]bool)
+	for _, s := range scenarios {
+		if s.ID == "" {
+			t.Error("scenario has empty ID")
+		}
+		if ids[s.ID] {
+			t.Errorf("duplicate scenario ID: %s", s.ID)
+		}
+		ids[s.ID] = true
+
+		if s.Description == "" {
+			t.Errorf("scenario %s has empty description", s.ID)
+		}
+		if s.SatisfactionCriteria == "" {
+			t.Errorf("scenario %s has empty satisfaction_criteria", s.ID)
+		}
+		if len(s.Steps) == 0 {
+			t.Errorf("scenario %s has no steps", s.ID)
+		}
+		for i, step := range s.Steps {
+			if step.Request.Method == "" {
+				t.Errorf("scenario %s step %d has empty method", s.ID, i)
+			}
+			if step.Request.Path == "" {
+				t.Errorf("scenario %s step %d has empty path", s.ID, i)
+			}
+			if step.Expect == "" {
+				t.Errorf("scenario %s step %d has empty expect", s.ID, i)
+			}
+		}
+	}
+
+	expectedIDs := []string{
+		"register", "crud", "list", "filter-completed", "pagination",
+		"ownership", "auth-required", "auth-invalid", "validation",
+		"not-found", "register-validation", "register-duplicate", "mark-completed",
+	}
+	for _, id := range expectedIDs {
+		if !ids[id] {
+			t.Errorf("missing expected scenario ID: %s", id)
+		}
+	}
+}

--- a/scenarios/examples/todo-app/auth-invalid.yaml
+++ b/scenarios/examples/todo-app/auth-invalid.yaml
@@ -1,0 +1,23 @@
+id: auth-invalid
+description: Requests with invalid API key return 401
+type: functional
+satisfaction_criteria: Invalid Bearer tokens are rejected with 401
+
+steps:
+  - description: GET /todos with invalid token
+    request:
+      method: GET
+      path: /todos
+      headers:
+        Authorization: "Bearer not-a-real-api-key"
+    expect: "Status 401. Response body contains an 'error' field."
+
+  - description: POST /todos with invalid token
+    request:
+      method: POST
+      path: /todos
+      headers:
+        Authorization: "Bearer 00000000-0000-0000-0000-000000000000"
+      body:
+        title: "Invalid auth todo"
+    expect: "Status 401. Response body contains an 'error' field."

--- a/scenarios/examples/todo-app/auth-required.yaml
+++ b/scenarios/examples/todo-app/auth-required.yaml
@@ -1,0 +1,33 @@
+id: auth-required
+description: Requests without Authorization header return 401
+type: functional
+satisfaction_criteria: All todo endpoints reject unauthenticated requests with 401
+
+steps:
+  - description: GET /todos without auth
+    request:
+      method: GET
+      path: /todos
+    expect: "Status 401. Response body contains an 'error' field."
+
+  - description: POST /todos without auth
+    request:
+      method: POST
+      path: /todos
+      body:
+        title: "Unauthorized todo"
+    expect: "Status 401. Response body contains an 'error' field."
+
+  - description: PUT /todos/{id} without auth
+    request:
+      method: PUT
+      path: /todos/00000000-0000-0000-0000-000000000000
+      body:
+        title: "Unauthorized update"
+    expect: "Status 401. Response body contains an 'error' field."
+
+  - description: DELETE /todos/{id} without auth
+    request:
+      method: DELETE
+      path: /todos/00000000-0000-0000-0000-000000000000
+    expect: "Status 401. Response body contains an 'error' field."

--- a/scenarios/examples/todo-app/crud.yaml
+++ b/scenarios/examples/todo-app/crud.yaml
@@ -1,0 +1,70 @@
+id: crud
+description: Create, read, update, and delete a todo
+type: functional
+satisfaction_criteria: All CRUD operations on todos return correct status codes and response bodies
+
+setup:
+  - description: Register a user
+    request:
+      method: POST
+      path: /users
+      body:
+        username: "crud_user"
+    capture:
+      - name: api_key
+        jsonpath: $.api_key
+  - description: Create a todo
+    request:
+      method: POST
+      path: /todos
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        title: "Buy groceries"
+    capture:
+      - name: todo_id
+        jsonpath: $.id
+
+steps:
+  - description: Read the created todo
+    request:
+      method: GET
+      path: /todos/{todo_id}
+      headers:
+        Authorization: "Bearer {api_key}"
+    expect: "Status 200. Response body contains 'title' equal to 'Buy groceries', 'completed' equal to false, and has 'id', 'user_id', and 'created_at' fields."
+
+  - description: Update the todo
+    request:
+      method: PUT
+      path: /todos/{todo_id}
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        title: "Buy organic groceries"
+        completed: true
+    expect: "Status 200. Response body contains 'title' equal to 'Buy organic groceries' and 'completed' equal to true. The id should remain the same."
+
+  - description: Verify update persisted
+    request:
+      method: GET
+      path: /todos/{todo_id}
+      headers:
+        Authorization: "Bearer {api_key}"
+    expect: "Status 200. Response body contains 'title' equal to 'Buy organic groceries' and 'completed' equal to true."
+
+  - description: Delete the todo
+    request:
+      method: DELETE
+      path: /todos/{todo_id}
+      headers:
+        Authorization: "Bearer {api_key}"
+    expect: "Status 204. Response body should be empty or absent."
+
+  - description: Verify delete
+    request:
+      method: GET
+      path: /todos/{todo_id}
+      headers:
+        Authorization: "Bearer {api_key}"
+    expect: "Status 404."

--- a/scenarios/examples/todo-app/filter-completed.yaml
+++ b/scenarios/examples/todo-app/filter-completed.yaml
@@ -1,0 +1,62 @@
+id: filter-completed
+description: Filter todos by completed status
+type: functional
+satisfaction_criteria: Filtering by completed status returns correct subsets and totals
+
+setup:
+  - description: Register a user
+    request:
+      method: POST
+      path: /users
+      body:
+        username: "filter_user"
+    capture:
+      - name: api_key
+        jsonpath: $.api_key
+  - description: Create first todo
+    request:
+      method: POST
+      path: /todos
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        title: "Incomplete task"
+    capture:
+      - name: todo1_id
+        jsonpath: $.id
+  - description: Create second todo
+    request:
+      method: POST
+      path: /todos
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        title: "Completed task"
+    capture:
+      - name: todo2_id
+        jsonpath: $.id
+  - description: Mark second todo as completed
+    request:
+      method: PUT
+      path: /todos/{todo2_id}
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        completed: true
+
+steps:
+  - description: Filter completed todos
+    request:
+      method: GET
+      path: /todos?completed=true
+      headers:
+        Authorization: "Bearer {api_key}"
+    expect: "Status 200. Response has 'todos' array with exactly 1 item that has 'completed' equal to true and title 'Completed task'. The 'total' field should be 1."
+
+  - description: Filter incomplete todos
+    request:
+      method: GET
+      path: /todos?completed=false
+      headers:
+        Authorization: "Bearer {api_key}"
+    expect: "Status 200. Response has 'todos' array with exactly 1 item that has 'completed' equal to false and title 'Incomplete task'. The 'total' field should be 1."

--- a/scenarios/examples/todo-app/list.yaml
+++ b/scenarios/examples/todo-app/list.yaml
@@ -1,0 +1,48 @@
+id: list
+description: Create multiple todos and verify list endpoint
+type: functional
+satisfaction_criteria: List endpoint returns all created todos with correct total count
+
+setup:
+  - description: Register a user
+    request:
+      method: POST
+      path: /users
+      body:
+        username: "list_user"
+    capture:
+      - name: api_key
+        jsonpath: $.api_key
+  - description: Create first todo
+    request:
+      method: POST
+      path: /todos
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        title: "Todo One"
+  - description: Create second todo
+    request:
+      method: POST
+      path: /todos
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        title: "Todo Two"
+  - description: Create third todo
+    request:
+      method: POST
+      path: /todos
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        title: "Todo Three"
+
+steps:
+  - description: List all todos
+    request:
+      method: GET
+      path: /todos
+      headers:
+        Authorization: "Bearer {api_key}"
+    expect: "Status 200. Response has 'todos' array with exactly 3 items and 'total' field equal to 3. Each todo should have id, title, completed, user_id, and created_at fields."

--- a/scenarios/examples/todo-app/mark-completed.yaml
+++ b/scenarios/examples/todo-app/mark-completed.yaml
@@ -1,0 +1,63 @@
+id: mark-completed
+description: Toggle todo completion status
+type: functional
+satisfaction_criteria: Todos can be marked completed and then unmarked
+
+setup:
+  - description: Register a user
+    request:
+      method: POST
+      path: /users
+      body:
+        username: "toggle_user"
+    capture:
+      - name: api_key
+        jsonpath: $.api_key
+  - description: Create a todo
+    request:
+      method: POST
+      path: /todos
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        title: "Toggleable todo"
+    capture:
+      - name: todo_id
+        jsonpath: $.id
+
+steps:
+  - description: Mark todo as completed
+    request:
+      method: PUT
+      path: /todos/{todo_id}
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        completed: true
+    expect: "Status 200. Response body contains 'completed' equal to true and 'title' equal to 'Toggleable todo'."
+
+  - description: Verify completed status persisted
+    request:
+      method: GET
+      path: /todos/{todo_id}
+      headers:
+        Authorization: "Bearer {api_key}"
+    expect: "Status 200. Response body contains 'completed' equal to true."
+
+  - description: Mark todo as incomplete again
+    request:
+      method: PUT
+      path: /todos/{todo_id}
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        completed: false
+    expect: "Status 200. Response body contains 'completed' equal to false and 'title' equal to 'Toggleable todo'."
+
+  - description: Verify incomplete status persisted
+    request:
+      method: GET
+      path: /todos/{todo_id}
+      headers:
+        Authorization: "Bearer {api_key}"
+    expect: "Status 200. Response body contains 'completed' equal to false."

--- a/scenarios/examples/todo-app/not-found.yaml
+++ b/scenarios/examples/todo-app/not-found.yaml
@@ -1,0 +1,42 @@
+id: not-found
+description: Verify 404 responses for nonexistent todos
+type: functional
+satisfaction_criteria: GET, PUT, and DELETE on nonexistent todo IDs return 404
+
+setup:
+  - description: Register a user
+    request:
+      method: POST
+      path: /users
+      body:
+        username: "notfound_user"
+    capture:
+      - name: api_key
+        jsonpath: $.api_key
+
+steps:
+  - description: GET nonexistent todo
+    request:
+      method: GET
+      path: /todos/00000000-0000-0000-0000-000000000000
+      headers:
+        Authorization: "Bearer {api_key}"
+    expect: "Status 404."
+
+  - description: PUT nonexistent todo
+    request:
+      method: PUT
+      path: /todos/00000000-0000-0000-0000-000000000000
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        title: "Ghost"
+    expect: "Status 404."
+
+  - description: DELETE nonexistent todo
+    request:
+      method: DELETE
+      path: /todos/00000000-0000-0000-0000-000000000000
+      headers:
+        Authorization: "Bearer {api_key}"
+    expect: "Status 404."

--- a/scenarios/examples/todo-app/ownership.yaml
+++ b/scenarios/examples/todo-app/ownership.yaml
@@ -1,0 +1,73 @@
+id: ownership
+description: Users cannot access other users' todos
+type: functional
+satisfaction_criteria: Accessing another user's todo returns 404 for GET, PUT, and DELETE
+
+setup:
+  - description: Register user A
+    request:
+      method: POST
+      path: /users
+      body:
+        username: "owner_a"
+    capture:
+      - name: api_key_a
+        jsonpath: $.api_key
+  - description: Register user B
+    request:
+      method: POST
+      path: /users
+      body:
+        username: "owner_b"
+    capture:
+      - name: api_key_b
+        jsonpath: $.api_key
+  - description: User A creates a todo
+    request:
+      method: POST
+      path: /todos
+      headers:
+        Authorization: "Bearer {api_key_a}"
+      body:
+        title: "User A's private todo"
+    capture:
+      - name: todo_a_id
+        jsonpath: $.id
+  - description: User B creates a todo
+    request:
+      method: POST
+      path: /todos
+      headers:
+        Authorization: "Bearer {api_key_b}"
+      body:
+        title: "User B's private todo"
+    capture:
+      - name: todo_b_id
+        jsonpath: $.id
+
+steps:
+  - description: User A tries to GET user B's todo
+    request:
+      method: GET
+      path: /todos/{todo_b_id}
+      headers:
+        Authorization: "Bearer {api_key_a}"
+    expect: "Status 404."
+
+  - description: User A tries to PUT user B's todo
+    request:
+      method: PUT
+      path: /todos/{todo_b_id}
+      headers:
+        Authorization: "Bearer {api_key_a}"
+      body:
+        title: "Hacked"
+    expect: "Status 404."
+
+  - description: User A tries to DELETE user B's todo
+    request:
+      method: DELETE
+      path: /todos/{todo_b_id}
+      headers:
+        Authorization: "Bearer {api_key_a}"
+    expect: "Status 404."

--- a/scenarios/examples/todo-app/pagination.yaml
+++ b/scenarios/examples/todo-app/pagination.yaml
@@ -1,0 +1,72 @@
+id: pagination
+description: Verify pagination with limit and offset
+type: functional
+satisfaction_criteria: Pagination returns correct subsets and total count
+
+setup:
+  - description: Register a user
+    request:
+      method: POST
+      path: /users
+      body:
+        username: "page_user"
+    capture:
+      - name: api_key
+        jsonpath: $.api_key
+  - description: Create todo 1
+    request:
+      method: POST
+      path: /todos
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        title: "Page Item 1"
+  - description: Create todo 2
+    request:
+      method: POST
+      path: /todos
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        title: "Page Item 2"
+  - description: Create todo 3
+    request:
+      method: POST
+      path: /todos
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        title: "Page Item 3"
+  - description: Create todo 4
+    request:
+      method: POST
+      path: /todos
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        title: "Page Item 4"
+  - description: Create todo 5
+    request:
+      method: POST
+      path: /todos
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        title: "Page Item 5"
+
+steps:
+  - description: Get first page with limit 2
+    request:
+      method: GET
+      path: /todos?limit=2&offset=0
+      headers:
+        Authorization: "Bearer {api_key}"
+    expect: "Status 200. Response has 'todos' array with exactly 2 items. Response has 'total' field equal to 5."
+
+  - description: Get second page with offset
+    request:
+      method: GET
+      path: /todos?limit=2&offset=2
+      headers:
+        Authorization: "Bearer {api_key}"
+    expect: "Status 200. Response has 'todos' array with exactly 2 items. Response has 'total' field equal to 5."

--- a/scenarios/examples/todo-app/register-duplicate.yaml
+++ b/scenarios/examples/todo-app/register-duplicate.yaml
@@ -1,0 +1,21 @@
+id: register-duplicate
+description: Duplicate username returns 409
+type: functional
+satisfaction_criteria: Registering an already-taken username returns 409 Conflict
+
+setup:
+  - description: Register a user
+    request:
+      method: POST
+      path: /users
+      body:
+        username: "taken_name"
+
+steps:
+  - description: Register with same username again
+    request:
+      method: POST
+      path: /users
+      body:
+        username: "taken_name"
+    expect: "Status 409. Response body contains an 'error' field with a message about the username being taken or already existing."

--- a/scenarios/examples/todo-app/register-validation.yaml
+++ b/scenarios/examples/todo-app/register-validation.yaml
@@ -1,0 +1,28 @@
+id: register-validation
+description: Verify user registration validation
+type: functional
+satisfaction_criteria: Invalid registration requests are rejected with appropriate error codes
+
+steps:
+  - description: Register with empty username
+    request:
+      method: POST
+      path: /users
+      body:
+        username: ""
+    expect: "Status 400. Response body contains an 'error' field with a message about the username being invalid or empty."
+
+  - description: Register with short username
+    request:
+      method: POST
+      path: /users
+      body:
+        username: "ab"
+    expect: "Status 400. Response body contains an 'error' field with a message about the username being too short."
+
+  - description: Register with missing username
+    request:
+      method: POST
+      path: /users
+      body: {}
+    expect: "Status 400. Response body contains an 'error' field with a message about the username being required or missing."

--- a/scenarios/examples/todo-app/register.yaml
+++ b/scenarios/examples/todo-app/register.yaml
@@ -1,0 +1,13 @@
+id: register
+description: User registration returns id, username, and api_key
+type: functional
+satisfaction_criteria: Registration returns 201 with all expected fields
+
+steps:
+  - description: Register a new user
+    request:
+      method: POST
+      path: /users
+      body:
+        username: "alice"
+    expect: "Status 201. Response body contains 'id' (UUID), 'username' equal to 'alice', and 'api_key' (UUID)."

--- a/scenarios/examples/todo-app/validation.yaml
+++ b/scenarios/examples/todo-app/validation.yaml
@@ -1,0 +1,46 @@
+id: validation
+description: Verify request validation for todo creation
+type: functional
+satisfaction_criteria: Invalid todo requests are rejected with 400 and an error message
+
+setup:
+  - description: Register a user
+    request:
+      method: POST
+      path: /users
+      body:
+        username: "validation_user"
+    capture:
+      - name: api_key
+        jsonpath: $.api_key
+
+steps:
+  - description: Create todo with empty title
+    request:
+      method: POST
+      path: /todos
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        title: ""
+    expect: "Status 400. Response body contains an 'error' field with a message about the title being invalid or empty."
+
+  - description: Create todo with missing title
+    request:
+      method: POST
+      path: /todos
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        completed: false
+    expect: "Status 400. Response body contains an 'error' field with a message about the title being required or missing."
+
+  - description: Create todo with title exceeding 200 characters
+    request:
+      method: POST
+      path: /todos
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        title: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    expect: "Status 400. Response body contains an 'error' field with a message about the title exceeding the maximum length."

--- a/specs/examples/todo-app/spec.md
+++ b/specs/examples/todo-app/spec.md
@@ -1,0 +1,96 @@
+# Todo App API
+
+A multi-user todo list API with API key authentication and per-user data isolation.
+
+## Data Models
+
+### User
+
+- `id` — UUID, generated server-side on registration
+- `username` — string, required, unique, 3–50 characters
+- `api_key` — UUID, generated server-side on registration
+
+### Todo
+
+- `id` — UUID, generated server-side on creation
+- `user_id` — UUID, the owning user
+- `title` — string, required, 1–200 characters
+- `completed` — boolean, default false
+- `created_at` — ISO 8601 timestamp, generated server-side on creation
+
+## Authentication
+
+All `/todos` endpoints require an `Authorization: Bearer {api_key}` header where `{api_key}` is the
+user's API key returned from registration. Missing or invalid API key returns `401 Unauthorized`
+with `{"error": "..."}`.
+
+## Endpoints
+
+### POST /users
+
+Register a new user.
+
+- Request body: `{"username": "..."}`
+- Response: `201 Created` with `{"id": "...", "username": "...", "api_key": "..."}`
+- Validation: return `400 Bad Request` with `{"error": "..."}` if username is missing, empty,
+  shorter than 3 characters, or exceeds 50 characters
+- Duplicate: return `409 Conflict` with `{"error": "..."}` if username is already taken
+
+### GET /todos
+
+List the authenticated user's todos with optional filtering and pagination.
+
+- Query parameters:
+  - `completed` — boolean filter (`true` or `false`), optional
+  - `limit` — integer, default 20, max 100
+  - `offset` — integer, default 0
+- Response: `200 OK` with `{"todos": [...], "total": N}` where `total` is the count of matching
+  todos (respecting the `completed` filter if set)
+- Only returns todos belonging to the authenticated user
+
+### POST /todos
+
+Create a new todo for the authenticated user.
+
+- Request body: `{"title": "..."}`
+- Response: `201 Created` with the full todo JSON including `id`, `user_id`, `completed`, and
+  `created_at`
+- Validation: return `400 Bad Request` with `{"error": "..."}` if title is missing, empty, or
+  exceeds 200 characters
+
+### GET /todos/{id}
+
+Retrieve a todo by ID.
+
+- Response: `200 OK` with the todo JSON
+- If not found or owned by a different user: `404 Not Found`
+
+### PUT /todos/{id}
+
+Update a todo.
+
+- Request body: `{"title": "...", "completed": true/false}` — both fields optional, only provided
+  fields are updated
+- Response: `200 OK` with the updated todo JSON
+- If not found or owned by a different user: `404 Not Found`
+- Validation: return `400 Bad Request` with `{"error": "..."}` if title is provided but empty or
+  exceeds 200 characters
+
+### DELETE /todos/{id}
+
+Delete a todo.
+
+- Response: `204 No Content`
+- If not found or owned by a different user: `404 Not Found`
+
+## Ownership
+
+Users can only access their own todos. Attempting to access another user's todo returns
+`404 Not Found` (not `403 Forbidden`) to avoid leaking the existence of other users' resources.
+
+## Requirements
+
+- In-memory storage (no database required)
+- Listen on port 8080
+- Any programming language
+- JSON content type for all responses


### PR DESCRIPTION
## Summary
- Add `specs/examples/todo-app/spec.md` — multi-user todo API with Bearer auth, ownership isolation, filtering, and pagination
- Add 13 scenario YAML files in `scenarios/examples/todo-app/` covering registration, CRUD, auth, ownership, validation, pagination, and filtering
- Add `internal/scenario/todo_app_test.go` validating all 13 scenarios parse correctly

## Test plan
- [x] `go build ./...` — no regressions
- [x] `make test` — all tests pass (including new `TestLoadTodoAppScenarios`)
- [x] `make lint` — 0 issues
- [x] All 13 YAML files parse with `scenario.LoadDir()`
- [x] Spec covers all behaviors tested by scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)