### PR TITLE
feat(cli)!: shorten binary name to octog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Compiled binary
-/octopusgarden
+/octog
 
 # Claude Code local state (keep .claude/skills/ if needed)
 .claude/settings.local.json

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,8 +5,8 @@ before:
     - go mod tidy
 
 builds:
-  - main: ./cmd/octopusgarden
-    binary: octopusgarden
+  - main: ./cmd/octog
+    binary: octog
     env:
       - CGO_ENABLED=0
     goos: [linux, darwin, windows]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ scenarios → LLM judge scores satisfaction → failures feed back → converges
 ## Commands
 
 ```bash
-make build   # compile octopusgarden binary
+make build   # compile octog binary
 make test    # run unit tests
 make lint    # golangci-lint (enforced on pre-push)
 make fmt     # gci + gofumpt
@@ -21,7 +21,8 @@ commit-msg hook. Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `tes
 
 ## Module & Packages
 
-`github.com/foundatron/octopusgarden` — Go 1.22+ — binary subcommands: `run`, `validate`, `status`
+`github.com/foundatron/octopusgarden` — Go 1.22+ — binary `octog` — subcommands: `run`, `validate`,
+`status`
 
 Internal packages: `spec` (parse markdown specs), `scenario` (load/run/judge YAML scenarios),
 `attractor` (convergence loop, file parsing), `container` (Docker build/run), `llm` (client

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ pre-commit install --hook-type pre-commit --hook-type pre-push --hook-type commi
 ## Build & Test
 
 ```bash
-make build   # compile octopusgarden binary
+make build   # compile octog binary
 make test    # run unit tests
 make lint    # golangci-lint
 make fmt     # gci + gofumpt
@@ -75,7 +75,7 @@ Minimize — stdlib first. See [CLAUDE.md](CLAUDE.md) for the list of allowed ex
 ## Project Structure
 
 ```text
-cmd/octopusgarden/    CLI entrypoint and subcommands
+cmd/octog/            CLI entrypoint and subcommands
 internal/
   spec/               Parse markdown specs
   scenario/           Load, run, and judge YAML scenarios

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-BINARY := octopusgarden
+BINARY := octog
 
 .PHONY: all help build test lint fmt clean
 
@@ -11,7 +11,7 @@ help: ## Show available targets
 	  { printf "  %-10s %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 
 build: ## Build the binary
-	go build -o $(BINARY) ./cmd/octopusgarden
+	go build -o $(BINARY) ./cmd/octog
 
 test: ## Run tests
 	go test ./...

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ mkdir -p ~/.octopusgarden && echo "ANTHROPIC_API_KEY=sk-..." > ~/.octopusgarden/
 Run the factory on the included example — an Items REST API:
 
 ```bash
-octopusgarden run \
+octog run \
   --spec specs/examples/hello-api/spec.md \
   --scenarios scenarios/examples/hello-api/ \
   --model claude-sonnet-4-20250514 \
@@ -82,7 +82,7 @@ octopusgarden run \
 Validate a running service against scenarios independently:
 
 ```bash
-octopusgarden validate \
+octog validate \
   --scenarios scenarios/examples/hello-api/ \
   --target http://localhost:8080
 ```
@@ -90,7 +90,7 @@ octopusgarden validate \
 Check past run history:
 
 ```bash
-octopusgarden status
+octog status
 ```
 
 Requires: Go 1.22+, Docker, an Anthropic API key.
@@ -98,7 +98,7 @@ Requires: Go 1.22+, Docker, an Anthropic API key.
 ## CLI Reference
 
 ```text
-octopusgarden <command> [flags]
+octog <command> [flags]
 
 Commands:
   run        Run the attractor loop to generate software from a spec

--- a/cmd/octog/main.go
+++ b/cmd/octog/main.go
@@ -83,14 +83,14 @@ func main() {
 }
 
 func printUsage() {
-	fmt.Fprintf(os.Stderr, `Usage: octopusgarden <command> [flags]
+	fmt.Fprintf(os.Stderr, `Usage: octog <command> [flags]
 
 Commands:
   run        Run the attractor loop to generate software from a spec
   validate   Validate a running service against scenarios
   status     Show recent runs, scores, and costs
 
-Run 'octopusgarden <command> --help' for details.
+Run 'octog <command> --help' for details.
 `)
 }
 
@@ -105,7 +105,7 @@ func runCmd(ctx context.Context, logger *slog.Logger, args []string) error {
 	contextBudget := fs.Int("context-budget", 0, "max estimated tokens for spec in system prompt; 0 = unlimited")
 
 	fs.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: octopusgarden run [flags]\n\nFlags:\n")
+		fmt.Fprintf(os.Stderr, "Usage: octog run [flags]\n\nFlags:\n")
 		fs.PrintDefaults()
 	}
 
@@ -222,7 +222,7 @@ func validateCmd(ctx context.Context, logger *slog.Logger, args []string) error 
 	threshold := fs.Float64("threshold", 0, "minimum satisfaction score (0-100); non-zero enables exit code 1 on failure")
 
 	fs.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: octopusgarden validate [flags]\n\nFlags:\n")
+		fmt.Fprintf(os.Stderr, "Usage: octog validate [flags]\n\nFlags:\n")
 		fs.PrintDefaults()
 	}
 
@@ -269,7 +269,7 @@ func statusCmd(ctx context.Context, _ *slog.Logger, args []string) error {
 	fs := flag.NewFlagSet("status", flag.ContinueOnError)
 
 	fs.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: octopusgarden status\n\nShow recent runs, scores, and costs.\n")
+		fmt.Fprintf(os.Stderr, "Usage: octog status\n\nShow recent runs, scores, and costs.\n")
 	}
 
 	if err := fs.Parse(args); err != nil {

--- a/cmd/octog/main_test.go
+++ b/cmd/octog/main_test.go
@@ -324,13 +324,8 @@ func TestValidateThreshold(t *testing.T) {
 }
 
 func TestLoadConfig(t *testing.T) {
-	// Create temp config file.
 	dir := t.TempDir()
-	configFile := filepath.Join(dir, "config")
 	content := "# comment\n\nANTHROPIC_API_KEY=sk-test-from-config\nOPENAI_API_KEY=sk-openai-test\n"
-	if err := os.WriteFile(configFile, []byte(content), 0o600); err != nil {
-		t.Fatal(err)
-	}
 
 	// Override HOME so configPath() resolves to our temp dir.
 	ogHome := os.Getenv("HOME")

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,7 +25,7 @@ octopusgarden/
 ├── go.mod
 ├── go.sum
 ├── cmd/
-│   └── octopusgarden/
+│   └── octog/
 │       └── main.go             # CLI entrypoint, subcommand routing
 ├── internal/
 │   ├── spec/
@@ -109,7 +109,7 @@ octopusgarden/
 ## Package Dependency DAG
 
 ```text
-cmd/octopusgarden
+cmd/octog
     ├── internal/attractor   (loop, convergence, fileparse)
     │       ├── internal/llm
     │       ├── internal/spec
@@ -124,8 +124,8 @@ cmd/octopusgarden
 
 Key constraint: `internal/attractor` never imports `internal/scenario`. The attractor receives spec
 content and failure feedback as strings. The validator (scenario runner + judge) is invoked by
-`cmd/octopusgarden`, not by the attractor. Store interaction is also owned by `cmd/octopusgarden` —
-the attractor returns a `RunResult` and the CLI records it post-hoc.
+`cmd/octog`, not by the attractor. Store interaction is also owned by `cmd/octog` — the attractor
+returns a `RunResult` and the CLI records it post-hoc.
 
 ## LLM Client Interface
 
@@ -696,9 +696,9 @@ After `docker run`, poll `GET http://localhost:{port}/` every 1s for up to the c
 ## CLI Interface
 
 ```text
-octopusgarden run --spec <path> --scenarios <dir> [--model claude-sonnet-4-20250514] [--budget 5.00] [--threshold 95] [--patch] [--context-budget 0]
-octopusgarden validate --scenarios <dir> --target http://localhost:8080 [--threshold 0]
-octopusgarden status  # show recent runs, scores, costs
+octog run --spec <path> --scenarios <dir> [--model claude-sonnet-4-20250514] [--budget 5.00] [--threshold 95] [--patch] [--context-budget 0]
+octog validate --scenarios <dir> --target http://localhost:8080 [--threshold 0]
+octog status  # show recent runs, scores, costs
 ```
 
 MVP does not include `twin`, `dashboard`, or `transfuse` subcommands.

--- a/internal/attractor/attractor.go
+++ b/internal/attractor/attractor.go
@@ -21,7 +21,7 @@ import (
 var errEmptySpec = errors.New("attractor: spec content is empty")
 
 // summarizeModel is the cheap model used for spec summarization.
-// Same model as judgeModel in cmd/octopusgarden/main.go — both use Haiku for cost efficiency.
+// Same model as judgeModel in cmd/octog/main.go — both use Haiku for cost efficiency.
 const summarizeModel = "claude-haiku-4-5-20251001"
 
 // Status constants for RunResult.


### PR DESCRIPTION
## Summary

- **BREAKING CHANGE**: Renames the binary from `octopusgarden` to `octog` for ergonomic CLI usage
- Updates CLI usage strings, Makefile, goreleaser, `.gitignore`, and all documentation
- Config/data directory remains `~/.octopusgarden/` — no migration needed
- Go module path (`github.com/foundatron/octopusgarden`) is unchanged — this is a binary rename only

Closes #23

## Test plan

- [x] `make build` produces `./octog` binary
- [x] `make test` — all tests pass
- [x] `make lint` — 0 issues
- [x] `./octog run --help` shows `Usage: octog run [flags]`
- [x] Config/store paths still use `~/.octopusgarden/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)