### PR TITLE
fix(llm): add Haiku 4.5 pricing, warn on fallback pricing

### DIFF
--- a/cmd/octopusgarden/main.go
+++ b/cmd/octopusgarden/main.go
@@ -39,6 +39,11 @@ var (
 func main() {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
 
+	if !llm.HasModelPricing(judgeModel) {
+		logger.Error("judge model has no pricing entry", "model", judgeModel)
+		os.Exit(1)
+	}
+
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 

--- a/internal/llm/anthropic.go
+++ b/internal/llm/anthropic.go
@@ -90,7 +90,10 @@ func (c *AnthropicClient) Generate(ctx context.Context, req GenerateRequest) (Ge
 	regularInput := int(resp.Usage.InputTokens)
 	output := int(resp.Usage.OutputTokens)
 
-	cost := CalculateCost(req.Model, regularInput, cacheCreation, cacheRead, output)
+	cost, usingFallback := CalculateCost(req.Model, regularInput, cacheCreation, cacheRead, output)
+	if usingFallback {
+		c.logger.Warn("using fallback pricing for unknown model", "model", req.Model)
+	}
 
 	c.logger.Info("anthropic generate",
 		"model", req.Model,
@@ -151,7 +154,10 @@ func (c *AnthropicClient) Judge(ctx context.Context, req JudgeRequest) (JudgeRes
 
 	regularInput := int(resp.Usage.InputTokens)
 	output := int(resp.Usage.OutputTokens)
-	cost := CalculateCost(req.Model, regularInput, 0, 0, output)
+	cost, usingFallback := CalculateCost(req.Model, regularInput, 0, 0, output)
+	if usingFallback {
+		c.logger.Warn("using fallback pricing for unknown model", "model", req.Model)
+	}
 
 	c.logger.Info("anthropic judge",
 		"model", req.Model,

--- a/internal/llm/anthropic_test.go
+++ b/internal/llm/anthropic_test.go
@@ -127,7 +127,7 @@ func TestAnthropicJudge(t *testing.T) {
 	resp, err := client.Judge(context.Background(), JudgeRequest{
 		SystemPrompt: "judge prompt",
 		UserPrompt:   "evaluate this",
-		Model:        "claude-haiku-3-5-20241022",
+		Model:        "claude-haiku-4-5-20251001",
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -184,6 +184,7 @@ func TestCalculateCost(t *testing.T) {
 		cacheRead     int
 		output        int
 		wantUSD       float64
+		wantFallback  bool
 	}{
 		{
 			name:    "sonnet no cache",
@@ -201,18 +202,28 @@ func TestCalculateCost(t *testing.T) {
 			wantUSD:       0.30 + 1.875 + 0.12 + 0.75,
 		},
 		{
+			name:    "haiku 4.5 no cache",
+			model:   "claude-haiku-4-5-20251001",
+			regular: 1_000_000, output: 1_000_000,
+			wantUSD: 1.00 + 5.00,
+		},
+		{
 			name:    "unknown model uses fallback",
 			model:   "unknown-model",
 			regular: 1_000_000, output: 1_000_000,
-			wantUSD: 15.00 + 75.00,
+			wantUSD:      15.00 + 75.00,
+			wantFallback: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := CalculateCost(tt.model, tt.regular, tt.cacheCreation, tt.cacheRead, tt.output)
+			got, fallback := CalculateCost(tt.model, tt.regular, tt.cacheCreation, tt.cacheRead, tt.output)
 			if math.Abs(got-tt.wantUSD) > 0.001 {
 				t.Errorf("CalculateCost() = %f, want %f", got, tt.wantUSD)
+			}
+			if fallback != tt.wantFallback {
+				t.Errorf("CalculateCost() fallback = %v, want %v", fallback, tt.wantFallback)
 			}
 		})
 	}

--- a/internal/llm/models.go
+++ b/internal/llm/models.go
@@ -22,6 +22,12 @@ var pricingTable = map[string]ModelPricing{
 		CacheWritePerMillion: 1.00,
 		CacheReadPerMillion:  0.08,
 	},
+	"claude-haiku-4-5-20251001": {
+		InputPerMillion:      1.00,
+		OutputPerMillion:     5.00,
+		CacheWritePerMillion: 1.25,
+		CacheReadPerMillion:  0.10,
+	},
 	"claude-opus-4-5": {
 		InputPerMillion:      15.00,
 		OutputPerMillion:     75.00,
@@ -39,7 +45,8 @@ var fallbackPricing = ModelPricing{
 }
 
 // CalculateCost returns the estimated USD cost for a request given token counts.
-func CalculateCost(model string, regularInputTokens, cacheCreationTokens, cacheReadTokens, outputTokens int) float64 {
+// The bool return indicates whether fallback pricing was used (true = unknown model).
+func CalculateCost(model string, regularInputTokens, cacheCreationTokens, cacheReadTokens, outputTokens int) (float64, bool) {
 	pricing, ok := pricingTable[model]
 	if !ok {
 		pricing = fallbackPricing
@@ -50,5 +57,11 @@ func CalculateCost(model string, regularInputTokens, cacheCreationTokens, cacheR
 	cost += float64(cacheReadTokens) * pricing.CacheReadPerMillion / 1_000_000
 	cost += float64(outputTokens) * pricing.OutputPerMillion / 1_000_000
 
-	return cost
+	return cost, !ok
+}
+
+// HasModelPricing reports whether the given model has an entry in the pricing table.
+func HasModelPricing(model string) bool {
+	_, ok := pricingTable[model]
+	return ok
 }


### PR DESCRIPTION
## Summary

- Add `claude-haiku-4-5-20251001` pricing entry ($1/$5/$1.25/$0.10 per MTok) to `pricingTable`
- Change `CalculateCost` to return `(float64, bool)` indicating whether fallback pricing was used
- Log `slog.Warn` in both `Generate` and `Judge` when an unknown model hits fallback pricing
- Validate the judge model has a pricing entry at startup (fail-fast in `main()`)

The judge model was silently falling back to Opus rates ($15/$75 per MTok), overstating judge costs by ~19x.

Closes #7

## Test plan

- [x] `make test` — all unit tests pass (new `TestCalculateCost` row for haiku 4.5, updated return signatures)
- [x] `make lint` — no violations
- [x] `make build` — binary compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)