### PR TITLE
fix(scripts): bash 3.2 compatibility for autoissue.sh

### DIFF
--- a/scripts/autoissue.sh
+++ b/scripts/autoissue.sh
@@ -258,7 +258,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-declare -A ISSUE_TITLES
+ISSUE_TITLES=()
 for ISSUE_NUMBER in "${ISSUES[@]}"; do
   log "Snapshotting issue #${ISSUE_NUMBER}..."
 
@@ -267,8 +267,8 @@ for ISSUE_NUMBER in "${ISSUES[@]}"; do
     exit 1
   }
 
-  ISSUE_TITLES[$ISSUE_NUMBER]=$(echo "$ISSUE_JSON" | jq -r '.title')
-  echo "    Title: ${ISSUE_TITLES[$ISSUE_NUMBER]}"
+  ISSUE_TITLES+=("$(echo "$ISSUE_JSON" | jq -r '.title')")
+  echo "    Title: ${ISSUE_TITLES[${#ISSUE_TITLES[@]}-1]}"
 
   {
     echo "# Issue #${ISSUE_NUMBER}: $(echo "$ISSUE_JSON" | jq -r '.title')"
@@ -297,9 +297,10 @@ log "All ${#ISSUES[@]} issues snapshotted and locked. No further network fetches
 TOTAL=${#ISSUES[@]}
 CURRENT=0
 
-for ISSUE_NUMBER in "${ISSUES[@]}"; do
+for IDX in "${!ISSUES[@]}"; do
+  ISSUE_NUMBER="${ISSUES[$IDX]}"
   CURRENT=$((CURRENT + 1))
-  ISSUE_TITLE="${ISSUE_TITLES[$ISSUE_NUMBER]}"
+  ISSUE_TITLE="${ISSUE_TITLES[$IDX]}"
   ISSUE_SNAPSHOT=$(cat "${WORK_DIR}/issue-${ISSUE_NUMBER}.md")
   ISSUE_WORK_DIR="${WORK_DIR}/${ISSUE_NUMBER}"
   mkdir -p "$ISSUE_WORK_DIR"


### PR DESCRIPTION
## Summary
- Replace `declare -A` (Bash 4+ associative array) with a plain indexed array in `autoissue.sh`
- macOS ships with Bash 3.2 which doesn't support associative arrays, causing `declare: -A: invalid option` error
- Uses parallel indexed arrays keyed by loop position instead

## Test plan
- [ ] Run `scripts/autoissue.sh <issue> --dry-run` on macOS with stock `/bin/bash` (3.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)