### PR TITLE
docs: add gene transfusion documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,11 +22,11 @@ commit-msg hook. Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `tes
 ## Module & Packages
 
 `github.com/foundatron/octopusgarden` — Go 1.24+ — binary `octog` — subcommands: `run`, `validate`,
-`status`
+`status`, `extract`
 
 Internal packages: `spec` (parse markdown specs), `scenario` (load/run/judge YAML scenarios),
 `attractor` (convergence loop, file parsing), `container` (Docker build/run), `llm` (client
-interface, Anthropic + OpenAI backends)
+interface, Anthropic + OpenAI backends), `gene` (scan exemplar codebases, LLM pattern extraction)
 
 ## Dependencies
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,7 @@ internal/
   attractor/          Convergence loop and file parsing
   container/          Docker build and run
   llm/                LLM client interface (Anthropic + OpenAI backends)
+  gene/               Gene transfusion (scan, analyze, gene types)
   store/              SQLite run history
 examples/             Example specs and scenarios (holdout sets)
 ```

--- a/README.md
+++ b/README.md
@@ -106,6 +106,19 @@ octog validate \
   --target http://localhost:8080
 ```
 
+Bootstrap generation with patterns from an existing project:
+
+```bash
+# Extract patterns from an exemplar codebase
+octog extract --source-dir /path/to/exemplar --output genes.json
+
+# Use extracted patterns to guide code generation
+octog run \
+  --spec examples/hello-api/spec.md \
+  --scenarios examples/hello-api/scenarios/ \
+  --genes genes.json
+```
+
 List available models and check past runs:
 
 ```bash
@@ -124,6 +137,7 @@ Commands:
   run        Run the attractor loop to generate software from a spec
   validate   Validate a running service against scenarios
   status     Show recent runs, scores, and costs
+  extract    Extract coding patterns from a source directory into a gene file
   models     List available models
   configure  Interactively configure API keys
 ```
@@ -140,6 +154,8 @@ Run `octog models` to list available models.
 | `--judge-model`    | `claude-haiku-4-5`  | LLM model for satisfaction judging                             |
 | `--budget`         | `5.00`              | Maximum spend in USD                                           |
 | `--threshold`      | `95`                | Satisfaction target (0-100)                                    |
+| `--genes`          | *(none)*            | Path to gene file from `octog extract` (bootstraps generation) |
+| `--language`       | `go`                | Target language: `go`, `python`, `node`, `rust`, or `auto`     |
 | `--patch`          | `false`             | Incremental patch mode (iteration 2+ sends only changed files) |
 | `--context-budget` | `0`                 | Max estimated tokens for spec in system prompt; 0 = unlimited  |
 
@@ -152,6 +168,14 @@ Run `octog models` to list available models.
 | `--judge-model` | `claude-haiku-4-5` | LLM model for satisfaction judging                                  |
 | `--threshold`   | `0`                | Minimum satisfaction score; non-zero enables exit code 1 on failure |
 
+### `extract`
+
+| Flag           | Default      | Description                                             |
+| -------------- | ------------ | ------------------------------------------------------- |
+| `--source-dir` | *(required)* | Path to source directory to extract patterns from       |
+| `--output`     | `genes.json` | Output file path (use `-` for stdout)                   |
+| `--model`      | *(auto)*     | LLM model for extraction (defaults to judge-tier model) |
+
 ### `status`
 
 No flags. Shows a table of recent runs with status, model, score, iterations, cost, and timestamp.
@@ -163,11 +187,15 @@ No flags. Shows a table of recent runs with status, model, score, iterations, co
   these during code generation)
 - **Attractor** — The convergence loop: generate -> test -> score -> feedback -> regenerate
 - **Satisfaction** — Probabilistic scoring (0-100) via LLM-as-judge, not boolean pass/fail
+- **Gene Transfusion** — Extract coding patterns from exemplar codebases to bootstrap generation
+  (`octog extract` → `octog run --genes`)
 
 ## Documentation
 
 - [Architecture](docs/architecture.md) — System design, data structures, LLM interfaces, Docker
   strategy
+- [Gene Transfusion](docs/gene-transfusion.md) — Extract and use coding patterns from exemplar
+  codebases
 - [Contributing](CONTRIBUTING.md) — Development setup, coding standards, and how to contribute
 
 ## License

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,6 +43,7 @@ octopusgarden/
 │   │   ├── json.go               # Shared JSON extraction for judge responses
 │   │   ├── models.go             # Model registry, cost tracking
 │   │   └── prompt.go             # Prompt templates
+│   ├── gene/                     # Gene transfusion (scan, analyze, gene types)
 │   ├── lint/                     # Spec and scenario linting
 │   └── store/                    # SQLite run history (db.go, types.go)
 ├── examples/                     # Example specs and scenarios
@@ -60,6 +61,9 @@ cmd/octog
     │       ├── internal/llm
     │       ├── internal/spec
     │       └── internal/container
+    ├── internal/gene        (scan, analyze, gene types)
+    │       ├── internal/llm
+    │       └── internal/spec
     ├── internal/scenario    (loader, runner, judge)
     │       └── internal/llm
     ├── internal/llm         (client interface, anthropic, openai, models, prompts)
@@ -608,7 +612,8 @@ even after caller context cancellation. `Close()` closes the underlying Docker c
 ## CLI Interface
 
 ```text
-octog run       --spec <path> --scenarios <dir> [--model claude-sonnet-4-6] [--judge-model claude-haiku-4-5] [--budget 5.00] [--threshold 95] [--patch] [--context-budget 0] [--provider anthropic|openai]
+octog run       --spec <path> --scenarios <dir> [--model claude-sonnet-4-6] [--judge-model claude-haiku-4-5] [--budget 5.00] [--threshold 95] [--genes genes.json] [--language go] [--patch] [--context-budget 0] [--provider anthropic|openai]
+octog extract   --source-dir <path> [--output genes.json] [--model ...] [--provider anthropic|openai]
 octog validate  --scenarios <dir> --target <url> [--judge-model claude-haiku-4-5] [--threshold 0] [--format text|json] [--provider anthropic|openai]
 octog status    [--format text|json]
 octog lint      --spec <path> --scenarios <dir>
@@ -616,11 +621,42 @@ octog models    [--provider anthropic|openai]
 octog configure
 ```
 
-Subcommands: `run`, `validate`, `status`, `lint`, `models`, `configure`.
+Subcommands: `run`, `validate`, `status`, `extract`, `lint`, `models`, `configure`.
 
 Provider is auto-detected from which API key is set. Use `--provider` to disambiguate when both are
 present. Config file (`~/.octopusgarden/config`) supports `ANTHROPIC_API_KEY` and `OPENAI_API_KEY`;
 env vars take precedence. `OPENAI_BASE_URL` overrides the OpenAI endpoint for Ollama etc.
+
+## Gene Transfusion
+
+Gene transfusion bootstraps code generation by extracting patterns from an exemplar codebase. The
+pipeline: `gene.Scan` selects high-signal files (markers, README, Dockerfile, entrypoint, handlers,
+models) within a ~20K token budget → `gene.Analyze` sends them to an LLM to produce a structured
+guide → the guide is stored as a `Gene` JSON file.
+
+[embedmd]:# (../internal/gene/gene.go go /^\/\/ Gene represents/ /^}/)
+```go
+// Gene represents an extracted coding guide for a specific language,
+// derived from a source repository's patterns and conventions.
+type Gene struct {
+	Version     int       `json:"version"`
+	Source      string    `json:"source"`
+	Language    string    `json:"language"`
+	ExtractedAt time.Time `json:"extracted_at"`
+	Guide       string    `json:"guide"`
+	TokenCount  int       `json:"token_count"`
+}
+```
+
+At runtime, `--genes genes.json` loads the guide into `RunOptions.Genes`. The attractor's
+`buildSystemPrompt` injects it between the spec and instructions with a "PROVEN PATTERNS" header.
+The spec always takes precedence on conflicts.
+
+Cross-language synthesis: when `Gene.Language` differs from the target `--language`, a
+`CROSS-LANGUAGE NOTE` is appended instructing the LLM to preserve structural patterns while using
+idiomatic target-language constructs.
+
+See [Gene Transfusion](gene-transfusion.md) for the full user guide.
 
 ## SQLite Schema
 

--- a/docs/gene-transfusion.md
+++ b/docs/gene-transfusion.md
@@ -1,0 +1,176 @@
+# Gene Transfusion
+
+Gene transfusion extracts coding patterns from an exemplar codebase and injects them into the
+attractor loop, bootstrapping code generation with proven architectural decisions.
+
+## Quick Start
+
+```bash
+# 1. Extract patterns from your best project
+octog extract --source-dir /path/to/exemplar --output genes.json
+
+# 2. Run the factory with extracted genes
+octog run \
+  --spec spec.md \
+  --scenarios scenarios/ \
+  --genes genes.json
+```
+
+## How It Works
+
+Gene transfusion is a three-stage pipeline:
+
+```text
+Source Directory ──→ Scan ──→ Analyze (LLM) ──→ Gene JSON
+                      │            │
+               select files   extract patterns
+               detect lang    produce guide
+```
+
+1. **Scan** (`internal/gene/scan.go`) — walks the source directory and selects high-signal files:
+   project markers (`go.mod`, `package.json`), README (truncated to 100 lines), Dockerfile,
+   entrypoint, largest handler file, and largest model file. Skips test files, generated files, lock
+   files, and binary assets. Enforces a ~20,000 token budget by dropping lower-priority files.
+
+1. **Analyze** (`internal/gene/analyze.go`) — sends the selected files to an LLM with a structured
+   extraction prompt. The LLM produces a concise guide covering: architectural pattern, invariants,
+   edge case handling, stack, directory structure, boot sequence, and build strategy. Uses the
+   judge-tier model (e.g. `claude-haiku-4-5`) since extraction is a summarization task.
+
+1. **Gene JSON** (`internal/gene/gene.go`) — the guide is stored as a versioned JSON file with
+   metadata: source directory, detected language, extraction timestamp, guide text, and token count.
+
+### Prompt Injection
+
+When `--genes` is provided to `octog run`, the gene guide is injected into the system prompt between
+the spec and the instructions:
+
+```text
+SPECIFICATION:
+<spec content>
+
+PROVEN PATTERNS (extracted from a working exemplar — synthesize equivalent behavior
+adapted to the specification above. Preserve the structural approach and invariants.
+The SPECIFICATION always takes precedence over these patterns on any conflict):
+
+<gene guide>
+
+INSTRUCTIONS:
+<capability-specific instructions>
+```
+
+The spec always takes precedence over gene patterns on any conflict, preserving holdout isolation
+semantics.
+
+## Gene JSON Format
+
+```json
+{
+  "version": 1,
+  "source": "/path/to/exemplar",
+  "language": "go",
+  "extracted_at": "2026-03-06T14:30:00Z",
+  "guide": "**PATTERN** — Layered architecture with...",
+  "token_count": 2320
+}
+```
+
+| Field          | Type   | Description                                          |
+| -------------- | ------ | ---------------------------------------------------- |
+| `version`      | int    | Schema version (currently 1)                         |
+| `source`       | string | Path to the source directory that was scanned        |
+| `language`     | string | Detected language: `go`, `python`, `node`, or `rust` |
+| `extracted_at` | string | ISO 8601 timestamp of extraction                     |
+| `guide`        | string | The extracted pattern guide (LLM-generated text)     |
+| `token_count`  | int    | Estimated token count of the guide                   |
+
+## Cross-Language Synthesis
+
+Genes extracted from one language can be used to generate code in another. When the gene's language
+differs from the target language, a cross-language note is automatically appended to the system
+prompt:
+
+```text
+CROSS-LANGUAGE NOTE: The exemplar above is written in Go. You are generating Python.
+Preserve the invariants, structural patterns, and architectural approach while using
+idiomatic Python constructs, libraries, and conventions.
+```
+
+This is useful when you have a well-structured project in one language and want to generate an
+equivalent in another — the architectural patterns transfer even when the idioms differ.
+
+## Language Auto-Detection
+
+When `--genes` is provided without an explicit `--language` flag, the target language is
+automatically set to the gene's language. This means:
+
+```bash
+# Gene was extracted from a Go project → generates Go code
+octog run --spec spec.md --scenarios scenarios/ --genes go-genes.json
+
+# Override with explicit --language to generate in a different language
+octog run --spec spec.md --scenarios scenarios/ --genes go-genes.json --language python
+```
+
+The auto-detection is logged:
+
+```text
+INFO loaded genes source=. language=go tokens=2320
+INFO auto-detected language from genes (override with --language) language=go
+```
+
+## CLI Reference
+
+### `extract`
+
+| Flag           | Default      | Description                                             |
+| -------------- | ------------ | ------------------------------------------------------- |
+| `--source-dir` | *(required)* | Path to the source directory to extract patterns from   |
+| `--output`     | `genes.json` | Output file path (use `-` for stdout)                   |
+| `--model`      | *(auto)*     | LLM model for extraction (defaults to judge-tier model) |
+| `--provider`   | *(auto)*     | LLM provider: `anthropic` or `openai`                   |
+
+### `run --genes`
+
+| Flag         | Default  | Description                                                 |
+| ------------ | -------- | ----------------------------------------------------------- |
+| `--genes`    | *(none)* | Path to `genes.json` file produced by `octog extract`       |
+| `--language` | `go`     | Target language (`go`, `python`, `node`, `rust`, or `auto`) |
+
+When `--genes` is provided and `--language` is not explicitly set, the target language is inferred
+from the gene file.
+
+## File Selection
+
+The scanner selects files by role, in priority order:
+
+| Role         | Selection strategy                       | Example                    |
+| ------------ | ---------------------------------------- | -------------------------- |
+| `marker`     | All project markers found                | `go.mod`, `package.json`   |
+| `readme`     | First README found (truncated 100 lines) | `README.md`                |
+| `dockerfile` | First Dockerfile found                   | `Dockerfile`               |
+| `entrypoint` | First recognized entrypoint              | `main.go`, `cmd/*/main.go` |
+| `handler`    | Largest file in handler-like directories | `routes/`, `handlers/`     |
+| `model`      | Largest file in model-like directories   | `models/`, `types/`        |
+
+When the total exceeds the ~20,000 token budget, files are dropped in reverse priority: model first,
+then handler, then readme.
+
+Skipped: `.git`, `vendor`, `node_modules`, `__pycache__`, test files (`*_test.go`, `*.test.ts`),
+generated files (`*.pb.go`, `*_generated.*`), lock files (`go.sum`, `package-lock.json`), and binary
+assets (`.exe`, `.png`, `.woff`).
+
+## Best Practices
+
+- **Extract from your best project.** The gene captures patterns from the source directory — pick a
+  well-structured exemplar that represents the conventions you want.
+- **Re-extract after major refactors.** Gene files are snapshots. If the exemplar's architecture
+  evolves, re-run `octog extract` to update the gene.
+- **Commit gene files.** They're small JSON files (~2-5 KB) that encode team conventions. Version
+  them alongside your specs and scenarios.
+- **Share across projects.** The same gene file can bootstrap multiple specs targeting the same
+  language and stack.
+- **Use cross-language for migrations.** Extract from a Go service, generate a Python equivalent —
+  the structural patterns transfer.
+- **Stdout mode for pipelines.** Use `--output -` to pipe gene JSON into other tools or inspect
+  without writing a file.


### PR DESCRIPTION
## Summary

- Create `docs/gene-transfusion.md` — full user guide covering quick start, pipeline, JSON format, cross-language synthesis, auto-detection, CLI reference, file selection, and best practices
- Update `README.md` — add `extract` to commands table, `--genes`/`--language` to run flags, extract flag table, gene transfusion quick start example, key concept bullet, doc link
- Update `docs/architecture.md` — add `gene/` to repo structure + package DAG, `extract` to CLI section, Gene Transfusion section with embedmd `Gene` struct
- Update `CONTRIBUTING.md` — add `gene/` to project structure
- Update `CLAUDE.md` — add `extract` subcommand and `gene` to internal packages list

## Verification

- All unit tests pass (`make test`)
- embedmd references sync (`make docs-check`)
- Lint clean (`make lint`, 0 issues)
- Manual `octog extract` produces valid gene JSON (2320 tokens, 7 sections)
- Manual `octog run --genes` loads genes, logs metadata, proceeds to attractor loop
- Error cases (missing file, invalid JSON) produce clear error messages
- Language auto-detection from genes works correctly

Closes #17

## Test plan

- [x] `make test` passes
- [x] `make docs-check` passes
- [x] `make lint` passes
- [x] `octog extract --source-dir . --output /tmp/genes.json` produces valid gene JSON
- [x] `octog run --genes /tmp/genes.json` loads and uses genes
- [x] `octog run --genes /nonexistent.json` errors cleanly
- [x] Language auto-detection from python gene file works

🤖 Generated with [Claude Code](https://claude.com/claude-code)