### PR TITLE
feat(scenario): add retry/poll modifier for steps

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -194,8 +194,16 @@ type Step struct {
 	Exec        *ExecRequest    `yaml:"exec"`
 	Browser     *BrowserRequest `yaml:"browser"`
 	GRPC        *GRPCRequest    `yaml:"grpc"`
+	Retry       *Retry          `yaml:"retry"`
 	Expect      string          `yaml:"expect"` // natural language, judged by LLM
 	Capture     []Capture       `yaml:"capture"`
+}
+
+// Retry configures retry/poll behavior for a step.
+type Retry struct {
+	Attempts int    `yaml:"attempts"` // max attempts (default: 3)
+	Interval string `yaml:"interval"` // delay between retries (default: "1s")
+	Timeout  string `yaml:"timeout"`  // overall timeout cap (optional)
 }
 
 // StepType returns the step type key: "request", "exec", "browser", "grpc", or "" if unknown.
@@ -360,6 +368,29 @@ grpc:
 ```
 
 Capture sources for gRPC steps: `status` (gRPC status code) and `headers` (response metadata).
+
+#### Retry / Poll
+
+Steps support an optional `retry` block for eventual-consistency scenarios (polling until a
+background job completes, waiting for a resource to appear). Retries fire only when
+`executor.Execute` returns a non-nil error (transport failures, timeouts). HTTP 4xx/5xx and non-zero
+exit codes are NOT errors — they produce a `StepOutput` for the judge.
+
+```yaml
+steps:
+  - description: "Wait for item to be processed"
+    request:
+      method: GET
+      path: /items/{item_id}
+    retry:
+      attempts: 10     # max attempts (default: 3)
+      interval: "2s"   # delay between retries (default: "1s")
+      timeout: "30s"   # overall timeout cap (optional)
+    expect: "Status 200 with status 'processed'"
+```
+
+`StepResult.Duration` reflects total wall time including retries and sleeps. Captures are applied
+only from the final successful attempt.
 
 ### Variable Capture and Substitution
 

--- a/internal/lint/scenario.go
+++ b/internal/lint/scenario.go
@@ -297,6 +297,12 @@ func lintStep(path string, node *yaml.Node, cs *captureSet, isSetup bool) []Diag
 		}
 	}
 
+	// Check retry.
+	retryFE, hasRetry := fields["retry"]
+	if hasRetry {
+		diags = append(diags, lintRetry(path, retryFE.value)...)
+	}
+
 	// Check captures.
 	capFE, hasCap := fields["capture"]
 	if hasCap {
@@ -860,6 +866,63 @@ func lintCaptureName(path string, fields map[string]*fieldEntry, capNode *yaml.N
 		})
 	}
 	cs.add(name, path, nameFE.value.Line)
+	return diags
+}
+
+func lintRetry(path string, node *yaml.Node) []Diagnostic {
+	if node.Kind != yaml.MappingNode {
+		return []Diagnostic{{
+			File:    path,
+			Line:    node.Line,
+			Level:   Error,
+			Message: "retry must be a mapping",
+		}}
+	}
+
+	var diags []Diagnostic
+	fields := nodeFields(node)
+
+	if attemptsFE, ok := fields["attempts"]; ok {
+		var a int
+		if err := attemptsFE.value.Decode(&a); err != nil {
+			diags = append(diags, Diagnostic{
+				File:    path,
+				Line:    attemptsFE.value.Line,
+				Level:   Error,
+				Message: fmt.Sprintf("retry attempts must be an integer: %s", err),
+			})
+		} else if a < 1 {
+			diags = append(diags, Diagnostic{
+				File:    path,
+				Line:    attemptsFE.value.Line,
+				Level:   Warning,
+				Message: "retry attempts should be at least 1 (defaults to 3)",
+			})
+		}
+	}
+
+	if intervalFE, ok := fields["interval"]; ok && intervalFE.value.Value != "" {
+		if _, err := time.ParseDuration(intervalFE.value.Value); err != nil {
+			diags = append(diags, Diagnostic{
+				File:    path,
+				Line:    intervalFE.value.Line,
+				Level:   Error,
+				Message: fmt.Sprintf("retry interval %q is not a valid duration", intervalFE.value.Value),
+			})
+		}
+	}
+
+	if timeoutFE, ok := fields["timeout"]; ok && timeoutFE.value.Value != "" {
+		if _, err := time.ParseDuration(timeoutFE.value.Value); err != nil {
+			diags = append(diags, Diagnostic{
+				File:    path,
+				Line:    timeoutFE.value.Line,
+				Level:   Error,
+				Message: fmt.Sprintf("retry timeout %q is not a valid duration", timeoutFE.value.Value),
+			})
+		}
+	}
+
 	return diags
 }
 

--- a/internal/lint/scenario_test.go
+++ b/internal/lint/scenario_test.go
@@ -786,6 +786,99 @@ steps:
 			wantMsg:    "multiple step types",
 		},
 		{
+			name: "valid retry block",
+			yaml: `id: test
+steps:
+  - description: Poll for result
+    request:
+      method: GET
+      path: /items/1
+    retry:
+      attempts: 5
+      interval: 2s
+      timeout: 30s
+    expect: "Status 200"
+`,
+			wantErrors: 0,
+			wantWarns:  0,
+		},
+		{
+			name: "retry invalid interval",
+			yaml: `id: test
+steps:
+  - description: Poll
+    request:
+      method: GET
+      path: /items/1
+    retry:
+      attempts: 3
+      interval: notaduration
+    expect: "ok"
+`,
+			wantErrors: 1,
+			wantMsg:    "retry interval",
+		},
+		{
+			name: "retry invalid timeout",
+			yaml: `id: test
+steps:
+  - description: Poll
+    request:
+      method: GET
+      path: /items/1
+    retry:
+      attempts: 3
+      timeout: notaduration
+    expect: "ok"
+`,
+			wantErrors: 1,
+			wantMsg:    "retry timeout",
+		},
+		{
+			name: "retry negative attempts warning",
+			yaml: `id: test
+steps:
+  - description: Poll
+    request:
+      method: GET
+      path: /items/1
+    retry:
+      attempts: -1
+    expect: "ok"
+`,
+			wantErrors: 0,
+			wantWarns:  1,
+			wantMsg:    "retry attempts should be at least 1",
+		},
+		{
+			name: "retry not a mapping",
+			yaml: `id: test
+steps:
+  - description: Poll
+    request:
+      method: GET
+      path: /items/1
+    retry: 5
+    expect: "ok"
+`,
+			wantErrors: 1,
+			wantMsg:    "retry must be a mapping",
+		},
+		{
+			name: "retry empty block uses defaults",
+			yaml: `id: test
+steps:
+  - description: Poll
+    request:
+      method: GET
+      path: /items/1
+    retry: {}
+    expect: "ok"
+`,
+			wantErrors: 0,
+			wantWarns:  0,
+		},
+		{
 			name: "browser and exec on same step",
 			yaml: `id: test
 steps:

--- a/internal/scenario/runner.go
+++ b/internal/scenario/runner.go
@@ -9,9 +9,16 @@ import (
 	"time"
 )
 
+const (
+	defaultRetryAttempts = 3
+	defaultRetryInterval = time.Second
+)
+
 var (
 	errSetupFailed          = errors.New("runner: setup step failed")
 	errNoExecutorRegistered = errors.New("no executor registered for step type")
+	errRetryInvalidInterval = errors.New("retry: invalid interval")
+	errRetryInvalidTimeout  = errors.New("retry: invalid timeout")
 )
 
 // Runner executes scenario steps by dispatching to registered StepExecutors.
@@ -40,7 +47,7 @@ func (r *Runner) Run(ctx context.Context, scenario Scenario) (Result, error) {
 			return Result{}, fmt.Errorf("%w: step %d (%s): %w", errSetupFailed, i, step.Description, err)
 		}
 
-		output, err := executor.Execute(ctx, step, vars)
+		output, err := r.executeStep(ctx, executor, step, vars)
 		if err != nil {
 			return Result{}, fmt.Errorf("%w: step %d (%s): %w", errSetupFailed, i, step.Description, err)
 		}
@@ -65,7 +72,7 @@ func (r *Runner) Run(ctx context.Context, scenario Scenario) (Result, error) {
 		}
 
 		start := time.Now()
-		output, err := executor.Execute(ctx, step, vars)
+		output, err := r.executeStep(ctx, executor, step, vars)
 		dur := time.Since(start)
 
 		result := StepResult{
@@ -93,6 +100,64 @@ func (r *Runner) Run(ctx context.Context, scenario Scenario) (Result, error) {
 		ScenarioID: scenario.ID,
 		Steps:      results,
 	}, nil
+}
+
+func (r *Runner) executeStep(ctx context.Context, executor StepExecutor, step Step, vars map[string]string) (StepOutput, error) {
+	if step.Retry == nil {
+		return executor.Execute(ctx, step, vars)
+	}
+	return r.executeWithRetry(ctx, executor, step, vars, step.Retry)
+}
+
+func (r *Runner) executeWithRetry(ctx context.Context, executor StepExecutor, step Step, vars map[string]string, retry *Retry) (StepOutput, error) {
+	attempts := retry.Attempts
+	if attempts <= 0 {
+		attempts = defaultRetryAttempts
+	}
+
+	interval, err := parseStepTimeout(retry.Interval, defaultRetryInterval)
+	if err != nil {
+		return StepOutput{}, fmt.Errorf("%w: %w", errRetryInvalidInterval, err)
+	}
+
+	execCtx := ctx
+	var cancel context.CancelFunc
+	if retry.Timeout != "" {
+		timeout, err := parseStepTimeout(retry.Timeout, 0)
+		if err != nil {
+			return StepOutput{}, fmt.Errorf("%w: %w", errRetryInvalidTimeout, err)
+		}
+		execCtx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	var lastOutput StepOutput
+	var lastErr error
+	for attempt := range attempts {
+		lastOutput, lastErr = executor.Execute(execCtx, step, vars)
+		if lastErr == nil {
+			return lastOutput, nil
+		}
+
+		r.Logger.Debug("retry: attempt failed",
+			"step", step.Description,
+			"attempt", attempt+1,
+			"maxAttempts", attempts,
+			"error", lastErr,
+		)
+
+		// Don't sleep after the last attempt.
+		if attempt < attempts-1 {
+			timer := time.NewTimer(interval)
+			select {
+			case <-execCtx.Done():
+				timer.Stop()
+				return lastOutput, execCtx.Err()
+			case <-timer.C:
+			}
+		}
+	}
+	return lastOutput, lastErr
 }
 
 func (r *Runner) resolveExecutor(step Step) (StepExecutor, error) {

--- a/internal/scenario/runner_test.go
+++ b/internal/scenario/runner_test.go
@@ -574,6 +574,315 @@ func TestResolveCapture(t *testing.T) {
 	}
 }
 
+// mockExecutor returns an error for the first failCount calls, then succeeds.
+type mockExecutor struct {
+	failCount int
+	callCount int
+	failErr   error
+	output    StepOutput
+}
+
+func (m *mockExecutor) Execute(_ context.Context, _ Step, _ map[string]string) (StepOutput, error) {
+	m.callCount++
+	if m.callCount <= m.failCount {
+		return StepOutput{}, m.failErr
+	}
+	return m.output, nil
+}
+
+func (m *mockExecutor) ValidCaptureSources() []string { return nil }
+
+func TestExecuteWithRetry(t *testing.T) {
+	okOutput := StepOutput{Observed: "ok", CaptureBody: `{"id":"1"}`}
+	transientErr := errors.New("connection refused")
+
+	tests := []struct {
+		name       string
+		retry      *Retry
+		failCount  int
+		wantErr    bool
+		wantCalls  int
+		wantOutput StepOutput
+	}{
+		{
+			name:       "succeeds on first attempt",
+			retry:      &Retry{Attempts: 3, Interval: "10ms"},
+			failCount:  0,
+			wantCalls:  1,
+			wantOutput: okOutput,
+		},
+		{
+			name:       "succeeds after transient failures",
+			retry:      &Retry{Attempts: 5, Interval: "10ms"},
+			failCount:  2,
+			wantCalls:  3,
+			wantOutput: okOutput,
+		},
+		{
+			name:      "exhausts all attempts",
+			retry:     &Retry{Attempts: 3, Interval: "10ms"},
+			failCount: 10,
+			wantErr:   true,
+			wantCalls: 3,
+		},
+		{
+			name:       "default attempts when zero",
+			retry:      &Retry{Attempts: 0, Interval: "10ms"},
+			failCount:  2,
+			wantCalls:  3,
+			wantOutput: okOutput,
+		},
+		{
+			name:      "invalid interval returns error",
+			retry:     &Retry{Attempts: 3, Interval: "notaduration"},
+			failCount: 0,
+			wantErr:   true,
+			wantCalls: 0,
+		},
+		{
+			name:      "invalid timeout returns error",
+			retry:     &Retry{Attempts: 3, Interval: "10ms", Timeout: "notaduration"},
+			failCount: 0,
+			wantErr:   true,
+			wantCalls: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockExecutor{
+				failCount: tt.failCount,
+				failErr:   transientErr,
+				output:    okOutput,
+			}
+
+			runner := NewRunner(map[string]StepExecutor{"request": mock}, newTestLogger())
+			step := Step{
+				Description: "test step",
+				Request:     &Request{Method: "GET", Path: "/test"},
+				Retry:       tt.retry,
+			}
+
+			output, err := runner.executeStep(context.Background(), mock, step, nil)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if output.Observed != tt.wantOutput.Observed {
+				t.Errorf("observed = %q, want %q", output.Observed, tt.wantOutput.Observed)
+			}
+			if mock.callCount != tt.wantCalls {
+				t.Errorf("callCount = %d, want %d", mock.callCount, tt.wantCalls)
+			}
+		})
+	}
+}
+
+func TestRetryTimeoutCapsRetries(t *testing.T) {
+	mock := &mockExecutor{
+		failCount: 100,
+		failErr:   errors.New("connection refused"),
+	}
+
+	runner := NewRunner(map[string]StepExecutor{"request": mock}, newTestLogger())
+	step := Step{
+		Description: "timeout step",
+		Request:     &Request{Method: "GET", Path: "/test"},
+		Retry:       &Retry{Attempts: 100, Interval: "50ms", Timeout: "120ms"},
+	}
+
+	_, err := runner.executeStep(context.Background(), mock, step, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	// Should have executed fewer than 10 attempts due to timeout.
+	if mock.callCount >= 10 {
+		t.Errorf("expected timeout to cap retries, got %d calls", mock.callCount)
+	}
+}
+
+func TestRetryContextCancellation(t *testing.T) {
+	mock := &mockExecutor{
+		failCount: 100,
+		failErr:   errors.New("connection refused"),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	runner := NewRunner(map[string]StepExecutor{"request": mock}, newTestLogger())
+	step := Step{
+		Description: "cancel step",
+		Request:     &Request{Method: "GET", Path: "/test"},
+		Retry:       &Retry{Attempts: 10, Interval: "1s"},
+	}
+
+	_, err := runner.executeStep(ctx, mock, step, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	// Should stop after first attempt + context check, returning context error.
+	if mock.callCount > 2 {
+		t.Errorf("expected early exit on cancel, got %d calls", mock.callCount)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got: %v", err)
+	}
+}
+
+func TestRetryNoRetryBehaviorUnchanged(t *testing.T) {
+	mock := &mockExecutor{
+		failCount: 0,
+		output:    StepOutput{Observed: "ok"},
+	}
+
+	runner := NewRunner(map[string]StepExecutor{"request": mock}, newTestLogger())
+	step := Step{
+		Description: "no retry",
+		Request:     &Request{Method: "GET", Path: "/test"},
+	}
+
+	output, err := runner.executeStep(context.Background(), mock, step, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if output.Observed != "ok" {
+		t.Errorf("observed = %q, want %q", output.Observed, "ok")
+	}
+	if mock.callCount != 1 {
+		t.Errorf("callCount = %d, want 1", mock.callCount)
+	}
+}
+
+func TestRetrySetupStepSuccess(t *testing.T) {
+	mock := &mockExecutor{
+		failCount: 1,
+		failErr:   errors.New("connection refused"),
+		output:    StepOutput{Observed: "ok", CaptureBody: `{"id":"42"}`},
+	}
+
+	runner := NewRunner(map[string]StepExecutor{"request": mock}, newTestLogger())
+	sc := Scenario{
+		ID: "retry-setup",
+		Setup: []Step{
+			{
+				Description: "Setup with retry",
+				Request:     &Request{Method: "POST", Path: "/items"},
+				Retry:       &Retry{Attempts: 3, Interval: "10ms"},
+				Capture:     []Capture{{Name: "item_id", JSONPath: "$.id"}},
+			},
+		},
+		Steps: []Step{
+			{
+				Description: "Read item",
+				Request:     &Request{Method: "GET", Path: "/items/{item_id}"},
+				Expect:      "ok",
+			},
+		},
+	}
+
+	result, err := runner.Run(context.Background(), sc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.callCount < 2 {
+		t.Errorf("callCount = %d, want at least 2 (1 fail + 1 success)", mock.callCount)
+	}
+	if len(result.Steps) != 1 {
+		t.Fatalf("got %d steps, want 1", len(result.Steps))
+	}
+}
+
+func TestRetrySetupExhausted(t *testing.T) {
+	mock := &mockExecutor{
+		failCount: 10,
+		failErr:   errors.New("connection refused"),
+	}
+
+	runner := NewRunner(map[string]StepExecutor{"request": mock}, newTestLogger())
+	sc := Scenario{
+		ID: "retry-setup-fail",
+		Setup: []Step{
+			{
+				Description: "Setup with retry",
+				Request:     &Request{Method: "POST", Path: "/items"},
+				Retry:       &Retry{Attempts: 3, Interval: "10ms"},
+			},
+		},
+		Steps: []Step{
+			{
+				Description: "Should not run",
+				Request:     &Request{Method: "GET", Path: "/items/1"},
+				Expect:      "never",
+			},
+		},
+	}
+
+	_, err := runner.Run(context.Background(), sc)
+	if err == nil {
+		t.Fatal("expected error for exhausted setup retry")
+	}
+	if !errors.Is(err, errSetupFailed) {
+		t.Errorf("expected errSetupFailed, got: %v", err)
+	}
+}
+
+func TestRetryCapturesFromFinalAttempt(t *testing.T) {
+	callCount := 0
+	exec := &countingExecutor{
+		maxFails: 2,
+		failErr:  errors.New("connection refused"),
+		outputs: []StepOutput{
+			{}, // fail
+			{}, // fail
+			{Observed: "ok", CaptureBody: `{"id":"final"}`},
+		},
+		callCount: &callCount,
+	}
+
+	runner := NewRunner(map[string]StepExecutor{"request": exec}, newTestLogger())
+	step := Step{
+		Description: "retry capture",
+		Request:     &Request{Method: "GET", Path: "/test"},
+		Retry:       &Retry{Attempts: 5, Interval: "10ms"},
+		Capture:     []Capture{{Name: "result_id", JSONPath: "$.id"}},
+	}
+
+	output, err := runner.executeStep(context.Background(), exec, step, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if output.CaptureBody != `{"id":"final"}` {
+		t.Errorf("capture body = %q, want from final attempt", output.CaptureBody)
+	}
+}
+
+type countingExecutor struct {
+	maxFails  int
+	failErr   error
+	outputs   []StepOutput
+	callCount *int
+}
+
+func (e *countingExecutor) Execute(_ context.Context, _ Step, _ map[string]string) (StepOutput, error) {
+	idx := *e.callCount
+	*e.callCount++
+	if idx < e.maxFails {
+		return StepOutput{}, e.failErr
+	}
+	if idx < len(e.outputs) {
+		return e.outputs[idx], nil
+	}
+	return StepOutput{}, nil
+}
+
+func (e *countingExecutor) ValidCaptureSources() []string { return nil }
+
 func TestRunnerUnknownStepType(t *testing.T) {
 	sc := Scenario{
 		ID: "unknown-type",

--- a/internal/scenario/types.go
+++ b/internal/scenario/types.go
@@ -64,8 +64,16 @@ type Step struct {
 	Exec        *ExecRequest    `yaml:"exec"`
 	Browser     *BrowserRequest `yaml:"browser"`
 	GRPC        *GRPCRequest    `yaml:"grpc"`
+	Retry       *Retry          `yaml:"retry"`
 	Expect      string          `yaml:"expect"` // natural language, judged by LLM
 	Capture     []Capture       `yaml:"capture"`
+}
+
+// Retry configures retry/poll behavior for a step.
+type Retry struct {
+	Attempts int    `yaml:"attempts"` // max attempts (default: 3)
+	Interval string `yaml:"interval"` // delay between retries (default: "1s")
+	Timeout  string `yaml:"timeout"`  // overall timeout cap (optional)
 }
 
 // StepType returns the step type key: "request", "exec", "browser", "grpc", or "" if unknown.

--- a/schemas/scenario.json
+++ b/schemas/scenario.json
@@ -65,10 +65,32 @@
           "type": "string",
           "description": "Natural-language expectation judged by the LLM."
         },
+        "retry": { "$ref": "#/$defs/retry" },
         "capture": {
           "type": "array",
           "items": { "$ref": "#/$defs/capture" },
           "description": "Variables to extract from the response for use in later steps."
+        }
+      }
+    },
+    "retry": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "attempts": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Maximum number of attempts. Default: 3."
+        },
+        "interval": {
+          "type": "string",
+          "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)+$",
+          "description": "Delay between retries as a Go duration (e.g. '1s', '500ms'). Default: 1s."
+        },
+        "timeout": {
+          "type": "string",
+          "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)+$",
+          "description": "Overall timeout cap for all retry attempts as a Go duration. Optional."
         }
       }
     },


### PR DESCRIPTION
## Summary

- Add optional `retry` block to any scenario step type for eventual-consistency use cases (polling until a background job completes, waiting for a resource to appear)
- Retries fire only on `executor.Execute` errors (transport failures, timeouts); HTTP 4xx/5xx are NOT errors — they produce `StepOutput` for the LLM judge
- Configurable `attempts` (default 3), `interval` (default 1s), and optional `timeout` cap
- Lint validation for retry block structure and duration fields
- JSON Schema updated for editor integration
- Architecture docs updated with retry semantics

Closes #54

## Test plan

- [x] `make test` — all unit tests pass (10 new retry tests + existing)
- [x] `make lint` — zero issues
- [x] `make docs` / `make docs-check` — embedmd synced

🤖 Generated with [Claude Code](https://claude.com/claude-code)