### PR TITLE
feat(gene): add cross-language synthesis with display names

### DIFF
--- a/internal/attractor/attractor_test.go
+++ b/internal/attractor/attractor_test.go
@@ -1205,6 +1205,47 @@ func TestAttractorRunGenesPersistAcrossIterations(t *testing.T) {
 	}
 }
 
+func TestAttractorCrossLanguagePrompt(t *testing.T) {
+	geneContent := "// Always use handler-per-route\nfunc handleGetItems(w http.ResponseWriter, r *http.Request) { ... }"
+
+	var capturedSystemPrompt string
+	client := &mockLLMClient{
+		generateFn: func(_ context.Context, req llm.GenerateRequest) (llm.GenerateResponse, error) {
+			capturedSystemPrompt = req.SystemPrompt
+			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
+		},
+	}
+	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+		return 100, nil, 0.005, nil
+	}
+
+	opts := defaultOpts(t)
+	opts.Genes = geneContent
+	opts.GeneLanguage = "go"
+	opts.Language = "python"
+
+	a := New(client, &mockContainerMgr{}, testLogger(), nil)
+	result, err := a.Run(context.Background(), "Build an app", opts, validate, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != StatusConverged {
+		t.Errorf("expected converged, got %q", result.Status)
+	}
+	if !strings.Contains(capturedSystemPrompt, "CROSS-LANGUAGE NOTE") {
+		t.Error("system prompt should contain CROSS-LANGUAGE NOTE")
+	}
+	if !strings.Contains(capturedSystemPrompt, "Go") {
+		t.Error("cross-language note should mention source language Go")
+	}
+	if !strings.Contains(capturedSystemPrompt, "Python") {
+		t.Error("cross-language note should mention target language Python")
+	}
+	if !strings.Contains(capturedSystemPrompt, geneContent) {
+		t.Error("system prompt should contain gene content")
+	}
+}
+
 func TestExtractFailureStrings(t *testing.T) {
 	history := []iterationFeedback{
 		{iteration: 1, kind: feedbackValidation, message: "Satisfaction score: 60.0/100\nFailures:\n- missing endpoint"},

--- a/internal/attractor/prompts.go
+++ b/internal/attractor/prompts.go
@@ -94,15 +94,34 @@ func buildSystemPrompt(spec string, caps ScenarioCapabilities, language, genes, 
 }
 
 // buildGeneSection formats the gene guide text for inclusion in the system prompt.
-// When geneLanguage differs from language, a cross-language adaptation note is added.
+// When geneLanguage differs from language, a cross-language adaptation note is appended
+// after the gene content, instructing the LLM to preserve invariants while using
+// idiomatic constructs in the target language.
 func buildGeneSection(genes, language, geneLanguage string) string {
 	var b strings.Builder
 	b.WriteString(geneSectionHeader)
-	if geneLanguage != "" && language != "" && geneLanguage != language {
-		fmt.Fprintf(&b, "(These patterns are from a %s implementation — adapt idioms to %s)\n\n", geneLanguage, language)
-	}
 	b.WriteString(genes)
+
+	if geneLanguage != "" && language != "" && geneLanguage != language {
+		sourceName := languageDisplayName(geneLanguage)
+		targetName := languageDisplayName(language)
+		fmt.Fprintf(&b, "\n\nCROSS-LANGUAGE NOTE: The exemplar above is written in %s. "+
+			"You are generating %s. Preserve the invariants, structural patterns, and "+
+			"architectural approach while using idiomatic %s constructs, libraries, and conventions.",
+			sourceName, targetName, targetName)
+	}
+
 	return b.String()
+}
+
+// languageDisplayName returns the human-readable display name for a language key.
+// Known languages use LanguageTemplate.Name (e.g. "go" → "Go", "node" → "Node.js").
+// Unknown languages fall back to the raw key string.
+func languageDisplayName(lang string) string {
+	if tmpl, ok := LookupLanguage(lang); ok {
+		return tmpl.Name
+	}
+	return lang
 }
 
 // buildCapabilitySuffix assembles the instruction text for a given capability set.

--- a/internal/attractor/prompts_test.go
+++ b/internal/attractor/prompts_test.go
@@ -537,42 +537,114 @@ func TestBuildSystemPromptGeneOrdering(t *testing.T) {
 	}
 }
 
-func TestBuildSystemPromptGeneCrossLanguage(t *testing.T) {
-	spec := "Build an API"
-	genes := "some patterns"
-
-	prompt := buildSystemPrompt(spec, ScenarioCapabilities{}, "python", genes, "go")
-	if !strings.Contains(prompt, "from a go implementation") {
-		t.Error("should contain cross-language source note")
-	}
-	if !strings.Contains(prompt, "adapt idioms to python") {
-		t.Error("should contain cross-language target note")
-	}
-}
-
-func TestBuildSystemPromptGeneSameLanguage(t *testing.T) {
-	spec := "Build an API"
-	genes := "some patterns"
-
-	prompt := buildSystemPrompt(spec, ScenarioCapabilities{}, "go", genes, "go")
-	if strings.Contains(prompt, "adapt idioms") {
+func TestBuildGeneSectionSameLanguage(t *testing.T) {
+	result := buildGeneSection("some patterns", "go", "go")
+	if strings.Contains(result, "CROSS-LANGUAGE NOTE") {
 		t.Error("same language should not include cross-language note")
 	}
 }
 
-func TestBuildSystemPromptGeneCrossLanguageEmptyLanguage(t *testing.T) {
-	spec := "Build an API"
-	genes := "some patterns"
+func TestBuildGeneSectionCrossLanguage(t *testing.T) {
+	result := buildGeneSection("some patterns", "python", "go")
+	if !strings.Contains(result, "CROSS-LANGUAGE NOTE") {
+		t.Error("cross-language should contain CROSS-LANGUAGE NOTE")
+	}
+}
 
-	// No cross-language note when either language is empty.
-	prompt := buildSystemPrompt(spec, ScenarioCapabilities{}, "", genes, "go")
-	if strings.Contains(prompt, "adapt idioms") {
+func TestBuildGeneSectionCrossLanguageContent(t *testing.T) {
+	result := buildGeneSection("some patterns", "python", "go")
+	if !strings.Contains(result, "Go") {
+		t.Error("note should mention source display name Go")
+	}
+	if !strings.Contains(result, "Python") {
+		t.Error("note should mention target display name Python")
+	}
+}
+
+func TestBuildGeneSectionCrossLanguagePreserve(t *testing.T) {
+	result := buildGeneSection("some patterns", "python", "go")
+	if !strings.Contains(result, "invariants") {
+		t.Error("note should mention invariants")
+	}
+	if !strings.Contains(result, "structural patterns") {
+		t.Error("note should mention structural patterns")
+	}
+}
+
+func TestBuildGeneSectionNoGeneLanguage(t *testing.T) {
+	result := buildGeneSection("some patterns", "python", "")
+	if strings.Contains(result, "CROSS-LANGUAGE NOTE") {
+		t.Error("should not include cross-language note when gene language is empty")
+	}
+}
+
+func TestBuildGeneSectionNoTargetLanguage(t *testing.T) {
+	result := buildGeneSection("some patterns", "", "go")
+	if strings.Contains(result, "CROSS-LANGUAGE NOTE") {
 		t.Error("should not include cross-language note when target language is empty")
 	}
+}
 
-	prompt = buildSystemPrompt(spec, ScenarioCapabilities{}, "go", genes, "")
-	if strings.Contains(prompt, "adapt idioms") {
-		t.Error("should not include cross-language note when gene language is empty")
+func TestBuildGeneSectionAllCombinations(t *testing.T) {
+	languages := []string{"go", "python", "node", "rust"}
+	displayNames := map[string]string{
+		"go": "Go", "python": "Python", "node": "Node.js", "rust": "Rust",
+	}
+
+	for _, gene := range languages {
+		for _, target := range languages {
+			name := gene + "_to_" + target
+			t.Run(name, func(t *testing.T) {
+				result := buildGeneSection("patterns", target, gene)
+				hasCrossNote := strings.Contains(result, "CROSS-LANGUAGE NOTE")
+				if gene == target && hasCrossNote {
+					t.Error("same language should not include cross-language note")
+				}
+				if gene != target && !hasCrossNote {
+					t.Error("different languages should include cross-language note")
+				}
+				if gene != target && !strings.Contains(result, displayNames[gene]) {
+					t.Errorf("note should mention source display name %s", displayNames[gene])
+				}
+				if gene != target && !strings.Contains(result, displayNames[target]) {
+					t.Errorf("note should mention target display name %s", displayNames[target])
+				}
+			})
+		}
+	}
+}
+
+func TestBuildGeneSectionUnknownLanguage(t *testing.T) {
+	result := buildGeneSection("some patterns", "python", "java")
+	if !strings.Contains(result, "CROSS-LANGUAGE NOTE") {
+		t.Error("unknown gene language should still trigger cross-language note")
+	}
+	if !strings.Contains(result, "java") {
+		t.Error("unknown language should fall back to raw string")
+	}
+	if !strings.Contains(result, "Python") {
+		t.Error("known target language should use display name")
+	}
+}
+
+func TestLanguageDisplayName(t *testing.T) {
+	tests := []struct {
+		lang string
+		want string
+	}{
+		{"go", "Go"},
+		{"python", "Python"},
+		{"node", "Node.js"},
+		{"rust", "Rust"},
+		{"unknown", "unknown"},
+		{"java", "java"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.lang, func(t *testing.T) {
+			if got := languageDisplayName(tt.lang); got != tt.want {
+				t.Errorf("languageDisplayName(%q) = %q, want %q", tt.lang, got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Updated `buildGeneSection` to append a `CROSS-LANGUAGE NOTE` when gene language differs from target language, instructing the LLM to preserve invariants while using idiomatic target-language constructs
- Added `languageDisplayName()` helper that maps language keys to human-readable names via `LanguageTemplate.Name` (e.g. `"node"` → `"Node.js"`), falling back to the raw key for unknown languages
- Replaced the previous minimal cross-language hint with the detailed note format from the issue spec

## Test plan

- [x] `TestBuildGeneSectionSameLanguage` — no note when gene=target
- [x] `TestBuildGeneSectionCrossLanguage` — note present when gene≠target
- [x] `TestBuildGeneSectionCrossLanguageContent` — note contains display names
- [x] `TestBuildGeneSectionCrossLanguagePreserve` — note mentions invariants/structural patterns
- [x] `TestBuildGeneSectionNoGeneLanguage` — no note when gene language empty
- [x] `TestBuildGeneSectionNoTargetLanguage` — no note when target language empty
- [x] `TestBuildGeneSectionAllCombinations` — 4×4 matrix (go/python/node/rust)
- [x] `TestBuildGeneSectionUnknownLanguage` — unknown language falls back to raw key
- [x] `TestLanguageDisplayName` — all known + unknown language mappings
- [x] `TestAttractorCrossLanguagePrompt` — integration test with mock LLM verifying captured system prompt
- [x] `make build && make test && make lint` all pass

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)