### PR TITLE
feat(cli): add --format json to validate and status commands

### DIFF
--- a/cmd/octog/main.go
+++ b/cmd/octog/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/foundatron/octopusgarden/internal/scenario"
 	"github.com/foundatron/octopusgarden/internal/spec"
 	"github.com/foundatron/octopusgarden/internal/store"
+	"github.com/foundatron/octopusgarden/internal/view"
 )
 
 // stepPassThreshold is the per-step score below which a step is labeled FAIL
@@ -41,6 +42,7 @@ var (
 	errBelowThreshold             = errors.New("satisfaction below threshold")
 	errInvalidThreshold           = errors.New("--threshold must be between 0 and 100")
 	errNoJudgeModelPricing        = errors.New("judge model has no pricing entry")
+	errInvalidFormat              = errors.New("--format must be \"text\" or \"json\"")
 )
 
 func main() {
@@ -228,6 +230,7 @@ func validateCmd(ctx context.Context, logger *slog.Logger, args []string) error 
 	target := fs.String("target", "", "target URL to validate against (required)")
 	judgeModel := fs.String("judge-model", "claude-haiku-4-5", "LLM model for satisfaction judging")
 	threshold := fs.Float64("threshold", 0, "minimum satisfaction score (0-100); non-zero enables exit code 1 on failure")
+	format := fs.String("format", "text", "output format: text or json")
 
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: octog validate [flags]\n\nFlags:\n")
@@ -236,6 +239,10 @@ func validateCmd(ctx context.Context, logger *slog.Logger, args []string) error 
 
 	if err := fs.Parse(args); err != nil {
 		return err
+	}
+
+	if *format != "text" && *format != "json" {
+		return errInvalidFormat
 	}
 
 	if *scenariosFlag == "" || *target == "" {
@@ -265,7 +272,15 @@ func validateCmd(ctx context.Context, logger *slog.Logger, args []string) error 
 		return fmt.Errorf("validate: %w", err)
 	}
 
-	fprintValidationResult(os.Stdout, agg)
+	switch *format {
+	case "json":
+		out := view.NewValidateOutput(agg, *target, *threshold, stepPassThreshold)
+		if err := view.WriteJSON(os.Stdout, out); err != nil {
+			return fmt.Errorf("write json: %w", err)
+		}
+	default:
+		fprintValidationResult(os.Stdout, agg)
+	}
 
 	if *threshold > 0 && agg.Satisfaction < *threshold {
 		return fmt.Errorf("%w: %.1f < %.1f", errBelowThreshold, agg.Satisfaction, *threshold)
@@ -275,13 +290,19 @@ func validateCmd(ctx context.Context, logger *slog.Logger, args []string) error 
 
 func statusCmd(ctx context.Context, _ *slog.Logger, args []string) error {
 	fs := flag.NewFlagSet("status", flag.ContinueOnError)
+	format := fs.String("format", "text", "output format: text or json")
 
 	fs.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: octog status\n\nShow recent runs, scores, and costs.\n")
+		fmt.Fprintf(os.Stderr, "Usage: octog status [flags]\n\nShow recent runs, scores, and costs.\n\nFlags:\n")
+		fs.PrintDefaults()
 	}
 
 	if err := fs.Parse(args); err != nil {
 		return err
+	}
+
+	if *format != "text" && *format != "json" {
+		return errInvalidFormat
 	}
 
 	storePath, err := resolveStorePath()
@@ -297,6 +318,11 @@ func statusCmd(ctx context.Context, _ *slog.Logger, args []string) error {
 	runs, err := st.ListRuns(ctx)
 	if err != nil {
 		return fmt.Errorf("list runs: %w", err)
+	}
+
+	if *format == "json" {
+		out := view.NewStatusOutput(runs)
+		return view.WriteJSON(os.Stdout, out)
 	}
 
 	if len(runs) == 0 {

--- a/cmd/octog/main_test.go
+++ b/cmd/octog/main_test.go
@@ -447,6 +447,26 @@ func TestValidateJudgeFlags(t *testing.T) {
 	}
 }
 
+func TestValidateCmdInvalidFormat(t *testing.T) {
+	logger := testLogger()
+	ctx := context.Background()
+	err := validateCmd(ctx, logger, []string{
+		"--scenarios", "s/", "--target", "http://localhost:1", "--format", "xml",
+	})
+	if !errors.Is(err, errInvalidFormat) {
+		t.Errorf("validateCmd(--format xml) = %v, want %v", err, errInvalidFormat)
+	}
+}
+
+func TestStatusCmdInvalidFormat(t *testing.T) {
+	logger := testLogger()
+	ctx := context.Background()
+	err := statusCmd(ctx, logger, []string{"--format", "yaml"})
+	if !errors.Is(err, errInvalidFormat) {
+		t.Errorf("statusCmd(--format yaml) = %v, want %v", err, errInvalidFormat)
+	}
+}
+
 func TestRunCmdInvalidThreshold(t *testing.T) {
 	logger := testLogger()
 	ctx := context.Background()

--- a/internal/view/status.go
+++ b/internal/view/status.go
@@ -1,0 +1,58 @@
+package view
+
+import (
+	"time"
+
+	"github.com/foundatron/octopusgarden/internal/store"
+)
+
+// StatusOutput is the JSON-serializable view of the status command.
+type StatusOutput struct {
+	Version int         `json:"version"`
+	Runs    []RunOutput `json:"runs"`
+}
+
+// RunOutput is the JSON-serializable view of a single run.
+type RunOutput struct {
+	ID           string  `json:"id"`
+	SpecPath     string  `json:"spec_path"`
+	Model        string  `json:"model"`
+	Threshold    float64 `json:"threshold"`
+	BudgetUSD    float64 `json:"budget_usd"`
+	StartedAt    string  `json:"started_at"`
+	FinishedAt   *string `json:"finished_at,omitempty"`
+	Satisfaction float64 `json:"satisfaction"`
+	Iterations   int     `json:"iterations"`
+	TotalTokens  int     `json:"total_tokens"`
+	TotalCostUSD float64 `json:"total_cost_usd"`
+	Status       string  `json:"status"`
+}
+
+// NewStatusOutput converts domain types into the JSON view.
+func NewStatusOutput(runs []store.Run) StatusOutput {
+	out := make([]RunOutput, 0, len(runs))
+	for _, r := range runs {
+		ro := RunOutput{
+			ID:           r.ID,
+			SpecPath:     r.SpecPath,
+			Model:        r.Model,
+			Threshold:    r.Threshold,
+			BudgetUSD:    r.BudgetUSD,
+			StartedAt:    r.StartedAt.Format(time.RFC3339),
+			Satisfaction: r.Satisfaction,
+			Iterations:   r.Iterations,
+			TotalTokens:  r.TotalTokens,
+			TotalCostUSD: r.TotalCostUSD,
+			Status:       r.Status,
+		}
+		if r.FinishedAt != nil {
+			s := r.FinishedAt.Format(time.RFC3339)
+			ro.FinishedAt = &s
+		}
+		out = append(out, ro)
+	}
+	return StatusOutput{
+		Version: 1,
+		Runs:    out,
+	}
+}

--- a/internal/view/validate.go
+++ b/internal/view/validate.go
@@ -1,0 +1,104 @@
+package view
+
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/foundatron/octopusgarden/internal/scenario"
+)
+
+// ValidateOutput is the JSON-serializable view of a validation run.
+type ValidateOutput struct {
+	Version        int              `json:"version"`
+	Target         string           `json:"target"`
+	AggregateScore float64          `json:"aggregate_score"`
+	Threshold      float64          `json:"threshold"`
+	Passed         bool             `json:"passed"`
+	TotalCostUSD   float64          `json:"total_cost_usd"`
+	Failures       []string         `json:"failures"`
+	Scenarios      []ScenarioOutput `json:"scenarios"`
+}
+
+// ScenarioOutput is the JSON-serializable view of a single scored scenario.
+type ScenarioOutput struct {
+	ID     string       `json:"id"`
+	Score  float64      `json:"score"`
+	Weight float64      `json:"weight"`
+	Steps  []StepOutput `json:"steps"`
+}
+
+// StepOutput is the JSON-serializable view of a single scored step.
+type StepOutput struct {
+	Description string   `json:"description"`
+	Score       int      `json:"score"`
+	Passed      bool     `json:"passed"`
+	Reasoning   string   `json:"reasoning"`
+	Failures    []string `json:"failures"`
+	DurationMs  int64    `json:"duration_ms"`
+	Error       *string  `json:"error,omitempty"`
+	CostUSD     float64  `json:"cost_usd"`
+}
+
+// NewValidateOutput converts domain types into the JSON view.
+// stepPassThreshold controls the per-step passed boolean.
+func NewValidateOutput(agg scenario.AggregateResult, target string, threshold float64, stepPassThreshold int) ValidateOutput {
+	scenarios := make([]ScenarioOutput, 0, len(agg.Scenarios))
+	for _, s := range agg.Scenarios {
+		steps := make([]StepOutput, 0, len(s.Steps))
+		for _, st := range s.Steps {
+			var errStr *string
+			if st.StepResult.Err != nil {
+				e := st.StepResult.Err.Error()
+				errStr = &e
+			}
+			stepFailures := st.StepScore.Failures
+			if stepFailures == nil {
+				stepFailures = []string{}
+			}
+			steps = append(steps, StepOutput{
+				Description: st.StepResult.Description,
+				Score:       st.StepScore.Score,
+				Passed:      st.StepScore.Score >= stepPassThreshold,
+				Reasoning:   st.StepScore.Reasoning,
+				Failures:    stepFailures,
+				DurationMs:  st.StepResult.Duration.Milliseconds(),
+				Error:       errStr,
+				CostUSD:     st.StepScore.CostUSD,
+			})
+		}
+		scenarios = append(scenarios, ScenarioOutput{
+			ID:     s.ScenarioID,
+			Score:  s.Score,
+			Weight: s.Weight,
+			Steps:  steps,
+		})
+	}
+
+	failures := agg.Failures
+	if failures == nil {
+		failures = []string{}
+	}
+
+	passed := true
+	if threshold > 0 {
+		passed = agg.Satisfaction >= threshold
+	}
+
+	return ValidateOutput{
+		Version:        1,
+		Target:         target,
+		AggregateScore: agg.Satisfaction,
+		Threshold:      threshold,
+		Passed:         passed,
+		TotalCostUSD:   agg.TotalCostUSD,
+		Failures:       failures,
+		Scenarios:      scenarios,
+	}
+}
+
+// WriteJSON encodes v as indented JSON to w with a trailing newline.
+func WriteJSON(w io.Writer, v any) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}

--- a/internal/view/view_test.go
+++ b/internal/view/view_test.go
@@ -1,0 +1,219 @@
+package view
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/foundatron/octopusgarden/internal/scenario"
+	"github.com/foundatron/octopusgarden/internal/store"
+)
+
+func TestNewValidateOutput(t *testing.T) {
+	agg := scenario.AggregateResult{
+		Satisfaction: 87.5,
+		TotalCostUSD: 0.05,
+		Failures:     []string{"missing field"},
+		Scenarios: []scenario.ScoredScenario{
+			{
+				ScenarioID: "crud",
+				Weight:     1.0,
+				Score:      90.0,
+				Steps: []scenario.ScoredStep{
+					{
+						StepResult: scenario.StepResult{
+							Description: "create item",
+							Duration:    150 * time.Millisecond,
+						},
+						StepScore: scenario.StepScore{
+							Score:     95,
+							Reasoning: "correct",
+							CostUSD:   0.001,
+						},
+					},
+					{
+						StepResult: scenario.StepResult{
+							Description: "bad step",
+							Duration:    50 * time.Millisecond,
+							Err:         errors.New("connection refused"),
+						},
+						StepScore: scenario.StepScore{
+							Score:     60,
+							Reasoning: "failed",
+							Failures:  []string{"no response"},
+							CostUSD:   0.001,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	out := NewValidateOutput(agg, "http://localhost:8080", 95.0, 80)
+
+	if out.Version != 1 {
+		t.Errorf("version = %d, want 1", out.Version)
+	}
+	if out.Target != "http://localhost:8080" {
+		t.Errorf("target = %q, want %q", out.Target, "http://localhost:8080")
+	}
+	if out.AggregateScore != 87.5 {
+		t.Errorf("aggregate_score = %f, want 87.5", out.AggregateScore)
+	}
+	if out.Threshold != 95.0 {
+		t.Errorf("threshold = %f, want 95.0", out.Threshold)
+	}
+	if out.Passed {
+		t.Error("passed = true, want false (87.5 < 95.0)")
+	}
+	if out.TotalCostUSD != 0.05 {
+		t.Errorf("total_cost_usd = %f, want 0.05", out.TotalCostUSD)
+	}
+	if len(out.Failures) != 1 || out.Failures[0] != "missing field" {
+		t.Errorf("failures = %v, want [missing field]", out.Failures)
+	}
+	if len(out.Scenarios) != 1 {
+		t.Fatalf("len(scenarios) = %d, want 1", len(out.Scenarios))
+	}
+
+	s := out.Scenarios[0]
+	if s.ID != "crud" {
+		t.Errorf("scenario.id = %q, want %q", s.ID, "crud")
+	}
+	if len(s.Steps) != 2 {
+		t.Fatalf("len(steps) = %d, want 2", len(s.Steps))
+	}
+
+	// Step 1: score 95 >= 80, passed
+	if !s.Steps[0].Passed {
+		t.Error("step[0].passed = false, want true (score 95 >= 80)")
+	}
+	if s.Steps[0].DurationMs != 150 {
+		t.Errorf("step[0].duration_ms = %d, want 150", s.Steps[0].DurationMs)
+	}
+	if s.Steps[0].Error != nil {
+		t.Errorf("step[0].error = %v, want nil", s.Steps[0].Error)
+	}
+	if s.Steps[0].Failures == nil {
+		t.Error("step[0].failures = nil, want empty slice (not null in JSON)")
+	}
+
+	// Step 2: score 60 < 80, failed, has error
+	if s.Steps[1].Passed {
+		t.Error("step[1].passed = true, want false (score 60 < 80)")
+	}
+	if s.Steps[1].Error == nil || *s.Steps[1].Error != "connection refused" {
+		t.Errorf("step[1].error = %v, want %q", s.Steps[1].Error, "connection refused")
+	}
+	if len(s.Steps[1].Failures) != 1 {
+		t.Errorf("step[1].failures = %v, want [no response]", s.Steps[1].Failures)
+	}
+}
+
+func TestNewValidateOutputPassedWhenAboveThreshold(t *testing.T) {
+	agg := scenario.AggregateResult{Satisfaction: 96.0}
+	out := NewValidateOutput(agg, "http://localhost:8080", 95.0, 80)
+	if !out.Passed {
+		t.Error("passed = false, want true (96.0 >= 95.0)")
+	}
+}
+
+func TestNewValidateOutputPassedWhenNoThreshold(t *testing.T) {
+	agg := scenario.AggregateResult{Satisfaction: 50.0}
+	out := NewValidateOutput(agg, "http://localhost:8080", 0, 80)
+	if !out.Passed {
+		t.Error("passed = false, want true (threshold 0 means no gate)")
+	}
+}
+
+func TestNewValidateOutputNilFailures(t *testing.T) {
+	agg := scenario.AggregateResult{Failures: nil}
+	out := NewValidateOutput(agg, "http://localhost:8080", 0, 80)
+	if out.Failures == nil {
+		t.Error("failures = nil, want empty slice (not null in JSON)")
+	}
+	if len(out.Failures) != 0 {
+		t.Errorf("len(failures) = %d, want 0", len(out.Failures))
+	}
+}
+
+func TestNewStatusOutput(t *testing.T) {
+	started := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	finished := time.Date(2026, 3, 1, 12, 5, 0, 0, time.UTC)
+	runs := []store.Run{
+		{
+			ID:           "abc123",
+			SpecPath:     "specs/hello.md",
+			Model:        "claude-sonnet-4-6",
+			Threshold:    95.0,
+			BudgetUSD:    5.0,
+			StartedAt:    started,
+			FinishedAt:   &finished,
+			Satisfaction: 99.0,
+			Iterations:   2,
+			TotalTokens:  5000,
+			TotalCostUSD: 0.15,
+			Status:       "converged",
+		},
+		{
+			ID:        "def456",
+			SpecPath:  "specs/todo.md",
+			Model:     "claude-sonnet-4-6",
+			StartedAt: started,
+			Status:    "running",
+		},
+	}
+
+	out := NewStatusOutput(runs)
+
+	if out.Version != 1 {
+		t.Errorf("version = %d, want 1", out.Version)
+	}
+	if len(out.Runs) != 2 {
+		t.Fatalf("len(runs) = %d, want 2", len(out.Runs))
+	}
+
+	r0 := out.Runs[0]
+	if r0.ID != "abc123" {
+		t.Errorf("runs[0].id = %q, want %q", r0.ID, "abc123")
+	}
+	if r0.StartedAt != "2026-03-01T12:00:00Z" {
+		t.Errorf("runs[0].started_at = %q, want RFC3339", r0.StartedAt)
+	}
+	if r0.FinishedAt == nil || *r0.FinishedAt != "2026-03-01T12:05:00Z" {
+		t.Errorf("runs[0].finished_at = %v, want RFC3339", r0.FinishedAt)
+	}
+	if r0.Satisfaction != 99.0 {
+		t.Errorf("runs[0].satisfaction = %f, want 99.0", r0.Satisfaction)
+	}
+
+	r1 := out.Runs[1]
+	if r1.FinishedAt != nil {
+		t.Errorf("runs[1].finished_at = %v, want nil", r1.FinishedAt)
+	}
+}
+
+func TestNewStatusOutputEmpty(t *testing.T) {
+	out := NewStatusOutput(nil)
+	if out.Runs == nil {
+		t.Error("runs = nil, want empty slice")
+	}
+}
+
+func TestWriteJSON(t *testing.T) {
+	var buf bytes.Buffer
+	data := map[string]int{"version": 1}
+	if err := WriteJSON(&buf, data); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var got map[string]int
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON output: %v", err)
+	}
+	if got["version"] != 1 {
+		t.Errorf("version = %d, want 1", got["version"])
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `--format` flag (`text`|`json`, default `text`) to both `validate` and `status` subcommands for CI/CD integration
- Creates purpose-built JSON view types in `internal/view/` (not json tags on domain types) — clean separation of serialization from domain logic
- Includes `version: 1` top-level field for forward schema compatibility
- Consistent nil-to-empty-slice handling ensures JSON never emits `null` for array fields
- RFC 3339 timestamps, duration in milliseconds, errors as `*string`

### Example: `octog status --format json`
```json
{
  "version": 1,
  "runs": [
    {
      "id": "8ff22b724a98d277",
      "spec_path": "specs/examples/expense-tracker/spec.md",
      "model": "claude-sonnet-4-6",
      "threshold": 95,
      "satisfaction": 99.6,
      "status": "converged",
      ...
    }
  ]
}
```

### Example: `octog validate --format json`
```json
{
  "version": 1,
  "target": "http://localhost:8080",
  "aggregate_score": 87.5,
  "threshold": 95,
  "passed": false,
  "scenarios": [...]
}
```

Closes #10

## Test plan
- [x] `go test ./internal/view/... ./cmd/octog/...` — 21 tests pass (7 new view tests, 2 new CLI tests)
- [x] `golangci-lint run` — 0 issues
- [x] Manual: `./octog status --format json` produces valid JSON with real run data
- [x] Manual: `./octog status --format text` unchanged from before
- [x] Manual: `./octog validate --format xml` returns `errInvalidFormat` with exit 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)