### PR TITLE
feat(cli): add models command and configurable judge model

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,14 +69,28 @@ export ANTHROPIC_API_KEY=sk-...
 mkdir -p ~/.octopusgarden && echo "ANTHROPIC_API_KEY=sk-..." > ~/.octopusgarden/config
 ```
 
-Run the factory on the included example — an Items REST API:
+Run the factory on the included examples:
 
 ```bash
+# Items REST API (uses default model: claude-sonnet-4-6)
 octog run \
   --spec specs/examples/hello-api/spec.md \
   --scenarios scenarios/examples/hello-api/ \
-  --model claude-sonnet-4-20250514 \
   --threshold 90
+
+# Todo app with auth
+octog run \
+  --spec specs/examples/todo-app/spec.md \
+  --scenarios scenarios/examples/todo-app/ \
+  --model claude-sonnet-4-6 \
+  --judge-model claude-haiku-4-5
+
+# Expense tracker
+octog run \
+  --spec specs/examples/expense-tracker/spec.md \
+  --scenarios scenarios/examples/expense-tracker/ \
+  --model claude-sonnet-4-6 \
+  --judge-model claude-haiku-4-5
 ```
 
 Validate a running service against scenarios independently:
@@ -87,9 +101,10 @@ octog validate \
   --target http://localhost:8080
 ```
 
-Check past run history:
+List available models and check past runs:
 
 ```bash
+octog models
 octog status
 ```
 
@@ -104,27 +119,32 @@ Commands:
   run        Run the attractor loop to generate software from a spec
   validate   Validate a running service against scenarios
   status     Show recent runs, scores, and costs
+  models     List available models
 ```
+
+Run `octog models` to list available models.
 
 ### `run`
 
-| Flag               | Default                    | Description                                                    |
-| ------------------ | -------------------------- | -------------------------------------------------------------- |
-| `--spec`           | *(required)*               | Path to the spec markdown file                                 |
-| `--scenarios`      | *(required)*               | Path to the scenarios directory                                |
-| `--model`          | `claude-sonnet-4-20250514` | LLM model for code generation                                  |
-| `--budget`         | `5.00`                     | Maximum spend in USD                                           |
-| `--threshold`      | `95`                       | Satisfaction target (0-100)                                    |
-| `--patch`          | `false`                    | Incremental patch mode (iteration 2+ sends only changed files) |
-| `--context-budget` | `0`                        | Max estimated tokens for spec in system prompt; 0 = unlimited  |
+| Flag               | Default             | Description                                                    |
+| ------------------ | ------------------- | -------------------------------------------------------------- |
+| `--spec`           | *(required)*        | Path to the spec markdown file                                 |
+| `--scenarios`      | *(required)*        | Path to the scenarios directory                                |
+| `--model`          | `claude-sonnet-4-6` | LLM model for code generation                                  |
+| `--judge-model`    | `claude-haiku-4-5`  | LLM model for satisfaction judging                             |
+| `--budget`         | `5.00`              | Maximum spend in USD                                           |
+| `--threshold`      | `95`                | Satisfaction target (0-100)                                    |
+| `--patch`          | `false`             | Incremental patch mode (iteration 2+ sends only changed files) |
+| `--context-budget` | `0`                 | Max estimated tokens for spec in system prompt; 0 = unlimited  |
 
 ### `validate`
 
-| Flag          | Default      | Description                                                         |
-| ------------- | ------------ | ------------------------------------------------------------------- |
-| `--scenarios` | *(required)* | Path to the scenarios directory                                     |
-| `--target`    | *(required)* | URL of the running service to validate                              |
-| `--threshold` | `0`          | Minimum satisfaction score; non-zero enables exit code 1 on failure |
+| Flag            | Default            | Description                                                         |
+| --------------- | ------------------ | ------------------------------------------------------------------- |
+| `--scenarios`   | *(required)*       | Path to the scenarios directory                                     |
+| `--target`      | *(required)*       | URL of the running service to validate                              |
+| `--judge-model` | `claude-haiku-4-5` | LLM model for satisfaction judging                                  |
+| `--threshold`   | `0`                | Minimum satisfaction score; non-zero enables exit code 1 on failure |
 
 ### `status`
 

--- a/cmd/octog/main.go
+++ b/cmd/octog/main.go
@@ -28,8 +28,6 @@ import (
 	"github.com/foundatron/octopusgarden/internal/store"
 )
 
-const judgeModel = "claude-haiku-4-5-20251001"
-
 // stepPassThreshold is the per-step score below which a step is labeled FAIL
 // in validation output. This is purely cosmetic — the --threshold flag on
 // validateCmd controls the aggregate satisfaction gate.
@@ -41,6 +39,7 @@ var (
 	errMissingAPIKey              = errors.New("ANTHROPIC_API_KEY not set (use env var or ~/.octopusgarden/config)")
 	errBelowThreshold             = errors.New("satisfaction below threshold")
 	errInvalidThreshold           = errors.New("--threshold must be between 0 and 100")
+	errNoJudgeModelPricing        = errors.New("judge model has no pricing entry")
 )
 
 func main() {
@@ -48,11 +47,6 @@ func main() {
 
 	if err := loadConfig(logger); err != nil {
 		logger.Warn("failed to load config", "error", err)
-	}
-
-	if !llm.HasModelPricing(judgeModel) {
-		logger.Error("judge model has no pricing entry", "model", judgeModel)
-		os.Exit(1)
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
@@ -71,6 +65,8 @@ func main() {
 		err = validateCmd(ctx, logger, os.Args[2:])
 	case "status":
 		err = statusCmd(ctx, logger, os.Args[2:])
+	case "models":
+		err = modelsCmd(ctx, logger, os.Args[2:])
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n\n", os.Args[1]) //nolint:gosec // G705 false positive: writing to stderr, not an HTTP response
 		printUsage()
@@ -93,6 +89,7 @@ Commands:
   run        Run the attractor loop to generate software from a spec
   validate   Validate a running service against scenarios
   status     Show recent runs, scores, and costs
+  models     List available models
 
 Run 'octog <command> --help' for details.
 `)
@@ -102,7 +99,8 @@ func runCmd(ctx context.Context, logger *slog.Logger, args []string) error {
 	fs := flag.NewFlagSet("run", flag.ContinueOnError)
 	specFlag := fs.String("spec", "", "path to spec file (required)")
 	scenariosFlag := fs.String("scenarios", "", "path to scenarios directory (required)")
-	model := fs.String("model", "claude-sonnet-4-20250514", "LLM model to use for generation")
+	model := fs.String("model", "claude-sonnet-4-6", "LLM model to use for generation")
+	judgeModel := fs.String("judge-model", "claude-haiku-4-5", "LLM model for satisfaction judging")
 	budget := fs.Float64("budget", 5.00, "maximum budget in USD")
 	threshold := fs.Float64("threshold", 95, "satisfaction threshold (0-100)")
 	patchMode := fs.Bool("patch", false, "enable incremental patch mode (iteration 2+ sends only changed files)")
@@ -122,8 +120,8 @@ func runCmd(ctx context.Context, logger *slog.Logger, args []string) error {
 		return errSpecAndScenariosRequired
 	}
 
-	if *threshold < 0 || *threshold > 100 {
-		return errInvalidThreshold
+	if err := validateJudgeFlags(*threshold, *judgeModel); err != nil {
+		return err
 	}
 
 	// Parse spec.
@@ -160,7 +158,7 @@ func runCmd(ctx context.Context, logger *slog.Logger, args []string) error {
 	defer func() { _ = st.Close() }()
 
 	// Build validate function.
-	validateFn := buildValidateFn(scenarios, llmClient, logger)
+	validateFn := buildValidateFn(scenarios, llmClient, logger, *judgeModel)
 
 	// Create attractor and run.
 	att := attractor.New(llmClient, containerMgr, logger)
@@ -224,6 +222,7 @@ func validateCmd(ctx context.Context, logger *slog.Logger, args []string) error 
 	fs := flag.NewFlagSet("validate", flag.ContinueOnError)
 	scenariosFlag := fs.String("scenarios", "", "path to scenarios directory (required)")
 	target := fs.String("target", "", "target URL to validate against (required)")
+	judgeModel := fs.String("judge-model", "claude-haiku-4-5", "LLM model for satisfaction judging")
 	threshold := fs.Float64("threshold", 0, "minimum satisfaction score (0-100); non-zero enables exit code 1 on failure")
 
 	fs.Usage = func() {
@@ -240,8 +239,8 @@ func validateCmd(ctx context.Context, logger *slog.Logger, args []string) error 
 		return errScenariosAndTargetRequired
 	}
 
-	if *threshold < 0 || *threshold > 100 {
-		return errInvalidThreshold
+	if err := validateJudgeFlags(*threshold, *judgeModel); err != nil {
+		return err
 	}
 
 	// Load scenarios.
@@ -257,7 +256,7 @@ func validateCmd(ctx context.Context, logger *slog.Logger, args []string) error 
 	}
 	llmClient := llm.NewAnthropicClient(apiKey, logger)
 
-	agg, err := runAndScore(ctx, scenarios, *target, llmClient, logger)
+	agg, err := runAndScore(ctx, scenarios, *target, llmClient, logger, *judgeModel)
 	if err != nil {
 		return fmt.Errorf("validate: %w", err)
 	}
@@ -311,6 +310,45 @@ func statusCmd(ctx context.Context, _ *slog.Logger, args []string) error {
 	return nil
 }
 
+func validateJudgeFlags(threshold float64, judgeModel string) error {
+	if threshold < 0 || threshold > 100 {
+		return errInvalidThreshold
+	}
+	if !llm.HasModelPricing(judgeModel) {
+		return fmt.Errorf("%s: %w", judgeModel, errNoJudgeModelPricing)
+	}
+	return nil
+}
+
+func modelsCmd(ctx context.Context, logger *slog.Logger, args []string) error {
+	fs := flag.NewFlagSet("models", flag.ContinueOnError)
+
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: octog models\n\nList available models from the Anthropic API.\n")
+	}
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	apiKey := os.Getenv("ANTHROPIC_API_KEY")
+	if apiKey == "" {
+		return errMissingAPIKey
+	}
+
+	client := llm.NewAnthropicClient(apiKey, logger)
+	models, err := client.ListModels(ctx)
+	if err != nil {
+		return fmt.Errorf("list models: %w", err)
+	}
+
+	fmt.Printf("%-40s %-30s %s\n", "ID", "NAME", "CREATED")
+	for _, m := range models {
+		fmt.Printf("%-40s %-30s %s\n", m.ID, m.DisplayName, m.CreatedAt.Format(time.DateOnly))
+	}
+	return nil
+}
+
 func openStore(ctx context.Context) (*store.Store, error) {
 	path, err := resolveStorePath()
 	if err != nil {
@@ -331,7 +369,7 @@ func resolveStorePath() (string, error) {
 	return filepath.Join(dir, "runs.db"), nil
 }
 
-func runAndScore(ctx context.Context, scenarios []scenario.Scenario, targetURL string, llmClient llm.Client, logger *slog.Logger) (scenario.AggregateResult, error) {
+func runAndScore(ctx context.Context, scenarios []scenario.Scenario, targetURL string, llmClient llm.Client, logger *slog.Logger, judgeModel string) (scenario.AggregateResult, error) {
 	type indexedResult struct {
 		index int
 		ss    scenario.ScoredScenario
@@ -400,9 +438,9 @@ func runAndScore(ctx context.Context, scenarios []scenario.Scenario, targetURL s
 	return scenario.Aggregate(scored), nil
 }
 
-func buildValidateFn(scenarios []scenario.Scenario, llmClient llm.Client, logger *slog.Logger) attractor.ValidateFn {
+func buildValidateFn(scenarios []scenario.Scenario, llmClient llm.Client, logger *slog.Logger, judgeModel string) attractor.ValidateFn {
 	return func(ctx context.Context, url string) (float64, []string, float64, error) {
-		agg, err := runAndScore(ctx, scenarios, url, llmClient, logger)
+		agg, err := runAndScore(ctx, scenarios, url, llmClient, logger, judgeModel)
 		if err != nil {
 			return 0, nil, 0, err
 		}

--- a/cmd/octog/main_test.go
+++ b/cmd/octog/main_test.go
@@ -82,7 +82,7 @@ func TestRunAndScore(t *testing.T) {
 		},
 	}
 
-	agg, err := runAndScore(context.Background(), scenarios, srv.URL, mock, testLogger())
+	agg, err := runAndScore(context.Background(), scenarios, srv.URL, mock, testLogger(), "claude-haiku-4-5-20251001")
 	if err != nil {
 		t.Fatalf("runAndScore: %v", err)
 	}
@@ -130,7 +130,7 @@ func TestRunAndScoreSetupFailure(t *testing.T) {
 
 	mock := &mockLLMClient{}
 	// Use unreachable address to deterministically cause connection errors.
-	agg, err := runAndScore(context.Background(), scenarios, "http://127.0.0.1:1", mock, testLogger())
+	agg, err := runAndScore(context.Background(), scenarios, "http://127.0.0.1:1", mock, testLogger(), "claude-haiku-4-5-20251001")
 	if err != nil {
 		t.Fatalf("runAndScore: %v", err)
 	}
@@ -302,7 +302,7 @@ func TestValidateThreshold(t *testing.T) {
 				},
 			}
 
-			agg, err := runAndScore(context.Background(), scenarios, srv.URL, mock, testLogger())
+			agg, err := runAndScore(context.Background(), scenarios, srv.URL, mock, testLogger(), "claude-haiku-4-5-20251001")
 			if err != nil {
 				t.Fatalf("runAndScore: %v", err)
 			}
@@ -416,6 +416,34 @@ func TestLoadConfigUnknownKey(t *testing.T) {
 	// Unknown key should not be set.
 	if got := os.Getenv("UNKNOWN_KEY"); got == "value" {
 		t.Error("unknown key should not be set in environment")
+	}
+}
+
+func TestValidateJudgeFlags(t *testing.T) {
+	tests := []struct {
+		name       string
+		threshold  float64
+		judgeModel string
+		wantErr    error
+	}{
+		{"valid", 95, "claude-haiku-4-5", nil},
+		{"threshold too high", 200, "claude-haiku-4-5", errInvalidThreshold},
+		{"threshold negative", -1, "claude-haiku-4-5", errInvalidThreshold},
+		{"unknown judge model", 95, "nonexistent-model", errNoJudgeModelPricing},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateJudgeFlags(tt.threshold, tt.judgeModel)
+			if tt.wantErr == nil {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("got %v, want %v", err, tt.wantErr)
+			}
+		})
 	}
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -684,12 +684,14 @@ After `docker run`, poll `GET http://localhost:{port}/` every 1s for up to the c
 ## CLI Interface
 
 ```text
-octog run --spec <path> --scenarios <dir> [--model claude-sonnet-4-20250514] [--budget 5.00] [--threshold 95] [--patch] [--context-budget 0]
-octog validate --scenarios <dir> --target http://localhost:8080 [--threshold 0]
-octog status  # show recent runs, scores, costs
+octog run --spec <path> --scenarios <dir> [--model claude-sonnet-4-6] [--judge-model claude-haiku-4-5] [--budget 5.00] [--threshold 95] [--patch] [--context-budget 0]
+octog validate --scenarios <dir> --target http://localhost:8080 [--judge-model claude-haiku-4-5] [--threshold 0]
+octog status   # show recent runs, scores, costs
+octog models   # list available models from the API
 ```
 
-MVP does not include `twin`, `dashboard`, or `transfuse` subcommands.
+Subcommands: `run`, `validate`, `status`, `models`. MVP does not include `twin`, `dashboard`, or
+`transfuse` subcommands.
 
 ### Config File
 

--- a/internal/attractor/attractor.go
+++ b/internal/attractor/attractor.go
@@ -21,8 +21,8 @@ import (
 var errEmptySpec = errors.New("attractor: spec content is empty")
 
 // summarizeModel is the cheap model used for spec summarization.
-// Same model as judgeModel in cmd/octog/main.go — both use Haiku for cost efficiency.
-const summarizeModel = "claude-haiku-4-5-20251001"
+// Haiku is also the default --judge-model for cost efficiency.
+const summarizeModel = "claude-haiku-4-5"
 
 // Status constants for RunResult.
 const (

--- a/internal/llm/anthropic.go
+++ b/internal/llm/anthropic.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/option"
@@ -112,6 +113,31 @@ func (c *AnthropicClient) Generate(ctx context.Context, req GenerateRequest) (Ge
 		CacheHit:     cacheRead > 0,
 		CostUSD:      cost,
 	}, nil
+}
+
+// AvailableModel holds metadata about an available model.
+type AvailableModel struct {
+	ID          string
+	DisplayName string
+	CreatedAt   time.Time
+}
+
+// ListModels queries the Anthropic API for available models.
+func (c *AnthropicClient) ListModels(ctx context.Context) ([]AvailableModel, error) {
+	iter := c.client.Models.ListAutoPaging(ctx, anthropic.ModelListParams{})
+	var models []AvailableModel
+	for iter.Next() {
+		m := iter.Current()
+		models = append(models, AvailableModel{
+			ID:          m.ID,
+			DisplayName: m.DisplayName,
+			CreatedAt:   m.CreatedAt,
+		})
+	}
+	if err := iter.Err(); err != nil {
+		return nil, fmt.Errorf("anthropic list models: %w", err)
+	}
+	return models, nil
 }
 
 // judgeResult is the expected JSON structure from the judge LLM.

--- a/internal/llm/anthropic_test.go
+++ b/internal/llm/anthropic_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/anthropics/anthropic-sdk-go/option"
 )
@@ -272,5 +273,68 @@ func TestCacheControlPropagation(t *testing.T) {
 
 	if cc["type"] != "ephemeral" {
 		t.Errorf("cache_control.type = %v, want ephemeral", cc["type"])
+	}
+}
+
+func TestListModels(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		resp := map[string]any{
+			"data": []map[string]any{
+				{
+					"id":           "claude-sonnet-4-6",
+					"display_name": "Claude Sonnet 4.6",
+					"created_at":   "2025-05-14T00:00:00Z",
+					"type":         "model",
+				},
+				{
+					"id":           "claude-haiku-4-5",
+					"display_name": "Claude Haiku 4.5",
+					"created_at":   "2025-10-01T00:00:00Z",
+					"type":         "model",
+				},
+			},
+			"has_more": false,
+			"first_id": "claude-sonnet-4-6",
+			"last_id":  "claude-haiku-4-5",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewAnthropicClient("test-key", newTestLogger(),
+		option.WithBaseURL(server.URL),
+	)
+
+	models, err := client.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(models) != 2 {
+		t.Fatalf("len(models) = %d, want 2", len(models))
+	}
+
+	if models[0].ID != "claude-sonnet-4-6" {
+		t.Errorf("models[0].ID = %q, want %q", models[0].ID, "claude-sonnet-4-6")
+	}
+	if models[0].DisplayName != "Claude Sonnet 4.6" {
+		t.Errorf("models[0].DisplayName = %q, want %q", models[0].DisplayName, "Claude Sonnet 4.6")
+	}
+	wantTime := time.Date(2025, 5, 14, 0, 0, 0, 0, time.UTC)
+	if !models[0].CreatedAt.Equal(wantTime) {
+		t.Errorf("models[0].CreatedAt = %v, want %v", models[0].CreatedAt, wantTime)
+	}
+
+	if models[1].ID != "claude-haiku-4-5" {
+		t.Errorf("models[1].ID = %q, want %q", models[1].ID, "claude-haiku-4-5")
+	}
+	if models[1].DisplayName != "Claude Haiku 4.5" {
+		t.Errorf("models[1].DisplayName = %q, want %q", models[1].DisplayName, "Claude Haiku 4.5")
 	}
 }

--- a/internal/llm/models.go
+++ b/internal/llm/models.go
@@ -16,6 +16,12 @@ var pricingTable = map[string]ModelPricing{
 		CacheWritePerMillion: 3.75,
 		CacheReadPerMillion:  0.30,
 	},
+	"claude-sonnet-4-6": {
+		InputPerMillion:      3.00,
+		OutputPerMillion:     15.00,
+		CacheWritePerMillion: 3.75,
+		CacheReadPerMillion:  0.30,
+	},
 	"claude-haiku-3-5-20241022": {
 		InputPerMillion:      0.80,
 		OutputPerMillion:     4.00,
@@ -28,15 +34,22 @@ var pricingTable = map[string]ModelPricing{
 		CacheWritePerMillion: 1.25,
 		CacheReadPerMillion:  0.10,
 	},
+	"claude-haiku-4-5": {
+		InputPerMillion:      1.00,
+		OutputPerMillion:     5.00,
+		CacheWritePerMillion: 1.25,
+		CacheReadPerMillion:  0.10,
+	},
 	"claude-opus-4-5": {
-		InputPerMillion:      15.00,
-		OutputPerMillion:     75.00,
-		CacheWritePerMillion: 18.75,
-		CacheReadPerMillion:  1.50,
+		InputPerMillion:      5.00,
+		OutputPerMillion:     25.00,
+		CacheWritePerMillion: 6.25,
+		CacheReadPerMillion:  0.50,
 	},
 }
 
-// fallbackPricing is used for unknown models (conservative/expensive).
+// fallbackPricing is used for unknown models. Intentionally set to the most
+// expensive known model tier to avoid under-reporting costs.
 var fallbackPricing = ModelPricing{
 	InputPerMillion:      15.00,
 	OutputPerMillion:     75.00,


### PR DESCRIPTION
## Summary

- Add `octog models` subcommand that queries the Anthropic List Models API and prints a table of available models
- Add `--judge-model` flag to `run` and `validate` subcommands (default `claude-haiku-4-5`), replacing the hardcoded const
- Update default model IDs to shorter alias forms (`claude-sonnet-4-6`, `claude-haiku-4-5`)
- Fix incorrect `claude-opus-4-5` pricing from $15/$75 to $5/$25
- Add alias-form entries to the pricing table (`claude-sonnet-4-6`, `claude-haiku-4-5`)

## Test plan

- [x] `make build` compiles
- [x] `make test` — all 7 packages pass (including new `TestListModels` and `TestValidateJudgeFlags`)
- [x] `make lint` — 0 issues
- [x] `octog models` — prints model list from Anthropic API
- [x] `octog run --help` / `octog validate --help` — show `--judge-model` flag
- [x] `octog run --judge-model nonexistent-model` — errors with "judge model has no pricing entry"
- [x] Manual end-to-end: todo-app with dated model IDs converged (100%, $0.09)
- [x] Manual end-to-end: expense-tracker with alias model IDs converged (100%, $0.13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)