### PR TITLE
feat(attractor): incremental generation with patch mode

### DIFF
--- a/cmd/octopusgarden/main.go
+++ b/cmd/octopusgarden/main.go
@@ -101,6 +101,7 @@ func runCmd(ctx context.Context, logger *slog.Logger, args []string) error {
 	model := fs.String("model", "claude-sonnet-4-20250514", "LLM model to use for generation")
 	budget := fs.Float64("budget", 5.00, "maximum budget in USD")
 	threshold := fs.Float64("threshold", 95, "satisfaction threshold (0-100)")
+	patchMode := fs.Bool("patch", false, "enable incremental patch mode (iteration 2+ sends only changed files)")
 
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: octopusgarden run [flags]\n\nFlags:\n")
@@ -161,6 +162,7 @@ func runCmd(ctx context.Context, logger *slog.Logger, args []string) error {
 		Model:     *model,
 		BudgetUSD: *budget,
 		Threshold: *threshold,
+		PatchMode: *patchMode,
 		Progress: func(p attractor.IterationProgress) {
 			if p.Outcome != attractor.OutcomeValidated {
 				fmt.Fprintf(os.Stderr, "iter %d/%d  %s  cost: $%.2f  [%s]\n", //nolint:gosec // G705 false positive: writing to stderr, not an HTTP response

--- a/internal/attractor/attractor.go
+++ b/internal/attractor/attractor.go
@@ -6,8 +6,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -88,6 +90,7 @@ type RunOptions struct {
 	WorkspaceDir  string        // default "./workspace"
 	HealthTimeout time.Duration // default 30s
 	Progress      ProgressFunc  // optional per-iteration callback
+	PatchMode     bool          // if true, iteration 2+ sends prev best files + failures
 }
 
 // RunResult holds the outcome of an attractor run.
@@ -109,18 +112,21 @@ type iterationFeedback struct {
 
 // runState holds mutable state across iterations of the attractor loop.
 type runState struct {
-	runID            string
-	opts             RunOptions
-	baseDir          string
-	bestDir          string
-	totalCost        float64
-	bestSatisfaction float64
-	stallCount       int
-	history          []iterationFeedback
-	scoreHistory     []float64
-	lastOutcome      IterationOutcome
-	lastSatisfaction float64
-	startTime        time.Time
+	runID                string
+	opts                 RunOptions
+	baseDir              string
+	bestDir              string
+	totalCost            float64
+	bestSatisfaction     float64
+	stallCount           int
+	history              []iterationFeedback
+	scoreHistory         []float64
+	lastOutcome          IterationOutcome
+	lastSatisfaction     float64
+	startTime            time.Time
+	bestFiles            map[string]string // files from the best-scoring iteration
+	patchActive          bool              // patch mode currently in effect (may disable on regression)
+	patchRegressionCount int               // consecutive regressions while patch mode active
 }
 
 func (s *runState) result(iter int, status string) *RunResult {
@@ -189,9 +195,10 @@ func (a *Attractor) Run(ctx context.Context, spec string, opts RunOptions, valid
 
 	opts = withDefaults(opts)
 	s := &runState{
-		runID:     generateRunID(),
-		opts:      opts,
-		startTime: time.Now(),
+		runID:       generateRunID(),
+		opts:        opts,
+		startTime:   time.Now(),
+		patchActive: opts.PatchMode,
 	}
 	s.baseDir = filepath.Join(opts.WorkspaceDir, s.runID)
 	s.bestDir = filepath.Join(s.baseDir, "best")
@@ -224,10 +231,18 @@ func (a *Attractor) Run(ctx context.Context, spec string, opts RunOptions, valid
 // iterate runs a single iteration of the attractor loop.
 // Returns (result, nil) for terminal conditions, (nil, nil) to continue, or (nil, err) for hard errors.
 func (a *Attractor) iterate(ctx context.Context, spec string, iter int, s *runState, validate ValidateFn) (*RunResult, error) {
+	// Build messages: patch mode sends previous best files + failures.
+	var messages []llm.Message
+	if s.patchActive && s.bestFiles != nil && iter > 1 {
+		messages = buildPatchMessages(s.history, s.bestFiles, s.bestSatisfaction)
+	} else {
+		messages = buildMessages(iter, s.history)
+	}
+
 	// Generate code via LLM.
 	genResp, err := a.llm.Generate(ctx, llm.GenerateRequest{
 		SystemPrompt: buildSystemPrompt(spec),
-		Messages:     buildMessages(iter, s.history),
+		Messages:     messages,
 		Model:        s.opts.Model,
 		CacheControl: &llm.CacheControl{Type: "ephemeral"},
 	})
@@ -244,6 +259,11 @@ func (a *Attractor) iterate(ctx context.Context, spec string, iter int, s *runSt
 		s.lastSatisfaction = 0
 		s.recordStall(iter, "parse_error", fmt.Sprintf("Failed to parse generated files: %s", err))
 		return a.checkStalled(iter, s), nil
+	}
+
+	// In patch mode, merge new output over previous best to carry forward unchanged files.
+	if s.patchActive && s.bestFiles != nil && iter > 1 {
+		files = MergeFiles(files, s.bestFiles)
 	}
 
 	// Write files to iteration directory.
@@ -307,17 +327,21 @@ func (a *Attractor) processValidation(iter int, satisfaction float64, failures [
 			return nil, fmt.Errorf("attractor: write best files: %w", err)
 		}
 		s.bestSatisfaction = satisfaction
+		s.bestFiles = maps.Clone(files)
 		return s.result(iter, StatusConverged), nil
 	}
 
 	if satisfaction > s.bestSatisfaction {
 		s.bestSatisfaction = satisfaction
+		s.bestFiles = maps.Clone(files)
 		s.stallCount = 0
+		s.patchRegressionCount = 0
 		if err := writeFiles(s.bestDir, files); err != nil {
 			return nil, fmt.Errorf("attractor: write best files: %w", err)
 		}
 	} else {
 		s.stallCount++
+		a.trackPatchRegression(iter, satisfaction, s)
 	}
 
 	s.history = append(s.history, iterationFeedback{
@@ -335,6 +359,21 @@ func (a *Attractor) processValidation(iter int, satisfaction float64, failures [
 	}
 
 	return nil, nil
+}
+
+// trackPatchRegression increments the regression counter when patch mode is active
+// and satisfaction drops below the best. After 2 consecutive regressions, patch mode
+// is disabled for the remainder of the run.
+func (a *Attractor) trackPatchRegression(iter int, satisfaction float64, s *runState) {
+	if !s.patchActive || satisfaction >= s.bestSatisfaction {
+		return
+	}
+	s.patchRegressionCount++
+	if s.patchRegressionCount >= 2 {
+		a.logger.Info("patch mode disabled after consecutive regressions",
+			"iteration", iter, "regression_count", s.patchRegressionCount)
+		s.patchActive = false
+	}
 }
 
 // checkStalled returns a stalled result if the stall limit is reached, nil otherwise.
@@ -422,6 +461,34 @@ func buildMessages(iter int, history []iterationFeedback) []llm.Message {
 	}
 
 	b.WriteString("Please generate a corrected version of the application. Output ALL files using the === FILE: path === format.")
+
+	return []llm.Message{
+		{Role: "user", Content: b.String()},
+	}
+}
+
+// buildPatchMessages constructs the user message for patch mode iterations.
+// It includes the previous best files as context and the most recent failures,
+// asking the LLM to output only changed files.
+func buildPatchMessages(history []iterationFeedback, bestFiles map[string]string, bestScore float64) []llm.Message {
+	var b strings.Builder
+	fmt.Fprintf(&b, "The current best version scored %.1f/100. Here are all current files:\n\n", bestScore)
+
+	paths := slices.Sorted(maps.Keys(bestFiles))
+	for _, p := range paths {
+		fmt.Fprintf(&b, "=== FILE: %s ===\n%s=== END FILE ===\n\n", p, bestFiles[p])
+	}
+
+	if len(history) > 0 {
+		b.WriteString("Failures to fix:\n\n")
+		start := max(len(history)-3, 0)
+		for _, fb := range history[start:] {
+			fmt.Fprintf(&b, "--- Iteration %d (%s) ---\n%s\n\n", fb.iteration, fb.kind, fb.message)
+		}
+	}
+
+	b.WriteString("Output ONLY the files that need to change using the === FILE: path === format. ")
+	b.WriteString("For files you are not changing, you may emit === UNCHANGED: path === as a comment, but this is optional.")
 
 	return []llm.Message{
 		{Role: "user", Content: b.String()},

--- a/internal/attractor/attractor_test.go
+++ b/internal/attractor/attractor_test.go
@@ -561,6 +561,304 @@ func TestProgressCallbackBuildFailure(t *testing.T) {
 	}
 }
 
+func patchOpts(t *testing.T) RunOptions {
+	t.Helper()
+	opts := defaultOpts(t)
+	opts.PatchMode = true
+	return opts
+}
+
+// isPatchMessage checks if a user message looks like a patch mode message.
+func isPatchMessage(msg string) bool {
+	return strings.Contains(msg, "current best version scored")
+}
+
+func TestPatchModeUsedOnIteration2(t *testing.T) {
+	var capturedMessages []string
+	client := &mockLLMClient{
+		generateFn: func(_ context.Context, req llm.GenerateRequest) (llm.GenerateResponse, error) {
+			if len(req.Messages) > 0 {
+				capturedMessages = append(capturedMessages, req.Messages[0].Content)
+			}
+			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
+		},
+	}
+	var callCount atomic.Int32
+	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+		n := callCount.Add(1)
+		if n == 1 {
+			return 60, []string{"missing endpoint"}, 0.005, nil
+		}
+		return 100, nil, 0.005, nil
+	}
+
+	a := New(client, &mockContainerMgr{}, testLogger())
+	result, err := a.Run(context.Background(), "Build an app", patchOpts(t), validate)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != StatusConverged {
+		t.Errorf("expected status %q, got %q", StatusConverged, result.Status)
+	}
+	if result.Iterations != 2 {
+		t.Errorf("expected 2 iterations, got %d", result.Iterations)
+	}
+	if len(capturedMessages) < 2 {
+		t.Fatalf("expected at least 2 captured messages, got %d", len(capturedMessages))
+	}
+	// Iteration 1 should use full generation.
+	if isPatchMessage(capturedMessages[0]) {
+		t.Error("iteration 1 should not use patch mode message")
+	}
+	// Iteration 2 should use patch mode (contains best files).
+	if !isPatchMessage(capturedMessages[1]) {
+		t.Error("iteration 2 should use patch mode message")
+	}
+	// Patch message should contain the files from iteration 1.
+	if !strings.Contains(capturedMessages[1], "package main") {
+		t.Error("patch message should contain previous best files content")
+	}
+}
+
+func TestPatchModeFallbackOnRegressions(t *testing.T) {
+	scores := []float64{70, 65, 60, 100}
+	var callCount atomic.Int32
+	var capturedMessages []string
+	client := &mockLLMClient{
+		generateFn: func(_ context.Context, req llm.GenerateRequest) (llm.GenerateResponse, error) {
+			if len(req.Messages) > 0 {
+				capturedMessages = append(capturedMessages, req.Messages[0].Content)
+			}
+			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
+		},
+	}
+	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+		n := callCount.Add(1)
+		idx := int(n) - 1
+		if idx >= len(scores) {
+			return 100, nil, 0.005, nil
+		}
+		return scores[idx], []string{"needs work"}, 0.005, nil
+	}
+
+	a := New(client, &mockContainerMgr{}, testLogger())
+	result, err := a.Run(context.Background(), "Build an app", patchOpts(t), validate)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != StatusConverged {
+		t.Errorf("expected converged, got %q", result.Status)
+	}
+	if len(capturedMessages) < 4 {
+		t.Fatalf("expected at least 4 messages, got %d", len(capturedMessages))
+	}
+	// Iter 1: full gen. Iter 2: patch (score 65 < 70, regression 1).
+	// Iter 3: patch (score 60 < 70, regression 2 → disable). Iter 4: full gen.
+	if isPatchMessage(capturedMessages[0]) {
+		t.Error("iteration 1 should use full gen")
+	}
+	if !isPatchMessage(capturedMessages[1]) {
+		t.Error("iteration 2 should use patch mode")
+	}
+	if !isPatchMessage(capturedMessages[2]) {
+		t.Error("iteration 3 should still use patch mode (disabled after this iteration)")
+	}
+	if isPatchMessage(capturedMessages[3]) {
+		t.Error("iteration 4 should use full gen after patch mode disabled")
+	}
+}
+
+func TestPatchModeRegressionResets(t *testing.T) {
+	scores := []float64{70, 65, 80, 75, 100}
+	var callCount atomic.Int32
+	var capturedMessages []string
+	client := &mockLLMClient{
+		generateFn: func(_ context.Context, req llm.GenerateRequest) (llm.GenerateResponse, error) {
+			if len(req.Messages) > 0 {
+				capturedMessages = append(capturedMessages, req.Messages[0].Content)
+			}
+			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
+		},
+	}
+	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+		n := callCount.Add(1)
+		idx := int(n) - 1
+		if idx >= len(scores) {
+			return 100, nil, 0.005, nil
+		}
+		return scores[idx], []string{"needs work"}, 0.005, nil
+	}
+
+	a := New(client, &mockContainerMgr{}, testLogger())
+	result, err := a.Run(context.Background(), "Build an app", patchOpts(t), validate)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != StatusConverged {
+		t.Errorf("expected converged, got %q", result.Status)
+	}
+	// Iter 1: 70 (full gen). Iter 2: 65 (patch, regression 1).
+	// Iter 3: 80 (patch, improvement → reset regression to 0).
+	// Iter 4: 75 (patch, regression 1 — not 2, so patch stays active).
+	// Iter 5: 100 (patch, converge).
+	// All iterations 2-5 should use patch mode since regression never hit 2.
+	for i := 1; i < len(capturedMessages); i++ {
+		if !isPatchMessage(capturedMessages[i]) {
+			t.Errorf("iteration %d should use patch mode", i+1)
+		}
+	}
+}
+
+func TestPatchModeDisabledByDefault(t *testing.T) {
+	var capturedMessages []string
+	client := &mockLLMClient{
+		generateFn: func(_ context.Context, req llm.GenerateRequest) (llm.GenerateResponse, error) {
+			if len(req.Messages) > 0 {
+				capturedMessages = append(capturedMessages, req.Messages[0].Content)
+			}
+			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
+		},
+	}
+	var callCount atomic.Int32
+	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+		n := callCount.Add(1)
+		if n == 1 {
+			return 60, []string{"needs work"}, 0.005, nil
+		}
+		return 100, nil, 0.005, nil
+	}
+
+	a := New(client, &mockContainerMgr{}, testLogger())
+	result, err := a.Run(context.Background(), "Build an app", defaultOpts(t), validate)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != StatusConverged {
+		t.Errorf("expected converged, got %q", result.Status)
+	}
+	// Without PatchMode, iteration 2 should NOT use patch message.
+	for i, msg := range capturedMessages {
+		if isPatchMessage(msg) {
+			t.Errorf("iteration %d should not use patch mode when PatchMode is false", i+1)
+		}
+	}
+}
+
+func TestPatchModeNotActiveWithoutBestFiles(t *testing.T) {
+	var buildCount atomic.Int32
+	var capturedMessages []string
+	client := &mockLLMClient{
+		generateFn: func(_ context.Context, req llm.GenerateRequest) (llm.GenerateResponse, error) {
+			if len(req.Messages) > 0 {
+				capturedMessages = append(capturedMessages, req.Messages[0].Content)
+			}
+			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
+		},
+	}
+	mgr := &mockContainerMgr{
+		buildFn: func(_ context.Context, _, _ string) error {
+			n := buildCount.Add(1)
+			if n == 1 {
+				return fmt.Errorf("build failed")
+			}
+			return nil
+		},
+	}
+	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+		return 100, nil, 0.005, nil
+	}
+
+	a := New(client, mgr, testLogger())
+	result, err := a.Run(context.Background(), "Build an app", patchOpts(t), validate)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != StatusConverged {
+		t.Errorf("expected converged, got %q", result.Status)
+	}
+	if len(capturedMessages) < 2 {
+		t.Fatalf("expected at least 2 messages, got %d", len(capturedMessages))
+	}
+	// Iteration 1 build failed → no bestFiles. Iteration 2 should use full gen.
+	if isPatchMessage(capturedMessages[1]) {
+		t.Error("iteration 2 should use full gen when bestFiles is nil (iter 1 build failed)")
+	}
+}
+
+func TestPatchModeMergesFiles(t *testing.T) {
+	// Iteration 1 produces 2 files. Iteration 2 produces only 1 changed file.
+	// The merged result should contain both files.
+	twoFileOutput := `=== FILE: main.go ===
+package main
+
+func main() { serve() }
+=== END FILE ===
+=== FILE: Dockerfile ===
+FROM golang:1.22
+=== END FILE ===`
+
+	oneFileOutput := `=== FILE: main.go ===
+package main
+
+func main() { serveFixed() }
+=== END FILE ===`
+
+	var callCount atomic.Int32
+	client := &mockLLMClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			n := callCount.Add(1)
+			if n == 1 {
+				return llm.GenerateResponse{Content: twoFileOutput, CostUSD: 0.01}, nil
+			}
+			return llm.GenerateResponse{Content: oneFileOutput, CostUSD: 0.01}, nil
+		},
+	}
+
+	var builtDir string
+	mgr := &mockContainerMgr{
+		buildFn: func(_ context.Context, dir, _ string) error {
+			builtDir = dir
+			return nil
+		},
+	}
+
+	var valCount atomic.Int32
+	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+		n := valCount.Add(1)
+		if n == 1 {
+			return 60, []string{"needs fix"}, 0.005, nil
+		}
+		return 100, nil, 0.005, nil
+	}
+
+	a := New(client, mgr, testLogger())
+	result, err := a.Run(context.Background(), "Build an app", patchOpts(t), validate)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != StatusConverged {
+		t.Fatalf("expected converged, got %q", result.Status)
+	}
+
+	// The directory built for iteration 2 should contain both files:
+	// main.go (updated) and Dockerfile (carried forward).
+	mainContent, err := os.ReadFile(filepath.Join(builtDir, "main.go"))
+	if err != nil {
+		t.Fatalf("failed to read main.go from build dir: %v", err)
+	}
+	if !strings.Contains(string(mainContent), "serveFixed") {
+		t.Error("main.go should contain updated content from iteration 2")
+	}
+
+	dockerContent, err := os.ReadFile(filepath.Join(builtDir, "Dockerfile"))
+	if err != nil {
+		t.Fatalf("failed to read Dockerfile from build dir: %v", err)
+	}
+	if !strings.Contains(string(dockerContent), "golang:1.22") {
+		t.Error("Dockerfile should be carried forward from iteration 1")
+	}
+}
+
 func TestValidateError(t *testing.T) {
 	client := &mockLLMClient{
 		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {

--- a/internal/attractor/fileparse.go
+++ b/internal/attractor/fileparse.go
@@ -2,6 +2,7 @@ package attractor
 
 import (
 	"errors"
+	"maps"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -13,9 +14,11 @@ var (
 )
 
 const (
-	filePrefix = "=== FILE: "
-	fileSuffix = " ==="
-	fileEnd    = "=== END FILE ==="
+	filePrefix      = "=== FILE: "
+	fileSuffix      = " ==="
+	fileEnd         = "=== END FILE ==="
+	unchangedPrefix = "=== UNCHANGED: "
+	unchangedSuffix = " ==="
 )
 
 // ParseFiles extracts file blocks from LLM output.
@@ -32,31 +35,27 @@ func ParseFiles(output string) (map[string]string, error) {
 	for _, line := range lines {
 		trimmed := strings.TrimSpace(line)
 
-		if strings.HasPrefix(trimmed, filePrefix) && strings.HasSuffix(trimmed, fileSuffix) {
-			// Extract path from === FILE: path ===
-			path := trimmed[len(filePrefix) : len(trimmed)-len(fileSuffix)]
-			path = strings.TrimSpace(path)
+		// Only skip UNCHANGED markers outside file blocks — inside a block
+		// the line is literal content and must be preserved.
+		if currentPath == "" && isUnchangedMarker(trimmed) {
+			continue
+		}
 
-			if path == "" {
-				continue
-			}
+		path, ok := extractFilePath(trimmed)
+		if ok {
 			if err := validatePath(path); err != nil {
 				return nil, err
 			}
-
 			// If we were already in a block, discard it (unclosed).
 			currentPath = path
 			currentContent.Reset()
 			continue
 		}
 
-		if trimmed == fileEnd {
-			if currentPath != "" {
-				content := normalizeTrailingNewline(currentContent.String())
-				files[currentPath] = content
-				currentPath = ""
-				currentContent.Reset()
-			}
+		if trimmed == fileEnd && currentPath != "" {
+			files[currentPath] = normalizeTrailingNewline(currentContent.String())
+			currentPath = ""
+			currentContent.Reset()
 			continue
 		}
 
@@ -72,6 +71,25 @@ func ParseFiles(output string) (map[string]string, error) {
 	return files, nil
 }
 
+// extractFilePath returns the path from a === FILE: path === header line.
+// Returns ("", false) if the line is not a file header or the path is empty.
+func extractFilePath(trimmed string) (string, bool) {
+	if !strings.HasPrefix(trimmed, filePrefix) || !strings.HasSuffix(trimmed, fileSuffix) {
+		return "", false
+	}
+	path := strings.TrimSpace(trimmed[len(filePrefix) : len(trimmed)-len(fileSuffix)])
+	if path == "" {
+		return "", false
+	}
+	return path, true
+}
+
+// isUnchangedMarker returns true for === UNCHANGED: path === advisory markers.
+// These are skipped during parsing — carry-forward is handled by MergeFiles.
+func isUnchangedMarker(trimmed string) bool {
+	return strings.HasPrefix(trimmed, unchangedPrefix) && strings.HasSuffix(trimmed, unchangedSuffix)
+}
+
 // validatePath rejects paths containing traversal components.
 func validatePath(path string) error {
 	if strings.HasPrefix(path, "/") {
@@ -82,6 +100,17 @@ func validatePath(path string) error {
 		return errPathTraversal
 	}
 	return nil
+}
+
+// MergeFiles merges new LLM output into the previous best file set.
+// Files present in newFiles replace their counterparts in prevFiles.
+// Files present in prevFiles but absent from newFiles are carried forward unchanged.
+// The result is a new map — prevFiles and newFiles are never mutated.
+func MergeFiles(newFiles, prevFiles map[string]string) map[string]string {
+	merged := make(map[string]string, len(prevFiles)+len(newFiles))
+	maps.Copy(merged, prevFiles)
+	maps.Copy(merged, newFiles)
+	return merged
 }
 
 // normalizeTrailingNewline ensures content ends with exactly one newline.

--- a/internal/attractor/fileparse_test.go
+++ b/internal/attractor/fileparse_test.go
@@ -2,6 +2,7 @@ package attractor
 
 import (
 	"errors"
+	"maps"
 	"testing"
 )
 
@@ -127,6 +128,29 @@ content
 			wantFiles: 1,
 		},
 		{
+			name: "unchanged marker ignored",
+			input: `=== UNCHANGED: keep.go ===
+=== FILE: changed.go ===
+new content
+=== END FILE ===`,
+			want: map[string]string{
+				"changed.go": "new content\n",
+			},
+			wantFiles: 1,
+		},
+		{
+			name: "unchanged marker inside open block preserved as content",
+			input: `=== FILE: main.go ===
+package main
+=== UNCHANGED: other.go ===
+func main() {}
+=== END FILE ===`,
+			want: map[string]string{
+				"main.go": "package main\n=== UNCHANGED: other.go ===\nfunc main() {}\n",
+			},
+			wantFiles: 1,
+		},
+		{
 			name: "unclosed block replaced by new block",
 			input: `=== FILE: first.go ===
 first content
@@ -171,6 +195,78 @@ second content
 				if gotContent != wantContent {
 					t.Errorf("file %q:\n  got:  %q\n  want: %q", path, gotContent, wantContent)
 				}
+			}
+		})
+	}
+}
+
+func TestMergeFiles(t *testing.T) {
+	tests := []struct {
+		name      string
+		newFiles  map[string]string
+		prevFiles map[string]string
+		want      map[string]string
+	}{
+		{
+			name:      "new overrides prev",
+			newFiles:  map[string]string{"main.go": "v2\n"},
+			prevFiles: map[string]string{"main.go": "v1\n", "Dockerfile": "FROM scratch\n"},
+			want:      map[string]string{"main.go": "v2\n", "Dockerfile": "FROM scratch\n"},
+		},
+		{
+			name:      "carry forward unmodified",
+			newFiles:  map[string]string{"handler.go": "new handler\n"},
+			prevFiles: map[string]string{"main.go": "main\n", "go.mod": "module m\n"},
+			want:      map[string]string{"handler.go": "new handler\n", "main.go": "main\n", "go.mod": "module m\n"},
+		},
+		{
+			name:      "empty new carries all prev",
+			newFiles:  map[string]string{},
+			prevFiles: map[string]string{"main.go": "main\n"},
+			want:      map[string]string{"main.go": "main\n"},
+		},
+		{
+			name:      "empty prev returns new only",
+			newFiles:  map[string]string{"main.go": "main\n"},
+			prevFiles: map[string]string{},
+			want:      map[string]string{"main.go": "main\n"},
+		},
+		{
+			name:      "both empty",
+			newFiles:  map[string]string{},
+			prevFiles: map[string]string{},
+			want:      map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Snapshot inputs to verify no mutation.
+			origNew := maps.Clone(tt.newFiles)
+			origPrev := maps.Clone(tt.prevFiles)
+
+			got := MergeFiles(tt.newFiles, tt.prevFiles)
+
+			if len(got) != len(tt.want) {
+				t.Fatalf("expected %d files, got %d: %v", len(tt.want), len(got), got)
+			}
+			for path, wantContent := range tt.want {
+				gotContent, ok := got[path]
+				if !ok {
+					t.Errorf("missing file %q", path)
+					continue
+				}
+				if gotContent != wantContent {
+					t.Errorf("file %q: got %q, want %q", path, gotContent, wantContent)
+				}
+			}
+
+			// Verify inputs were not mutated.
+			if !maps.Equal(tt.newFiles, origNew) {
+				t.Error("newFiles was mutated")
+			}
+			if !maps.Equal(tt.prevFiles, origPrev) {
+				t.Error("prevFiles was mutated")
 			}
 		})
 	}

--- a/scenarios/examples/expense-tracker/auth-invalid.yaml
+++ b/scenarios/examples/expense-tracker/auth-invalid.yaml
@@ -1,0 +1,25 @@
+id: auth-invalid
+description: Invalid API key returns 401
+type: functional
+satisfaction_criteria: Invalid Bearer token returns 401
+
+steps:
+  - description: GET /categories with invalid token
+    request:
+      method: GET
+      path: /categories
+      headers:
+        Authorization: "Bearer invalid-key-12345"
+    expect: "Status 401."
+
+  - description: POST /expenses with invalid token
+    request:
+      method: POST
+      path: /expenses
+      headers:
+        Authorization: "Bearer invalid-key-12345"
+      body:
+        amount: 10.00
+        description: "Test"
+        date: "2025-01-15"
+    expect: "Status 401."

--- a/scenarios/examples/expense-tracker/auth-required.yaml
+++ b/scenarios/examples/expense-tracker/auth-required.yaml
@@ -1,0 +1,41 @@
+id: auth-required
+description: Endpoints require authentication
+type: functional
+satisfaction_criteria: All protected endpoints return 401 without auth header
+
+steps:
+  - description: GET /categories without auth
+    request:
+      method: GET
+      path: /categories
+    expect: "Status 401."
+
+  - description: POST /categories without auth
+    request:
+      method: POST
+      path: /categories
+      body:
+        name: "Food"
+    expect: "Status 401."
+
+  - description: GET /expenses without auth
+    request:
+      method: GET
+      path: /expenses
+    expect: "Status 401."
+
+  - description: POST /expenses without auth
+    request:
+      method: POST
+      path: /expenses
+      body:
+        amount: 10.00
+        description: "Lunch"
+        date: "2025-01-15"
+    expect: "Status 401."
+
+  - description: GET /expenses/summary without auth
+    request:
+      method: GET
+      path: /expenses/summary
+    expect: "Status 401."

--- a/scenarios/examples/expense-tracker/category-crud.yaml
+++ b/scenarios/examples/expense-tracker/category-crud.yaml
@@ -1,0 +1,63 @@
+id: category-crud
+description: Create, list, and delete categories
+type: functional
+satisfaction_criteria: CRUD operations on categories return correct status codes and response bodies
+
+setup:
+  - description: Register a user
+    request:
+      method: POST
+      path: /users
+      body:
+        username: "cat_user"
+    capture:
+      - name: api_key
+        jsonpath: $.api_key
+
+steps:
+  - description: Create a category
+    request:
+      method: POST
+      path: /categories
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        name: "Food"
+    capture:
+      - name: cat_id
+        jsonpath: $.id
+    expect: "Status 201. Response body contains 'id' (UUID), 'user_id' (UUID), 'name' equal to 'Food', and 'created_at' (ISO 8601 timestamp)."
+
+  - description: Create a second category
+    request:
+      method: POST
+      path: /categories
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        name: "Transport"
+    expect: "Status 201. Response body contains 'name' equal to 'Transport'."
+
+  - description: List categories
+    request:
+      method: GET
+      path: /categories
+      headers:
+        Authorization: "Bearer {api_key}"
+    expect: "Status 200. Response body contains 'categories' array with exactly 2 items. One has name 'Food' and the other has name 'Transport'."
+
+  - description: Delete the first category
+    request:
+      method: DELETE
+      path: /categories/{cat_id}
+      headers:
+        Authorization: "Bearer {api_key}"
+    expect: "Status 204. Response body should be empty or absent."
+
+  - description: List categories after deletion
+    request:
+      method: GET
+      path: /categories
+      headers:
+        Authorization: "Bearer {api_key}"
+    expect: "Status 200. Response body contains 'categories' array with exactly 1 item with name 'Transport'."

--- a/scenarios/examples/expense-tracker/category-duplicate.yaml
+++ b/scenarios/examples/expense-tracker/category-duplicate.yaml
@@ -1,0 +1,34 @@
+id: category-duplicate
+description: Duplicate category name returns 409
+type: functional
+satisfaction_criteria: Creating a category with an existing name returns 409
+
+setup:
+  - description: Register a user
+    request:
+      method: POST
+      path: /users
+      body:
+        username: "catdup_user"
+    capture:
+      - name: api_key
+        jsonpath: $.api_key
+  - description: Create a category
+    request:
+      method: POST
+      path: /categories
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        name: "Food"
+
+steps:
+  - description: Create duplicate category
+    request:
+      method: POST
+      path: /categories
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        name: "Food"
+    expect: "Status 409. Response body contains 'error' field."

--- a/scenarios/examples/expense-tracker/category-validation.yaml
+++ b/scenarios/examples/expense-tracker/category-validation.yaml
@@ -1,0 +1,35 @@
+id: category-validation
+description: Category creation rejects invalid names
+type: functional
+satisfaction_criteria: Missing and empty names return 400
+
+setup:
+  - description: Register a user
+    request:
+      method: POST
+      path: /users
+      body:
+        username: "catval_user"
+    capture:
+      - name: api_key
+        jsonpath: $.api_key
+
+steps:
+  - description: Empty category name
+    request:
+      method: POST
+      path: /categories
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        name: ""
+    expect: "Status 400. Response body contains 'error' field."
+
+  - description: Missing category name
+    request:
+      method: POST
+      path: /categories
+      headers:
+        Authorization: "Bearer {api_key}"
+      body: {}
+    expect: "Status 400. Response body contains 'error' field."

--- a/scenarios/examples/expense-tracker/expense-crud.yaml
+++ b/scenarios/examples/expense-tracker/expense-crud.yaml
@@ -1,0 +1,78 @@
+id: expense-crud
+description: Create, read, update, and delete an expense
+type: functional
+satisfaction_criteria: All CRUD operations on expenses return correct status codes and response bodies
+
+setup:
+  - description: Register a user
+    request:
+      method: POST
+      path: /users
+      body:
+        username: "exp_user"
+    capture:
+      - name: api_key
+        jsonpath: $.api_key
+  - description: Create a category
+    request:
+      method: POST
+      path: /categories
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        name: "Food"
+    capture:
+      - name: cat_id
+        jsonpath: $.id
+
+steps:
+  - description: Create an expense with category
+    request:
+      method: POST
+      path: /expenses
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        amount: 42.50
+        description: "Weekly groceries"
+        date: "2025-01-15"
+        category_id: "{cat_id}"
+    capture:
+      - name: expense_id
+        jsonpath: $.id
+    expect: "Status 201. Response body contains 'id' (UUID), 'user_id' (UUID), 'amount' equal to 42.5 or 42.50, 'description' equal to 'Weekly groceries', 'date' equal to '2025-01-15', 'category_id' matching the category UUID, and 'created_at' (ISO 8601 timestamp)."
+
+  - description: Read the expense
+    request:
+      method: GET
+      path: /expenses/{expense_id}
+      headers:
+        Authorization: "Bearer {api_key}"
+    expect: "Status 200. Response body contains 'amount' equal to 42.5 or 42.50, 'description' equal to 'Weekly groceries', 'date' equal to '2025-01-15', and 'category_id' matching the category UUID."
+
+  - description: Update the expense
+    request:
+      method: PUT
+      path: /expenses/{expense_id}
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        amount: 55.00
+        description: "Weekly groceries (organic)"
+    expect: "Status 200. Response body contains 'amount' equal to 55 or 55.00, 'description' equal to 'Weekly groceries (organic)'. The date should still be '2025-01-15' and category_id should be unchanged."
+
+  - description: Delete the expense
+    request:
+      method: DELETE
+      path: /expenses/{expense_id}
+      headers:
+        Authorization: "Bearer {api_key}"
+    expect: "Status 204. Response body should be empty or absent."
+
+  - description: Verify delete
+    request:
+      method: GET
+      path: /expenses/{expense_id}
+      headers:
+        Authorization: "Bearer {api_key}"
+    expect: "Status 404."

--- a/scenarios/examples/expense-tracker/expense-filter.yaml
+++ b/scenarios/examples/expense-tracker/expense-filter.yaml
@@ -1,0 +1,106 @@
+id: expense-filter
+description: Filter expenses by category and date range
+type: functional
+satisfaction_criteria: Filtering by category_id, date_from, and date_to returns correct subsets
+weight: 1.5
+
+setup:
+  - description: Register a user
+    request:
+      method: POST
+      path: /users
+      body:
+        username: "expfilter_user"
+    capture:
+      - name: api_key
+        jsonpath: $.api_key
+  - description: Create food category
+    request:
+      method: POST
+      path: /categories
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        name: "Food"
+    capture:
+      - name: food_id
+        jsonpath: $.id
+  - description: Create transport category
+    request:
+      method: POST
+      path: /categories
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        name: "Transport"
+    capture:
+      - name: transport_id
+        jsonpath: $.id
+  - description: Food expense Jan 10
+    request:
+      method: POST
+      path: /expenses
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        amount: 25.00
+        description: "Groceries"
+        date: "2025-01-10"
+        category_id: "{food_id}"
+  - description: Food expense Jan 20
+    request:
+      method: POST
+      path: /expenses
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        amount: 30.00
+        description: "Restaurant"
+        date: "2025-01-20"
+        category_id: "{food_id}"
+  - description: Transport expense Jan 15
+    request:
+      method: POST
+      path: /expenses
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        amount: 15.00
+        description: "Bus pass"
+        date: "2025-01-15"
+        category_id: "{transport_id}"
+  - description: Uncategorized expense Feb 01
+    request:
+      method: POST
+      path: /expenses
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        amount: 50.00
+        description: "Misc purchase"
+        date: "2025-02-01"
+
+steps:
+  - description: Filter by food category
+    request:
+      method: GET
+      path: /expenses?category_id={food_id}
+      headers:
+        Authorization: "Bearer {api_key}"
+    expect: "Status 200. Response body contains 'expenses' array with exactly 2 items and 'total' equal to 2. Both expenses should have category_id matching the food category."
+
+  - description: Filter by date range Jan 12 to Jan 25
+    request:
+      method: GET
+      path: /expenses?date_from=2025-01-12&date_to=2025-01-25
+      headers:
+        Authorization: "Bearer {api_key}"
+    expect: "Status 200. Response body contains 'expenses' array with exactly 2 items and 'total' equal to 2. Should include the restaurant (Jan 20) and bus pass (Jan 15) but not groceries (Jan 10) or misc (Feb 01)."
+
+  - description: Filter by category and date range
+    request:
+      method: GET
+      path: /expenses?category_id={food_id}&date_from=2025-01-15&date_to=2025-01-31
+      headers:
+        Authorization: "Bearer {api_key}"
+    expect: "Status 200. Response body contains 'expenses' array with exactly 1 item and 'total' equal to 1. The expense should be the restaurant (Jan 20, food category)."

--- a/scenarios/examples/expense-tracker/expense-list.yaml
+++ b/scenarios/examples/expense-tracker/expense-list.yaml
@@ -1,0 +1,70 @@
+id: expense-list
+description: List expenses with pagination
+type: functional
+satisfaction_criteria: GET /expenses returns correct items with total count and respects pagination
+
+setup:
+  - description: Register a user
+    request:
+      method: POST
+      path: /users
+      body:
+        username: "explist_user"
+    capture:
+      - name: api_key
+        jsonpath: $.api_key
+  - description: Create expense 1
+    request:
+      method: POST
+      path: /expenses
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        amount: 10.00
+        description: "Expense one"
+        date: "2025-01-01"
+  - description: Create expense 2
+    request:
+      method: POST
+      path: /expenses
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        amount: 20.00
+        description: "Expense two"
+        date: "2025-01-02"
+  - description: Create expense 3
+    request:
+      method: POST
+      path: /expenses
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        amount: 30.00
+        description: "Expense three"
+        date: "2025-01-03"
+
+steps:
+  - description: List all expenses
+    request:
+      method: GET
+      path: /expenses
+      headers:
+        Authorization: "Bearer {api_key}"
+    expect: "Status 200. Response body contains 'expenses' array with exactly 3 items and 'total' equal to 3."
+
+  - description: List with limit 2
+    request:
+      method: GET
+      path: /expenses?limit=2
+      headers:
+        Authorization: "Bearer {api_key}"
+    expect: "Status 200. Response body contains 'expenses' array with exactly 2 items and 'total' equal to 3."
+
+  - description: List with offset 2
+    request:
+      method: GET
+      path: /expenses?limit=2&offset=2
+      headers:
+        Authorization: "Bearer {api_key}"
+    expect: "Status 200. Response body contains 'expenses' array with exactly 1 item and 'total' equal to 3."

--- a/scenarios/examples/expense-tracker/expense-no-category.yaml
+++ b/scenarios/examples/expense-tracker/expense-no-category.yaml
@@ -1,0 +1,39 @@
+id: expense-no-category
+description: Create and retrieve an expense without a category
+type: functional
+satisfaction_criteria: Expense without category_id has null category_id in response
+
+setup:
+  - description: Register a user
+    request:
+      method: POST
+      path: /users
+      body:
+        username: "nocat_user"
+    capture:
+      - name: api_key
+        jsonpath: $.api_key
+
+steps:
+  - description: Create expense without category
+    request:
+      method: POST
+      path: /expenses
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        amount: 19.99
+        description: "Uncategorized purchase"
+        date: "2025-03-01"
+    capture:
+      - name: expense_id
+        jsonpath: $.id
+    expect: "Status 201. Response body contains 'id', 'amount' equal to 19.99, 'description' equal to 'Uncategorized purchase', 'date' equal to '2025-03-01', and 'category_id' that is null."
+
+  - description: Read expense and verify null category
+    request:
+      method: GET
+      path: /expenses/{expense_id}
+      headers:
+        Authorization: "Bearer {api_key}"
+    expect: "Status 200. Response body contains 'category_id' that is null and 'amount' equal to 19.99."

--- a/scenarios/examples/expense-tracker/expense-summary.yaml
+++ b/scenarios/examples/expense-tracker/expense-summary.yaml
@@ -1,0 +1,106 @@
+id: expense-summary
+description: Per-category spending summary with date filtering
+type: functional
+satisfaction_criteria: Summary endpoint returns correct per-category totals, counts, and grand total
+weight: 2.0
+
+setup:
+  - description: Register a user
+    request:
+      method: POST
+      path: /users
+      body:
+        username: "summary_user"
+    capture:
+      - name: api_key
+        jsonpath: $.api_key
+  - description: Create food category
+    request:
+      method: POST
+      path: /categories
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        name: "Food"
+    capture:
+      - name: food_id
+        jsonpath: $.id
+  - description: Create transport category
+    request:
+      method: POST
+      path: /categories
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        name: "Transport"
+    capture:
+      - name: transport_id
+        jsonpath: $.id
+  - description: Food expense 1
+    request:
+      method: POST
+      path: /expenses
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        amount: 25.00
+        description: "Groceries"
+        date: "2025-01-10"
+        category_id: "{food_id}"
+  - description: Food expense 2
+    request:
+      method: POST
+      path: /expenses
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        amount: 35.50
+        description: "Restaurant"
+        date: "2025-01-20"
+        category_id: "{food_id}"
+  - description: Transport expense
+    request:
+      method: POST
+      path: /expenses
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        amount: 15.00
+        description: "Bus pass"
+        date: "2025-01-15"
+        category_id: "{transport_id}"
+  - description: Uncategorized expense
+    request:
+      method: POST
+      path: /expenses
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        amount: 50.00
+        description: "Misc purchase"
+        date: "2025-02-01"
+
+steps:
+  - description: Full summary without date filter
+    request:
+      method: GET
+      path: /expenses/summary
+      headers:
+        Authorization: "Bearer {api_key}"
+    expect: "Status 200. Response body contains 'categories' array and 'grand_total'. The grand_total should be 125.50. The categories array should have 3 entries: Food with total 60.50 and count 2, Transport with total 15.00 and count 1, and Uncategorized (category_id null) with total 50.00 and count 1."
+
+  - description: Summary filtered to January only
+    request:
+      method: GET
+      path: /expenses/summary?date_from=2025-01-01&date_to=2025-01-31
+      headers:
+        Authorization: "Bearer {api_key}"
+    expect: "Status 200. Response body contains 'grand_total' equal to 75.50. The categories array should have 2 entries: Food with total 60.50 and count 2, Transport with total 15.00 and count 1. The uncategorized expense (Feb 01) should not be included."
+
+  - description: Summary filtered to narrow date range
+    request:
+      method: GET
+      path: /expenses/summary?date_from=2025-01-15&date_to=2025-01-31
+      headers:
+        Authorization: "Bearer {api_key}"
+    expect: "Status 200. Response body contains 'grand_total' equal to 50.50. Should include Food with total 35.50 and count 1 (restaurant only), and Transport with total 15.00 and count 1."

--- a/scenarios/examples/expense-tracker/expense-validation.yaml
+++ b/scenarios/examples/expense-tracker/expense-validation.yaml
@@ -1,0 +1,88 @@
+id: expense-validation
+description: Expense creation rejects invalid inputs
+type: functional
+satisfaction_criteria: Invalid amount, description, date, and category_id all return 400
+weight: 1.5
+
+setup:
+  - description: Register a user
+    request:
+      method: POST
+      path: /users
+      body:
+        username: "expval_user"
+    capture:
+      - name: api_key
+        jsonpath: $.api_key
+
+steps:
+  - description: Missing amount
+    request:
+      method: POST
+      path: /expenses
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        description: "Test"
+        date: "2025-01-15"
+    expect: "Status 400. Response body contains 'error' field."
+
+  - description: Zero amount
+    request:
+      method: POST
+      path: /expenses
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        amount: 0
+        description: "Test"
+        date: "2025-01-15"
+    expect: "Status 400. Response body contains 'error' field."
+
+  - description: Negative amount
+    request:
+      method: POST
+      path: /expenses
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        amount: -5.00
+        description: "Test"
+        date: "2025-01-15"
+    expect: "Status 400. Response body contains 'error' field."
+
+  - description: Missing description
+    request:
+      method: POST
+      path: /expenses
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        amount: 10.00
+        date: "2025-01-15"
+    expect: "Status 400. Response body contains 'error' field."
+
+  - description: Invalid date format
+    request:
+      method: POST
+      path: /expenses
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        amount: 10.00
+        description: "Test"
+        date: "01-15-2025"
+    expect: "Status 400. Response body contains 'error' field."
+
+  - description: Non-existent category_id
+    request:
+      method: POST
+      path: /expenses
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        amount: 10.00
+        description: "Test"
+        date: "2025-01-15"
+        category_id: "00000000-0000-0000-0000-000000000000"
+    expect: "Status 400. Response body contains 'error' field."

--- a/scenarios/examples/expense-tracker/not-found.yaml
+++ b/scenarios/examples/expense-tracker/not-found.yaml
@@ -1,0 +1,50 @@
+id: not-found
+description: Non-existent resources return 404
+type: functional
+satisfaction_criteria: GET, PUT, and DELETE on non-existent IDs return 404
+
+setup:
+  - description: Register a user
+    request:
+      method: POST
+      path: /users
+      body:
+        username: "notfound_exp_user"
+    capture:
+      - name: api_key
+        jsonpath: $.api_key
+
+steps:
+  - description: GET non-existent expense
+    request:
+      method: GET
+      path: /expenses/00000000-0000-0000-0000-000000000000
+      headers:
+        Authorization: "Bearer {api_key}"
+    expect: "Status 404."
+
+  - description: PUT non-existent expense
+    request:
+      method: PUT
+      path: /expenses/00000000-0000-0000-0000-000000000000
+      headers:
+        Authorization: "Bearer {api_key}"
+      body:
+        amount: 10.00
+    expect: "Status 404."
+
+  - description: DELETE non-existent expense
+    request:
+      method: DELETE
+      path: /expenses/00000000-0000-0000-0000-000000000000
+      headers:
+        Authorization: "Bearer {api_key}"
+    expect: "Status 404."
+
+  - description: DELETE non-existent category
+    request:
+      method: DELETE
+      path: /categories/00000000-0000-0000-0000-000000000000
+      headers:
+        Authorization: "Bearer {api_key}"
+    expect: "Status 404."

--- a/scenarios/examples/expense-tracker/ownership.yaml
+++ b/scenarios/examples/expense-tracker/ownership.yaml
@@ -1,0 +1,85 @@
+id: ownership
+description: Users cannot access other users' categories or expenses
+type: functional
+satisfaction_criteria: Cross-user access returns 404 for categories and expenses
+weight: 1.5
+
+setup:
+  - description: Register user A
+    request:
+      method: POST
+      path: /users
+      body:
+        username: "owner_a_exp"
+    capture:
+      - name: api_key_a
+        jsonpath: $.api_key
+  - description: Register user B
+    request:
+      method: POST
+      path: /users
+      body:
+        username: "owner_b_exp"
+    capture:
+      - name: api_key_b
+        jsonpath: $.api_key
+  - description: User A creates a category
+    request:
+      method: POST
+      path: /categories
+      headers:
+        Authorization: "Bearer {api_key_a}"
+      body:
+        name: "A's Category"
+    capture:
+      - name: cat_a_id
+        jsonpath: $.id
+  - description: User A creates an expense
+    request:
+      method: POST
+      path: /expenses
+      headers:
+        Authorization: "Bearer {api_key_a}"
+      body:
+        amount: 100.00
+        description: "A's expense"
+        date: "2025-01-15"
+        category_id: "{cat_a_id}"
+    capture:
+      - name: expense_a_id
+        jsonpath: $.id
+
+steps:
+  - description: User B tries to GET user A's expense
+    request:
+      method: GET
+      path: /expenses/{expense_a_id}
+      headers:
+        Authorization: "Bearer {api_key_b}"
+    expect: "Status 404."
+
+  - description: User B tries to PUT user A's expense
+    request:
+      method: PUT
+      path: /expenses/{expense_a_id}
+      headers:
+        Authorization: "Bearer {api_key_b}"
+      body:
+        amount: 999.00
+    expect: "Status 404."
+
+  - description: User B tries to DELETE user A's expense
+    request:
+      method: DELETE
+      path: /expenses/{expense_a_id}
+      headers:
+        Authorization: "Bearer {api_key_b}"
+    expect: "Status 404."
+
+  - description: User B tries to DELETE user A's category
+    request:
+      method: DELETE
+      path: /categories/{cat_a_id}
+      headers:
+        Authorization: "Bearer {api_key_b}"
+    expect: "Status 404."

--- a/scenarios/examples/expense-tracker/register-duplicate.yaml
+++ b/scenarios/examples/expense-tracker/register-duplicate.yaml
@@ -1,0 +1,21 @@
+id: register-duplicate
+description: Duplicate username returns 409
+type: functional
+satisfaction_criteria: Second registration with same username returns 409 Conflict
+
+setup:
+  - description: Register first user
+    request:
+      method: POST
+      path: /users
+      body:
+        username: "dup_user"
+
+steps:
+  - description: Register duplicate username
+    request:
+      method: POST
+      path: /users
+      body:
+        username: "dup_user"
+    expect: "Status 409. Response body contains 'error' field."

--- a/scenarios/examples/expense-tracker/register-validation.yaml
+++ b/scenarios/examples/expense-tracker/register-validation.yaml
@@ -1,0 +1,28 @@
+id: register-validation
+description: Registration rejects invalid usernames
+type: functional
+satisfaction_criteria: Missing, empty, too-short, and too-long usernames all return 400
+
+steps:
+  - description: Empty username
+    request:
+      method: POST
+      path: /users
+      body:
+        username: ""
+    expect: "Status 400. Response body contains 'error' field."
+
+  - description: Missing username field
+    request:
+      method: POST
+      path: /users
+      body: {}
+    expect: "Status 400. Response body contains 'error' field."
+
+  - description: Username too short
+    request:
+      method: POST
+      path: /users
+      body:
+        username: "ab"
+    expect: "Status 400. Response body contains 'error' field."

--- a/scenarios/examples/expense-tracker/register.yaml
+++ b/scenarios/examples/expense-tracker/register.yaml
@@ -1,0 +1,13 @@
+id: register
+description: Register a new user and receive API key
+type: functional
+satisfaction_criteria: Registration returns 201 with id, username, and api_key
+
+steps:
+  - description: Register a new user
+    request:
+      method: POST
+      path: /users
+      body:
+        username: "expense_user"
+    expect: "Status 201. Response body contains 'id' (UUID string), 'username' equal to 'expense_user', and 'api_key' (UUID string)."

--- a/specs/examples/expense-tracker/spec.md
+++ b/specs/examples/expense-tracker/spec.md
@@ -1,0 +1,165 @@
+# Expense Tracker API
+
+A multi-user expense tracking API with categories, date-range filtering, and per-category spending
+summaries. Users register to get an API key, create categories to organize expenses, and record
+expenses with amounts and dates.
+
+## Data Models
+
+### User
+
+- `id` — UUID, generated server-side on registration
+- `username` — string, required, unique, 3–50 characters
+- `api_key` — UUID, generated server-side on registration
+
+### Category
+
+- `id` — UUID, generated server-side on creation
+- `user_id` — UUID, the owning user
+- `name` — string, required, 1–100 characters, unique per user
+- `created_at` — ISO 8601 timestamp, generated server-side on creation
+
+### Expense
+
+- `id` — UUID, generated server-side on creation
+- `user_id` — UUID, the owning user
+- `category_id` — UUID, optional, must reference an existing category owned by the same user
+- `amount` — number, required, must be greater than zero (supports decimals, e.g. 9.99)
+- `description` — string, required, 1–500 characters
+- `date` — string, required, format YYYY-MM-DD
+- `created_at` — ISO 8601 timestamp, generated server-side on creation
+
+## Authentication
+
+All `/categories` and `/expenses` endpoints require an `Authorization: Bearer {api_key}` header
+where `{api_key}` is the user's API key returned from registration. Missing or invalid API key
+returns `401 Unauthorized` with `{"error": "..."}`.
+
+## Endpoints
+
+### POST /users
+
+Register a new user.
+
+- Request body: `{"username": "..."}`
+- Response: `201 Created` with `{"id": "...", "username": "...", "api_key": "..."}`
+- Validation: return `400 Bad Request` with `{"error": "..."}` if username is missing, empty,
+  shorter than 3 characters, or exceeds 50 characters
+- Duplicate: return `409 Conflict` with `{"error": "..."}` if username is already taken
+
+### POST /categories
+
+Create a new category for the authenticated user.
+
+- Request body: `{"name": "..."}`
+- Response: `201 Created` with the full category JSON including `id`, `user_id`, and `created_at`
+- Validation: return `400 Bad Request` with `{"error": "..."}` if name is missing, empty, or exceeds
+  100 characters
+- Duplicate: return `409 Conflict` with `{"error": "..."}` if the user already has a category with
+  the same name (case-sensitive)
+
+### GET /categories
+
+List the authenticated user's categories.
+
+- Response: `200 OK` with `{"categories": [...]}`
+- Only returns categories belonging to the authenticated user
+
+### DELETE /categories/{id}
+
+Delete a category. Expenses referencing this category retain their `category_id` value (it becomes a
+dangling reference) — they are not deleted or modified.
+
+- Response: `204 No Content`
+- If not found or owned by a different user: `404 Not Found`
+
+### POST /expenses
+
+Create a new expense for the authenticated user.
+
+- Request body:
+  `{"amount": 42.50, "description": "...", "date": "2025-01-15", "category_id": "..."}` where
+  `category_id` is optional
+- Response: `201 Created` with the full expense JSON including `id`, `user_id`, `category_id` (null
+  if not provided), and `created_at`
+- Validation: return `400 Bad Request` with `{"error": "..."}` if:
+  - `amount` is missing, zero, or negative
+  - `description` is missing, empty, or exceeds 500 characters
+  - `date` is missing or not in YYYY-MM-DD format
+  - `category_id` is provided but does not reference an existing category owned by the same user
+
+### GET /expenses/{id}
+
+Retrieve an expense by ID.
+
+- Response: `200 OK` with the expense JSON
+- If not found or owned by a different user: `404 Not Found`
+
+### PUT /expenses/{id}
+
+Update an expense.
+
+- Request body: `{"amount": ..., "description": "...", "date": "...", "category_id": "..."}` — all
+  fields optional, only provided fields are updated
+- To clear `category_id`, send `"category_id": null`
+- Response: `200 OK` with the updated expense JSON
+- If not found or owned by a different user: `404 Not Found`
+- Validation: same rules as creation for any provided fields
+
+### DELETE /expenses/{id}
+
+Delete an expense.
+
+- Response: `204 No Content`
+- If not found or owned by a different user: `404 Not Found`
+
+### GET /expenses
+
+List the authenticated user's expenses with optional filtering and pagination.
+
+- Query parameters:
+  - `category_id` — UUID filter, optional; return only expenses with this category
+  - `date_from` — YYYY-MM-DD, optional; return only expenses on or after this date
+  - `date_to` — YYYY-MM-DD, optional; return only expenses on or before this date
+  - `limit` — integer, default 20, max 100
+  - `offset` — integer, default 0
+- Response: `200 OK` with `{"expenses": [...], "total": N}` where `total` is the count of matching
+  expenses (respecting all filters)
+- Only returns expenses belonging to the authenticated user
+
+### GET /expenses/summary
+
+Return per-category spending totals for the authenticated user.
+
+- Query parameters:
+  - `date_from` — YYYY-MM-DD, optional; include only expenses on or after this date
+  - `date_to` — YYYY-MM-DD, optional; include only expenses on or before this date
+- Response: `200 OK` with the following structure:
+
+```json
+{
+  "categories": [
+    {"category_id": "...", "category_name": "...", "total": 150.00, "count": 3},
+    {"category_id": null, "category_name": "Uncategorized", "total": 25.50, "count": 1}
+  ],
+  "grand_total": 175.50
+}
+```
+
+- Categories with zero expenses in the date range are omitted
+- Expenses without a `category_id` are grouped under `null` / `"Uncategorized"`
+- `total` is the sum of `amount` for that category; `count` is the number of expenses
+- Only includes the authenticated user's expenses
+
+## Ownership
+
+Users can only access their own categories and expenses. Attempting to access another user's
+resource returns `404 Not Found` (not `403 Forbidden`) to avoid leaking the existence of other
+users' resources.
+
+## Requirements
+
+- In-memory storage (no database required)
+- Listen on port 8080
+- Any programming language
+- JSON content type for all responses


### PR DESCRIPTION
## Summary

- Implement patch mode for the attractor loop: iteration 2+ sends previous best files + categorized failures, asking the LLM to output only changed files
- `MergeFiles` conservatively carries forward unmentioned files (never silently deletes)
- Auto-fallback: after 2 consecutive regressions, patch mode disables and reverts to full regeneration
- Opt-in via `--patch` CLI flag (default off)
- New expense-tracker example spec + 16 holdout scenarios for testing multi-iteration convergence (categories + expenses with FK validation, date filtering, aggregation summary)

Closes #13

## Test plan

- [x] `make test` — all 32 attractor tests pass (6 new patch mode tests + 2 MergeFiles/UNCHANGED tests)
- [x] `make lint` — 0 issues
- [x] `make build` — binary compiles
- [ ] Integration: `octopusgarden run --spec specs/examples/expense-tracker/spec.md --scenarios scenarios/examples/expense-tracker --patch` converges in 3-4 iterations

🤖 Generated with [Claude Code](https://claude.com/claude-code)