### PR TITLE
feat(cli): add octog configure interactive setup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,16 @@ cd octopusgarden
 make build
 ```
 
-Set your API key (either as an env var or in the config file):
+Configure your API key:
 
 ```bash
+# Interactive setup (recommended)
+octog configure
+
+# Or set an env var
 export ANTHROPIC_API_KEY=sk-...
-# or
+
+# Or write the config file directly
 mkdir -p ~/.octopusgarden && echo "ANTHROPIC_API_KEY=sk-..." > ~/.octopusgarden/config
 ```
 
@@ -120,6 +125,7 @@ Commands:
   validate   Validate a running service against scenarios
   status     Show recent runs, scores, and costs
   models     List available models
+  configure  Interactively configure API keys
 ```
 
 Run `octog models` to list available models.

--- a/cmd/octog/main.go
+++ b/cmd/octog/main.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"io/fs"
 	"log/slog"
+	"maps"
 	"net/http"
 	"os"
 	"os/signal"
@@ -77,6 +78,8 @@ func main() {
 		err = lintCmd(ctx, logger, os.Args[2:])
 	case "models":
 		err = modelsCmd(ctx, logger, os.Args[2:])
+	case "configure":
+		err = configureCmd(ctx, logger, os.Args[2:])
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n\n", os.Args[1]) //nolint:gosec // G705 false positive: writing to stderr, not an HTTP response
 		printUsage()
@@ -101,6 +104,7 @@ Commands:
   status     Show recent runs, scores, and costs
   lint       Check spec and scenario files for errors
   models     List available models
+  configure  Interactively configure API keys
 
 Run 'octog <command> --help' for details.
 `)
@@ -661,7 +665,14 @@ func fprintValidationResult(w io.Writer, agg scenario.AggregateResult) {
 var configAllowedKeys = map[string]bool{
 	"ANTHROPIC_API_KEY": true,
 	"OPENAI_API_KEY":    true,
+	"OPENAI_BASE_URL":   true,
 }
+
+// configKeys defines the prompt order for `octog configure`.
+var configKeys = []string{"ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OPENAI_BASE_URL"}
+
+// configClearValue is the sentinel input that clears an existing config value.
+const configClearValue = "-"
 
 func configPath() (string, error) {
 	home, err := os.UserHomeDir()
@@ -686,7 +697,7 @@ func loadConfig(logger *slog.Logger) error {
 	}
 
 	// Warn if file is world-readable.
-	if perm := info.Mode().Perm(); perm&0o044 != 0 {
+	if perm := info.Mode().Perm(); perm&0o077 != 0 {
 		logger.Warn("config file has overly permissive permissions, recommend 0600",
 			"path", path, "mode", fmt.Sprintf("%04o", perm))
 	}
@@ -805,4 +816,180 @@ func printResult(result *attractor.RunResult) {
 	fmt.Printf("  Satisfaction: %.1f%%\n", result.Satisfaction)
 	fmt.Printf("  Cost:         $%.4f\n", result.CostUSD)
 	fmt.Printf("  Output:       %s\n", result.OutputDir)
+}
+
+func configureCmd(_ context.Context, _ *slog.Logger, args []string) error {
+	fs := flag.NewFlagSet("configure", flag.ContinueOnError)
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: octog configure\n\nInteractively configure API keys and settings.\n")
+	}
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	cfgPath, err := configPath()
+	if err != nil {
+		return err
+	}
+
+	return configureInteractive(os.Stdin, os.Stdout, cfgPath)
+}
+
+func configureInteractive(r io.Reader, w io.Writer, cfgPath string) error {
+	values, originalLines, err := readConfigFile(cfgPath)
+	if err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintf(w, "\nOctopusGarden Configuration\nConfig file: %s\n\n", cfgPath)
+
+	scanner := bufio.NewScanner(r)
+	newValues := make(map[string]string, len(configKeys))
+	maps.Copy(newValues, values)
+
+	for _, key := range configKeys {
+		current := values[key]
+		prompt := "not set"
+		if current != "" {
+			prompt = maskValue(current)
+		}
+		_, _ = fmt.Fprintf(w, "%s [%s]: ", key, prompt)
+		if !scanner.Scan() {
+			// EOF — keep all remaining values as-is.
+			break
+		}
+		input := strings.TrimSpace(scanner.Text())
+		switch {
+		case input == configClearValue:
+			delete(newValues, key)
+		case input != "":
+			newValues[key] = input
+		}
+		// Empty input (Enter) keeps the existing value.
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("read input: %w", err)
+	}
+
+	_, _ = fmt.Fprintln(w)
+
+	// Warn if no API key is configured.
+	if newValues["ANTHROPIC_API_KEY"] == "" && newValues["OPENAI_API_KEY"] == "" {
+		_, _ = fmt.Fprintln(w, "Warning: no API key configured. Run 'octog configure' to add one.")
+		_, _ = fmt.Fprintln(w)
+	}
+
+	if err := writeConfigFile(cfgPath, newValues, originalLines); err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintf(w, "Configuration saved to %s\n", cfgPath)
+	return nil
+}
+
+// maskValue masks a config value for display. Values 16+ chars show first4...last4,
+// shorter values show ****.
+func maskValue(value string) string {
+	if len(value) >= 16 {
+		return value[:4] + "..." + value[len(value)-4:]
+	}
+	return "****"
+}
+
+// readConfigFile reads a config file and returns a map of known key-value pairs
+// plus the original lines (for comment/ordering preservation). Returns an empty
+// map and nil lines if the file does not exist.
+func readConfigFile(path string) (map[string]string, []string, error) {
+	f, err := os.Open(path) //nolint:gosec // G304: path derives from configPath()/UserHomeDir
+	if errors.Is(err, fs.ErrNotExist) {
+		return make(map[string]string), nil, nil
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("open config: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	values := make(map[string]string)
+	var lines []string
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		lines = append(lines, line)
+
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		key, value, ok := strings.Cut(trimmed, "=")
+		if !ok {
+			continue
+		}
+		values[strings.TrimSpace(key)] = strings.TrimSpace(value)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, nil, fmt.Errorf("read config: %w", err)
+	}
+	return values, lines, nil
+}
+
+// writeConfigFile writes config values to the given path, preserving comments and
+// unknown keys from originalLines. Known keys are updated in-place; new keys are
+// appended at the end in configKeys order. Creates the parent directory (0700) if needed.
+// Note: existing key lines are normalized to KEY=VALUE format (whitespace around = is removed).
+func writeConfigFile(path string, values map[string]string, originalLines []string) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+
+	// Track which keys we've written so we can append new ones.
+	written := make(map[string]bool)
+
+	var out []string
+	for _, line := range originalLines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			out = append(out, line)
+			continue
+		}
+		key, _, ok := strings.Cut(trimmed, "=")
+		if !ok {
+			out = append(out, line)
+			continue
+		}
+		key = strings.TrimSpace(key)
+
+		if v, exists := values[key]; exists {
+			out = append(out, key+"="+v)
+			written[key] = true
+		} else {
+			// Key was cleared or is unknown-but-absent — only drop known keys.
+			if configAllowedKeys[key] {
+				// Cleared — omit the line.
+				written[key] = true
+			} else {
+				// Unknown key — pass through.
+				out = append(out, line)
+			}
+		}
+	}
+
+	// Append new keys that weren't in the original file, in configKeys order.
+	for _, key := range configKeys {
+		if written[key] {
+			continue
+		}
+		if v, exists := values[key]; exists {
+			out = append(out, key+"="+v)
+		}
+	}
+
+	content := strings.Join(out, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		return fmt.Errorf("write config: %w", err)
+	}
+	return nil
 }

--- a/cmd/octog/main_test.go
+++ b/cmd/octog/main_test.go
@@ -329,8 +329,6 @@ func TestLoadConfig(t *testing.T) {
 	content := "# comment\n\nANTHROPIC_API_KEY=sk-test-from-config\nOPENAI_API_KEY=sk-openai-test\n"
 
 	// Override HOME so configPath() resolves to our temp dir.
-	ogHome := os.Getenv("HOME")
-	// Put config at dir/.octopusgarden/config
 	ogDir := filepath.Join(dir, ".octopusgarden")
 	if err := os.MkdirAll(ogDir, 0o750); err != nil {
 		t.Fatal(err)
@@ -340,13 +338,11 @@ func TestLoadConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("HOME", dir)
-	defer func() { _ = os.Setenv("HOME", ogHome) }()
 
 	// Ensure the env vars are unset before loading.
+	// t.Setenv("", "") makes os.Getenv return "" which loadConfig treats as unset.
 	t.Setenv("ANTHROPIC_API_KEY", "")
 	t.Setenv("OPENAI_API_KEY", "")
-	os.Unsetenv("ANTHROPIC_API_KEY")
-	os.Unsetenv("OPENAI_API_KEY")
 
 	logger := testLogger()
 	if err := loadConfig(logger); err != nil {
@@ -568,6 +564,332 @@ func TestStatusCmdInvalidFormat(t *testing.T) {
 	err := statusCmd(ctx, logger, []string{"--format", "yaml"})
 	if !errors.Is(err, errInvalidFormat) {
 		t.Errorf("statusCmd(--format yaml) = %v, want %v", err, errInvalidFormat)
+	}
+}
+
+func TestMaskValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"empty", "", "****"},
+		{"short", "abc", "****"},
+		{"exactly 15", "123456789012345", "****"},
+		{"exactly 16", "1234567890123456", "1234...3456"},
+		{"long API key", "sk-ant-api03-abcdefg-hijklmnop", "sk-a...mnop"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := maskValue(tt.input)
+			if got != tt.want {
+				t.Errorf("maskValue(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfigureInteractiveNewConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, ".octopusgarden", "config")
+
+	input := "sk-ant-test-key-1234\n\nhttp://localhost:11434\n"
+	var out bytes.Buffer
+
+	if err := configureInteractive(strings.NewReader(input), &out, cfgPath); err != nil {
+		t.Fatalf("configureInteractive: %v", err)
+	}
+
+	// Verify file was created.
+	content, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+
+	got := string(content)
+	if !strings.Contains(got, "ANTHROPIC_API_KEY=sk-ant-test-key-1234") {
+		t.Errorf("config missing ANTHROPIC_API_KEY, got:\n%s", got)
+	}
+	if !strings.Contains(got, "OPENAI_BASE_URL=http://localhost:11434") {
+		t.Errorf("config missing OPENAI_BASE_URL, got:\n%s", got)
+	}
+	// OPENAI_API_KEY was skipped (empty input) and never set — should not appear.
+	if strings.Contains(got, "OPENAI_API_KEY=") {
+		t.Errorf("config should not contain empty OPENAI_API_KEY, got:\n%s", got)
+	}
+
+	// Verify directory permissions.
+	dirInfo, err := os.Stat(filepath.Dir(cfgPath))
+	if err != nil {
+		t.Fatalf("stat dir: %v", err)
+	}
+	if perm := dirInfo.Mode().Perm(); perm != 0o700 {
+		t.Errorf("dir perm = %04o, want 0700", perm)
+	}
+
+	// Verify file permissions.
+	fileInfo, err := os.Stat(cfgPath)
+	if err != nil {
+		t.Fatalf("stat file: %v", err)
+	}
+	if perm := fileInfo.Mode().Perm(); perm != 0o600 {
+		t.Errorf("file perm = %04o, want 0600", perm)
+	}
+
+	// Verify output mentions "saved".
+	if !strings.Contains(out.String(), "Configuration saved") {
+		t.Errorf("output missing 'Configuration saved', got:\n%s", out.String())
+	}
+}
+
+func TestConfigureInteractiveUpdateExisting(t *testing.T) {
+	dir := t.TempDir()
+	cfgDir := filepath.Join(dir, ".octopusgarden")
+	if err := os.MkdirAll(cfgDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(cfgDir, "config")
+
+	existing := "# My settings\nANTHROPIC_API_KEY=sk-ant-existing-key-5678\nOPENAI_API_KEY=sk-openai-old\n"
+	if err := os.WriteFile(cfgPath, []byte(existing), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Keep ANTHROPIC (empty enter), update OPENAI, skip BASE_URL.
+	input := "\nsk-openai-new\n\n"
+	var out bytes.Buffer
+
+	if err := configureInteractive(strings.NewReader(input), &out, cfgPath); err != nil {
+		t.Fatalf("configureInteractive: %v", err)
+	}
+
+	// Output should show masked existing values.
+	output := out.String()
+	// sk-ant-existing-key-5678 (24 chars, >=16) → first4...last4 = sk-a...5678
+	if !strings.Contains(output, "sk-a...5678") {
+		t.Errorf("output should show masked ANTHROPIC key, got:\n%s", output)
+	}
+	// sk-openai-old (13 chars, <16) → ****
+	if !strings.Contains(output, "OPENAI_API_KEY [****]") {
+		t.Errorf("output should show masked OPENAI key, got:\n%s", output)
+	}
+
+	content, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	got := string(content)
+
+	// Comment preserved.
+	if !strings.Contains(got, "# My settings") {
+		t.Errorf("comment not preserved, got:\n%s", got)
+	}
+	// ANTHROPIC unchanged.
+	if !strings.Contains(got, "ANTHROPIC_API_KEY=sk-ant-existing-key-5678") {
+		t.Errorf("ANTHROPIC_API_KEY should be unchanged, got:\n%s", got)
+	}
+	// OPENAI updated.
+	if !strings.Contains(got, "OPENAI_API_KEY=sk-openai-new") {
+		t.Errorf("OPENAI_API_KEY should be updated, got:\n%s", got)
+	}
+}
+
+func TestConfigureInteractiveClearValue(t *testing.T) {
+	dir := t.TempDir()
+	cfgDir := filepath.Join(dir, ".octopusgarden")
+	if err := os.MkdirAll(cfgDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(cfgDir, "config")
+
+	existing := "ANTHROPIC_API_KEY=sk-ant-old\nOPENAI_API_KEY=sk-openai-old\n"
+	if err := os.WriteFile(cfgPath, []byte(existing), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Clear ANTHROPIC with "-", keep OPENAI, skip BASE_URL.
+	input := "-\n\n\n"
+	var out bytes.Buffer
+
+	if err := configureInteractive(strings.NewReader(input), &out, cfgPath); err != nil {
+		t.Fatalf("configureInteractive: %v", err)
+	}
+
+	content, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	got := string(content)
+
+	// ANTHROPIC should be gone.
+	if strings.Contains(got, "ANTHROPIC_API_KEY") {
+		t.Errorf("ANTHROPIC_API_KEY should be cleared, got:\n%s", got)
+	}
+	// OPENAI still there.
+	if !strings.Contains(got, "OPENAI_API_KEY=sk-openai-old") {
+		t.Errorf("OPENAI_API_KEY should be preserved, got:\n%s", got)
+	}
+}
+
+func TestConfigureInteractiveEOF(t *testing.T) {
+	dir := t.TempDir()
+	cfgDir := filepath.Join(dir, ".octopusgarden")
+	if err := os.MkdirAll(cfgDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(cfgDir, "config")
+
+	existing := "ANTHROPIC_API_KEY=sk-ant-keep\nOPENAI_API_KEY=sk-openai-keep\n"
+	if err := os.WriteFile(cfgPath, []byte(existing), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Piped empty input (immediate EOF).
+	var out bytes.Buffer
+	if err := configureInteractive(strings.NewReader(""), &out, cfgPath); err != nil {
+		t.Fatalf("configureInteractive: %v", err)
+	}
+
+	content, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	got := string(content)
+
+	// All existing values preserved.
+	if !strings.Contains(got, "ANTHROPIC_API_KEY=sk-ant-keep") {
+		t.Errorf("ANTHROPIC_API_KEY should be preserved on EOF, got:\n%s", got)
+	}
+	if !strings.Contains(got, "OPENAI_API_KEY=sk-openai-keep") {
+		t.Errorf("OPENAI_API_KEY should be preserved on EOF, got:\n%s", got)
+	}
+}
+
+func TestConfigureInteractiveNoKeyWarning(t *testing.T) {
+	dir := t.TempDir()
+
+	tests := []struct {
+		name        string
+		input       string
+		wantWarning bool
+	}{
+		{"no keys", "\n\n\n", true},
+		{"anthropic set", "sk-ant-key-12345678\n\n\n", false},
+		{"openai set", "\nsk-openai-key-12345678\n\n", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(dir, tt.name, ".octopusgarden", "config")
+			var out bytes.Buffer
+			if err := configureInteractive(strings.NewReader(tt.input), &out, path); err != nil {
+				t.Fatalf("configureInteractive: %v", err)
+			}
+			hasWarning := strings.Contains(out.String(), "Warning: no API key configured")
+			if hasWarning != tt.wantWarning {
+				t.Errorf("warning present = %v, want %v\noutput:\n%s", hasWarning, tt.wantWarning, out.String())
+			}
+		})
+	}
+}
+
+func TestReadConfigFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+
+	content := "# comment\n\nANTHROPIC_API_KEY=sk-test\nUNKNOWN=value\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	values, lines, err := readConfigFile(path)
+	if err != nil {
+		t.Fatalf("readConfigFile: %v", err)
+	}
+
+	if values["ANTHROPIC_API_KEY"] != "sk-test" {
+		t.Errorf("ANTHROPIC_API_KEY = %q, want %q", values["ANTHROPIC_API_KEY"], "sk-test")
+	}
+	if values["UNKNOWN"] != "value" {
+		t.Errorf("UNKNOWN = %q, want %q", values["UNKNOWN"], "value")
+	}
+	if len(lines) != 4 {
+		t.Errorf("expected 4 original lines, got %d", len(lines))
+	}
+	if lines[0] != "# comment" {
+		t.Errorf("lines[0] = %q, want %q", lines[0], "# comment")
+	}
+}
+
+func TestReadConfigFileMissing(t *testing.T) {
+	values, lines, err := readConfigFile(filepath.Join(t.TempDir(), "nonexistent"))
+	if err != nil {
+		t.Fatalf("readConfigFile on missing file: %v", err)
+	}
+	if len(values) != 0 {
+		t.Errorf("expected empty map, got %v", values)
+	}
+	if lines != nil {
+		t.Errorf("expected nil lines, got %v", lines)
+	}
+}
+
+func TestWriteConfigFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sub", "config")
+
+	originalLines := []string{
+		"# API keys",
+		"ANTHROPIC_API_KEY=old-key",
+		"",
+		"CUSTOM_THING=preserved",
+	}
+	values := map[string]string{
+		"ANTHROPIC_API_KEY": "new-key",
+		"OPENAI_API_KEY":    "sk-openai",
+		"CUSTOM_THING":      "preserved",
+	}
+
+	if err := writeConfigFile(path, values, originalLines); err != nil {
+		t.Fatalf("writeConfigFile: %v", err)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	got := string(content)
+
+	// Comment preserved.
+	if !strings.Contains(got, "# API keys") {
+		t.Errorf("comment not preserved, got:\n%s", got)
+	}
+	// ANTHROPIC updated in-place.
+	if !strings.Contains(got, "ANTHROPIC_API_KEY=new-key") {
+		t.Errorf("ANTHROPIC_API_KEY not updated, got:\n%s", got)
+	}
+	// Unknown key preserved.
+	if !strings.Contains(got, "CUSTOM_THING=preserved") {
+		t.Errorf("CUSTOM_THING not preserved, got:\n%s", got)
+	}
+	// New OPENAI appended.
+	if !strings.Contains(got, "OPENAI_API_KEY=sk-openai") {
+		t.Errorf("OPENAI_API_KEY not appended, got:\n%s", got)
+	}
+
+	// Verify file permissions.
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("perm = %04o, want 0600", perm)
+	}
+
+	// Verify ANTHROPIC comes before OPENAI (in-place before appended).
+	anthIdx := strings.Index(got, "ANTHROPIC_API_KEY")
+	openIdx := strings.Index(got, "OPENAI_API_KEY")
+	if anthIdx > openIdx {
+		t.Errorf("ANTHROPIC_API_KEY should come before OPENAI_API_KEY in output")
 	}
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -457,9 +457,10 @@ octog validate  --scenarios <dir> --target <url> [--judge-model claude-haiku-4-5
 octog status    [--format text|json]
 octog lint      --spec <path> --scenarios <dir>
 octog models    [--provider anthropic|openai]
+octog configure
 ```
 
-Subcommands: `run`, `validate`, `status`, `lint`, `models`.
+Subcommands: `run`, `validate`, `status`, `lint`, `models`, `configure`.
 
 Provider is auto-detected from which API key is set. Use `--provider` to disambiguate when both are
 present. Config file (`~/.octopusgarden/config`) supports `ANTHROPIC_API_KEY` and `OPENAI_API_KEY`;


### PR DESCRIPTION
## Summary

- Adds `octog configure` subcommand for guided interactive API key setup (like `aws configure`)
- Prompts for `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, and `OPENAI_BASE_URL` in order
- Masks existing values (first4...last4 for 16+ chars, `****` for shorter), supports clearing with `-`, preserves comments and unknown keys in config file
- Warns when no API key is configured after prompts
- Adds `OPENAI_BASE_URL` to `configAllowedKeys` so it's loaded from config file
- Tightens config file permission check from `0o044` to `0o077` (warns on any group/other access)
- 9 new tests covering all interactive flows, file I/O, masking, and permissions

## Test plan

- [x] `make build` compiles successfully
- [x] `make test` — all existing + 9 new tests pass
- [x] `make lint` — 0 issues
- [x] `make fmt` — clean
- [ ] Manual: `octog configure` interactive flow works end-to-end
- [ ] Manual: re-run shows masked existing values, Enter preserves them
- [ ] Manual: `-` clears a value

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)