### PR TITLE
test(llm): add integration tests for LLM clients against real APIs

### DIFF
--- a/internal/llm/anthropic_integration_test.go
+++ b/internal/llm/anthropic_integration_test.go
@@ -1,0 +1,130 @@
+//go:build integration
+
+package llm
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+const anthropicIntegrationModel = "claude-haiku-4-5-20251001"
+
+func newAnthropicIntegrationClient(t *testing.T) *AnthropicClient {
+	t.Helper()
+	key := os.Getenv("ANTHROPIC_API_KEY")
+	if key == "" {
+		t.Skip("ANTHROPIC_API_KEY not set")
+	}
+	return NewAnthropicClient(key, newTestLogger())
+}
+
+func TestIntegrationAnthropicGenerate(t *testing.T) {
+	client := newAnthropicIntegrationClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	resp, err := client.Generate(ctx, GenerateRequest{
+		SystemPrompt: "You are a helpful assistant.",
+		Messages:     []Message{{Role: "user", Content: "Reply with the word 'hello'"}},
+		Model:        anthropicIntegrationModel,
+	})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	if resp.Content == "" {
+		t.Error("Content is empty")
+	}
+	if resp.InputTokens <= 0 {
+		t.Errorf("InputTokens = %d, want > 0", resp.InputTokens)
+	}
+	if resp.OutputTokens <= 0 {
+		t.Errorf("OutputTokens = %d, want > 0", resp.OutputTokens)
+	}
+	if resp.CostUSD <= 0 {
+		t.Errorf("CostUSD = %f, want > 0", resp.CostUSD)
+	}
+	if resp.FinishReason != "end_turn" {
+		t.Errorf("FinishReason = %q, want %q", resp.FinishReason, "end_turn")
+	}
+}
+
+func TestIntegrationAnthropicJudge(t *testing.T) {
+	client := newAnthropicIntegrationClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	systemPrompt := `You are a code satisfaction judge. Evaluate the provided output and respond with ONLY valid JSON in this exact format:
+{"score": <integer 0-100>, "reasoning": "<brief explanation>", "failures": []}`
+
+	resp, err := client.Judge(ctx, JudgeRequest{
+		SystemPrompt: systemPrompt,
+		UserPrompt:   "The function returns 42 as expected. Score this 100.",
+		Model:        anthropicIntegrationModel,
+	})
+	if err != nil {
+		t.Fatalf("Judge: %v", err)
+	}
+
+	if resp.Score < 0 || resp.Score > 100 {
+		t.Errorf("Score = %d, want 0-100", resp.Score)
+	}
+	if resp.Reasoning == "" {
+		t.Error("Reasoning is empty")
+	}
+	if resp.CostUSD <= 0 {
+		t.Errorf("CostUSD = %f, want > 0", resp.CostUSD)
+	}
+}
+
+// TestIntegrationAnthropicGenerateCacheControl verifies that prompt caching
+// works end-to-end. Cache hits are best-effort (require ≥1024 tokens and TTL
+// constraints), so a missing cache hit is logged but not a hard failure.
+func TestIntegrationAnthropicGenerateCacheControl(t *testing.T) {
+	client := newAnthropicIntegrationClient(t)
+
+	// Build a system prompt well above Anthropic's 1024-token minimum for caching.
+	// Each repetition is ~50 tokens; 30 repetitions ≈ 1500 tokens.
+	chunk := "You are a highly capable software engineer assistant. Your task is to generate clean, correct, well-structured Go code that satisfies the specification provided. Follow idiomatic Go conventions, handle all errors explicitly, and write code that is easy to maintain. "
+	systemPrompt := strings.Repeat(chunk, 30)
+
+	userMsg := []Message{{Role: "user", Content: "Reply with the word 'hello'"}}
+
+	// First call — populates the cache.
+	ctx1, cancel1 := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel1()
+
+	resp1, err := client.Generate(ctx1, GenerateRequest{
+		SystemPrompt: systemPrompt,
+		Messages:     userMsg,
+		Model:        anthropicIntegrationModel,
+		CacheControl: &CacheControl{Type: "ephemeral"},
+	})
+	if err != nil {
+		t.Fatalf("Generate (first call): %v", err)
+	}
+	t.Logf("first call: cache_hit=%v input_tokens=%d cost_usd=%.6f", resp1.CacheHit, resp1.InputTokens, resp1.CostUSD)
+
+	// Second call — should hit the cache.
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel2()
+
+	resp2, err := client.Generate(ctx2, GenerateRequest{
+		SystemPrompt: systemPrompt,
+		Messages:     userMsg,
+		Model:        anthropicIntegrationModel,
+		CacheControl: &CacheControl{Type: "ephemeral"},
+	})
+	if err != nil {
+		t.Fatalf("Generate (second call): %v", err)
+	}
+	t.Logf("second call: cache_hit=%v input_tokens=%d cost_usd=%.6f", resp2.CacheHit, resp2.InputTokens, resp2.CostUSD)
+
+	// Soft assertion: cache hits are best-effort depending on API state and TTL.
+	if !resp2.CacheHit {
+		t.Log("WARNING: second call did not get a cache hit; this may be a transient API condition")
+	}
+}

--- a/internal/llm/openai_integration_test.go
+++ b/internal/llm/openai_integration_test.go
@@ -1,0 +1,101 @@
+//go:build integration
+
+package llm
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+const openaiIntegrationModel = "gpt-4.1-nano"
+
+func newOpenAIIntegrationClient(t *testing.T) *OpenAIClient {
+	t.Helper()
+	key := os.Getenv("OPENAI_API_KEY")
+	if key == "" {
+		t.Skip("OPENAI_API_KEY not set")
+	}
+	return NewOpenAIClient(key, "", false, newTestLogger())
+}
+
+func TestIntegrationOpenAIGenerate(t *testing.T) {
+	client := newOpenAIIntegrationClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	resp, err := client.Generate(ctx, GenerateRequest{
+		SystemPrompt: "You are a helpful assistant.",
+		Messages:     []Message{{Role: "user", Content: "Reply with the word 'hello'"}},
+		Model:        openaiIntegrationModel,
+	})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	if resp.Content == "" {
+		t.Error("Content is empty")
+	}
+	if resp.InputTokens <= 0 {
+		t.Errorf("InputTokens = %d, want > 0", resp.InputTokens)
+	}
+	if resp.OutputTokens <= 0 {
+		t.Errorf("OutputTokens = %d, want > 0", resp.OutputTokens)
+	}
+	if resp.CostUSD <= 0 {
+		t.Errorf("CostUSD = %f, want > 0", resp.CostUSD)
+	}
+	if resp.FinishReason != "stop" {
+		t.Errorf("FinishReason = %q, want %q", resp.FinishReason, "stop")
+	}
+}
+
+func TestIntegrationOpenAIJudge(t *testing.T) {
+	client := newOpenAIIntegrationClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	systemPrompt := `You are a code satisfaction judge. Evaluate the provided output and respond with ONLY valid JSON in this exact format:
+{"score": <integer 0-100>, "reasoning": "<brief explanation>", "failures": []}`
+
+	resp, err := client.Judge(ctx, JudgeRequest{
+		SystemPrompt: systemPrompt,
+		UserPrompt:   "The function returns 42 as expected. Score this 100.",
+		Model:        openaiIntegrationModel,
+	})
+	if err != nil {
+		t.Fatalf("Judge: %v", err)
+	}
+
+	if resp.Score < 0 || resp.Score > 100 {
+		t.Errorf("Score = %d, want 0-100", resp.Score)
+	}
+	if resp.Reasoning == "" {
+		t.Error("Reasoning is empty")
+	}
+	if resp.CostUSD <= 0 {
+		t.Errorf("CostUSD = %f, want > 0", resp.CostUSD)
+	}
+}
+
+// TestIntegrationOpenAIGenerateFinishReasonLength verifies that a MaxTokens=1
+// constraint forces a "length" finish reason from the API.
+func TestIntegrationOpenAIGenerateFinishReasonLength(t *testing.T) {
+	client := newOpenAIIntegrationClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	resp, err := client.Generate(ctx, GenerateRequest{
+		Messages:  []Message{{Role: "user", Content: "Write a long story about a dragon."}},
+		Model:     openaiIntegrationModel,
+		MaxTokens: 1,
+	})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	if resp.FinishReason != "length" {
+		t.Errorf("FinishReason = %q, want %q", resp.FinishReason, "length")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `//go:build integration` tests for both the Anthropic and OpenAI LLM backends
- Tests skip cleanly when the relevant API key env var is not set
- No production code changes

### Anthropic tests (`internal/llm/anthropic_integration_test.go`)
- `TestIntegrationAnthropicGenerate` — verifies content, token counts, cost, and `end_turn` finish reason using `claude-haiku-4-5-20251001`
- `TestIntegrationAnthropicJudge` — verifies score in 0-100 range, non-empty reasoning, cost
- `TestIntegrationAnthropicGenerateCacheControl` — two-call test with `cache_control: ephemeral` on a ≥1024-token system prompt; cache hit is soft-asserted (logged, not hard-failed) to avoid flakiness

### OpenAI tests (`internal/llm/openai_integration_test.go`)
- `TestIntegrationOpenAIGenerate` — same assertions using `gpt-4.1-nano`
- `TestIntegrationOpenAIJudge` — verifies JSON judge parsing against real API
- `TestIntegrationOpenAIGenerateFinishReasonLength` — sends `MaxTokens: 1` to force a `"length"` finish reason

### Run integration tests locally
```
ANTHROPIC_API_KEY=sk-ant-... go test -tags=integration ./internal/llm/...
OPENAI_API_KEY=sk-...        go test -tags=integration ./internal/llm/...
```

## Architect Review

**0 errors, 0 warnings, 0 nits — PASS**

- All assertions match plan spec exactly
- `const` model IDs avoid `gochecknoglobals` lint
- `newTestLogger()` reused from existing `anthropic_test.go` (same package)
- Cache soft-assertion is correctly implemented: hard-fail only on API error, `t.Log` if cache miss
- Cheapest models selected (`claude-haiku-4-5-20251001`, `gpt-4.1-nano`) to minimize CI cost per run (~$0.001–0.01 total)

Closes #83