### PR TITLE
test(store): add file-based SQLite integration tests

### DIFF
--- a/internal/store/db.go
+++ b/internal/store/db.go
@@ -29,6 +29,10 @@ func NewStore(ctx context.Context, path string) (*Store, error) {
 		return nil, fmt.Errorf("store: open: %w", err)
 	}
 
+	// Limit to a single connection so PRAGMAs set below apply to all operations.
+	// SQLite only allows one concurrent writer; WAL mode handles concurrent reads.
+	db.SetMaxOpenConns(1)
+
 	if _, err := db.ExecContext(ctx, "PRAGMA journal_mode=WAL"); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("store: pragma wal: %w", err)

--- a/internal/store/db_integration_test.go
+++ b/internal/store/db_integration_test.go
@@ -1,0 +1,247 @@
+//go:build integration
+
+package store
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// newFileStore opens a file-based Store at dir/test.db and registers cleanup.
+func newFileStore(t *testing.T, dir string) *Store {
+	t.Helper()
+	s, err := NewStore(context.Background(), filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func TestFileBasedPersistence(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+	now := time.Now().Truncate(time.Second)
+
+	// Write a run and iteration via s1, then explicitly close it before reopening.
+	s1, err := NewStore(ctx, filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("NewStore s1: %v", err)
+	}
+	run := Run{
+		ID:           "persist-run-1",
+		SpecPath:     "/specs/app.md",
+		Model:        "claude-sonnet-4-6",
+		Threshold:    95.0,
+		BudgetUSD:    10.0,
+		StartedAt:    now,
+		Satisfaction: 98.5,
+		Iterations:   4,
+		TotalTokens:  20000,
+		TotalCostUSD: 0.85,
+		Status:       "converged",
+		Language:     "go",
+	}
+	if err := s1.RecordRun(ctx, run); err != nil {
+		t.Fatalf("RecordRun: %v", err)
+	}
+	it := Iteration{
+		RunID:        "persist-run-1",
+		Iteration:    1,
+		Satisfaction: 98.5,
+		InputTokens:  10000,
+		OutputTokens: 10000,
+		CostUSD:      0.85,
+		Failures:     []string{},
+		CreatedAt:    now,
+	}
+	if err := s1.RecordIteration(ctx, it); err != nil {
+		t.Fatalf("RecordIteration: %v", err)
+	}
+	if err := s1.Close(); err != nil {
+		t.Fatalf("Close s1: %v", err)
+	}
+
+	// Reopen at the same path and read back data.
+	s2, err := NewStore(ctx, filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("NewStore reopen: %v", err)
+	}
+	t.Cleanup(func() { _ = s2.Close() })
+
+	got, err := s2.GetRun(ctx, "persist-run-1")
+	if err != nil {
+		t.Fatalf("GetRun: %v", err)
+	}
+
+	if got.ID != "persist-run-1" {
+		t.Errorf("ID = %q, want %q", got.ID, "persist-run-1")
+	}
+	if got.SpecPath != "/specs/app.md" {
+		t.Errorf("SpecPath = %q, want %q", got.SpecPath, "/specs/app.md")
+	}
+	if got.Model != "claude-sonnet-4-6" {
+		t.Errorf("Model = %q, want %q", got.Model, "claude-sonnet-4-6")
+	}
+	if got.Threshold != 95.0 {
+		t.Errorf("Threshold = %v, want 95.0", got.Threshold)
+	}
+	if got.Satisfaction != 98.5 {
+		t.Errorf("Satisfaction = %v, want 98.5", got.Satisfaction)
+	}
+	if got.Iterations != 4 {
+		t.Errorf("Iterations = %d, want 4", got.Iterations)
+	}
+	if got.TotalCostUSD != 0.85 {
+		t.Errorf("TotalCostUSD = %v, want 0.85", got.TotalCostUSD)
+	}
+	if got.Status != "converged" {
+		t.Errorf("Status = %q, want %q", got.Status, "converged")
+	}
+	if got.Language != "go" {
+		t.Errorf("Language = %q, want %q", got.Language, "go")
+	}
+	if !got.StartedAt.Equal(now) {
+		t.Errorf("StartedAt = %v, want %v", got.StartedAt, now)
+	}
+
+	runs, err := s2.ListRuns(ctx)
+	if err != nil {
+		t.Fatalf("ListRuns: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("ListRuns count = %d, want 1", len(runs))
+	}
+	if runs[0].ID != "persist-run-1" {
+		t.Errorf("ListRuns[0].ID = %q, want %q", runs[0].ID, "persist-run-1")
+	}
+}
+
+func TestWALModeEnabled(t *testing.T) {
+	s := newFileStore(t, t.TempDir())
+	ctx := context.Background()
+
+	var mode string
+	if err := s.db.QueryRowContext(ctx, "PRAGMA journal_mode").Scan(&mode); err != nil {
+		t.Fatalf("PRAGMA journal_mode: %v", err)
+	}
+	if mode != "wal" {
+		t.Errorf("journal_mode = %q, want %q", mode, "wal")
+	}
+}
+
+func TestConcurrentAccess(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+	const n = 10
+
+	// Open two independent stores to the same file.
+	s1 := newFileStore(t, dir)
+	s2, err := NewStore(ctx, filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("NewStore s2: %v", err)
+	}
+	t.Cleanup(func() { _ = s2.Close() })
+
+	now := time.Now().Truncate(time.Second)
+
+	// Write N runs concurrently via s1.
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			run := Run{
+				ID:        fmt.Sprintf("concurrent-run-%02d", i),
+				SpecPath:  "/spec.md",
+				Model:     "model",
+				Threshold: 95.0,
+				StartedAt: now,
+				Status:    "converged",
+			}
+			errs[i] = s1.RecordRun(ctx, run)
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d RecordRun: %v", i, err)
+		}
+	}
+
+	// Read back all runs via s2.
+	runs, err := s2.ListRuns(ctx)
+	if err != nil {
+		t.Fatalf("ListRuns: %v", err)
+	}
+	if len(runs) != n {
+		t.Errorf("ListRuns count = %d, want %d", len(runs), n)
+	}
+}
+
+func TestConcurrentIterationWrites(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+	const n = 10
+
+	s := newFileStore(t, dir)
+	now := time.Now().Truncate(time.Second)
+
+	// Insert a parent run.
+	run := Run{
+		ID:        "parent-run",
+		SpecPath:  "/spec.md",
+		Model:     "model",
+		Threshold: 95.0,
+		StartedAt: now,
+		Status:    "running",
+	}
+	if err := s.RecordRun(ctx, run); err != nil {
+		t.Fatalf("RecordRun: %v", err)
+	}
+
+	// Write N iterations concurrently.
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			it := Iteration{
+				RunID:        "parent-run",
+				Iteration:    i + 1,
+				Satisfaction: float64(50 + i),
+				InputTokens:  1000,
+				OutputTokens: 500,
+				CostUSD:      0.01,
+				Failures:     []string{},
+				CreatedAt:    now,
+			}
+			errs[i] = s.RecordIteration(ctx, it)
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d RecordIteration: %v", i, err)
+		}
+	}
+
+	// Verify all N iterations were persisted.
+	var count int
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM iterations WHERE run_id = 'parent-run'`,
+	).Scan(&count); err != nil {
+		t.Fatalf("count iterations: %v", err)
+	}
+	if count != n {
+		t.Errorf("iteration count = %d, want %d", count, n)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `internal/store/db_integration_test.go` with four integration tests (build tag `integration`) covering file-based SQLite behaviour absent from the existing in-memory unit tests
- Fixes a production bug in `NewStore`: `PRAGMA busy_timeout=5000` was only applied to the first connection opened; adding `db.SetMaxOpenConns(1)` ensures all pool connections share the configured pragmas

## Tests added

| Test | What it exercises |
|------|-------------------|
| `TestFileBasedPersistence` | Write Run + Iteration, close store, reopen at same path, verify all fields survive (cross-session durability) |
| `TestWALModeEnabled` | Assert `PRAGMA journal_mode` returns `"wal"` on a file-based store |
| `TestConcurrentAccess` | Two independent `Store` instances on the same file; 10 goroutines write via one, reads confirmed via the other |
| `TestConcurrentIterationWrites` | Single store, 10 concurrent goroutines each writing a distinct Iteration; verifies all rows persist |

Run with: `go test -tags=integration ./internal/store/...`

## Architect review summary

**0 errors, 1 warning (fixed), 1 nit**

- **Warning (fixed):** `TestFileBasedPersistence` originally used `newFileStore` for s1, deferring close to `t.Cleanup` — meaning both s1 and s2 would be open simultaneously. Fixed by explicitly calling `s1.Close()` before reopening as s2, ensuring provable serialization.
- **Nit:** Goroutine error collection via pre-allocated `errs []error` slice + `wg.Wait()` before ranging is safe and idiomatic. No change needed.
- **Production fix surfaced by tests:** `SetMaxOpenConns(1)` is the standard Go+SQLite pattern; without it, concurrent goroutines obtain separate pool connections that don't inherit connection-level PRAGMAs, causing `SQLITE_BUSY` failures despite `busy_timeout` being set.

Closes #85