### PR TITLE
feat(scenario): exec files: field for writing temp files before execution

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -241,6 +241,7 @@ type ExecRequest struct {
 	Stdin   string            `yaml:"stdin"`
 	Env     map[string]string `yaml:"env"`
 	Timeout string            `yaml:"timeout"`
+	Files   map[string]string `yaml:"files"` // absolute path → content; written before command execution
 }
 
 // BrowserRequest describes a browser automation action.

--- a/internal/lint/scenario.go
+++ b/internal/lint/scenario.go
@@ -421,6 +421,39 @@ func lintExec(path string, node *yaml.Node, cs *captureSet) []Diagnostic {
 		}
 	}
 
+	// Check files: must be a mapping; keys must be absolute paths; check var refs in keys and values.
+	if filesFE, ok := fields["files"]; ok {
+		diags = append(diags, lintExecFiles(path, filesFE, cs)...)
+	}
+
+	return diags
+}
+
+func lintExecFiles(path string, filesFE *fieldEntry, cs *captureSet) []Diagnostic {
+	if filesFE.value.Kind != yaml.MappingNode {
+		return []Diagnostic{{
+			File:    path,
+			Line:    filesFE.value.Line,
+			Level:   Error,
+			Message: "exec files must be a mapping",
+		}}
+	}
+
+	var diags []Diagnostic
+	for i := 0; i+1 < len(filesFE.value.Content); i += 2 {
+		keyNode := filesFE.value.Content[i]
+		valNode := filesFE.value.Content[i+1]
+		if !strings.HasPrefix(keyNode.Value, "/") {
+			diags = append(diags, Diagnostic{
+				File:    path,
+				Line:    keyNode.Line,
+				Level:   Error,
+				Message: fmt.Sprintf("exec files path %q must be absolute (start with /); paths that begin with a variable reference such as {base_dir}/file must also include a leading /", keyNode.Value),
+			})
+		}
+		diags = append(diags, checkVarRefs(extractVarRefs(keyNode.Value), cs, path, keyNode.Line)...)
+		diags = append(diags, checkVarRefs(extractVarRefs(valNode.Value), cs, path, valNode.Line)...)
+	}
 	return diags
 }
 

--- a/internal/lint/scenario_test.go
+++ b/internal/lint/scenario_test.go
@@ -893,6 +893,106 @@ steps:
 			wantErrors: 1,
 			wantMsg:    "multiple step types",
 		},
+		{
+			name: "valid exec with files",
+			yaml: `id: test
+steps:
+  - description: Run with config
+    exec:
+      command: cat /tmp/config.yaml
+      files:
+        /tmp/config.yaml: "key: value"
+    expect: "outputs config"
+`,
+			wantErrors: 0,
+			wantWarns:  0,
+		},
+		{
+			name: "exec files relative path",
+			yaml: `id: test
+steps:
+  - description: Bad file path
+    exec:
+      command: echo hello
+      files:
+        relative/path.txt: "content"
+    expect: "ok"
+`,
+			wantErrors: 1,
+			wantMsg:    "must be absolute",
+		},
+		{
+			name: "exec files var ref in content",
+			yaml: `id: test
+setup:
+  - description: Get token
+    request:
+      method: POST
+      path: /login
+    capture:
+      - name: token
+        jsonpath: $.token
+steps:
+  - description: Write config with token
+    exec:
+      command: cat /tmp/config
+      files:
+        /tmp/config: "auth: {token}"
+    expect: "ok"
+`,
+			wantErrors: 0,
+			wantWarns:  0,
+		},
+		{
+			name: "exec files var ref in path key",
+			yaml: `id: test
+setup:
+  - description: Get dir
+    request:
+      method: GET
+      path: /setup
+    capture:
+      - name: base_dir
+        jsonpath: $.dir
+steps:
+  - description: Write to dynamic path
+    exec:
+      command: echo done
+      files:
+        /{base_dir}/config.yaml: "key: value"
+    expect: "ok"
+`,
+			wantErrors: 0,
+			wantWarns:  0,
+		},
+		{
+			name: "exec files uncaptured var ref in content",
+			yaml: `id: test
+steps:
+  - description: Write file with missing var
+    exec:
+      command: echo done
+      files:
+        /tmp/config.yaml: "auth: {missing_token}"
+    expect: "ok"
+`,
+			wantErrors: 0,
+			wantWarns:  1,
+			wantMsg:    "never captured",
+		},
+		{
+			name: "exec files not a mapping",
+			yaml: `id: test
+steps:
+  - description: Bad files field
+    exec:
+      command: echo hello
+      files: "not a mapping"
+    expect: "ok"
+`,
+			wantErrors: 1,
+			wantMsg:    "exec files must be a mapping",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/scenario/exec.go
+++ b/internal/scenario/exec.go
@@ -5,8 +5,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"os/exec"
+	"path"
+	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -20,6 +24,8 @@ const (
 	// Keep in sync with the constant of the same name in internal/container/docker.go.
 	defaultMaxOutputBytes = 10 << 20 // 10MB
 )
+
+var errWriteFileFailed = errors.New("write file failed")
 
 // containerSession provides command execution inside a running container.
 // Satisfied by *container.Session via structural typing.
@@ -48,10 +54,76 @@ func (e *ExecExecutor) Execute(ctx context.Context, step Step, vars map[string]s
 		return StepOutput{}, fmt.Errorf("exec: parse timeout: %w", err)
 	}
 
+	if err := e.writeFiles(ctx, step.Exec.Files, vars); err != nil {
+		return StepOutput{}, err
+	}
+
 	if e.Session != nil {
 		return e.runContainer(ctx, command, stdin, env, timeout)
 	}
 	return e.runLocal(ctx, command, stdin, env, timeout)
+}
+
+// writeFiles writes each file in the files map before command execution.
+// Paths and content may contain {variable} references which are substituted from vars.
+// Files are written in sorted key order for determinism.
+func (e *ExecExecutor) writeFiles(ctx context.Context, files map[string]string, vars map[string]string) error {
+	for _, rawPath := range slices.Sorted(maps.Keys(files)) {
+		filePath := substituteVars(rawPath, vars)
+		content := substituteVars(files[rawPath], vars)
+
+		var err error
+		if e.Session != nil {
+			// Use path.Dir (not filepath.Dir) for container paths: containers always use Linux
+			// path separators regardless of the host OS.
+			err = e.writeFileContainer(ctx, filePath, path.Dir(filePath), content)
+		} else {
+			err = writeFileLocal(filePath, filepath.Dir(filePath), content)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// writeFileContainer writes a single file inside the container using mkdir+cat.
+// Paths are shell-quoted to prevent command injection.
+func (e *ExecExecutor) writeFileContainer(ctx context.Context, filePath, dir, content string) error {
+	cmd := "mkdir -p " + shellQuote(dir) + " && cat > " + shellQuote(filePath)
+	result, err := e.Session.Exec(ctx, cmd, container.ExecOptions{
+		Stdin:          content,
+		Timeout:        defaultExecTimeout,
+		MaxOutputBytes: defaultMaxOutputBytes,
+	})
+	if err != nil {
+		return fmt.Errorf("write file %q: %w", filePath, err)
+	}
+	if result.ExitCode != 0 {
+		return fmt.Errorf("write file %q: %w", filePath, errWriteFileFailed)
+	}
+	return nil
+}
+
+// writeFileLocal writes a single file on the local filesystem.
+// Permissions 0o700/0o600 apply only to newly created directories and files; existing files
+// have their content replaced but their permissions are not modified by os.WriteFile.
+// This matches the behavior of local exec steps, which already have full host filesystem access.
+func writeFileLocal(filePath, dir, content string) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("write file %q: %w", filePath, err)
+	}
+	if err := os.WriteFile(filePath, []byte(content), 0o600); err != nil {
+		return fmt.Errorf("write file %q: %w", filePath, err)
+	}
+	return nil
+}
+
+// shellQuote returns a POSIX single-quoted string safe for interpolation in sh -c commands.
+// The '\” idiom ends the single-quoted string, appends a literal single-quote via \', then
+// reopens single-quoting — the standard POSIX escape since \' is not valid inside '...'.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
 func (e *ExecExecutor) runContainer(ctx context.Context, command, stdin string, env map[string]string, timeout time.Duration) (StepOutput, error) {

--- a/internal/scenario/exec_integration_test.go
+++ b/internal/scenario/exec_integration_test.go
@@ -127,3 +127,33 @@ func TestIntegrationExecContainerStdin(t *testing.T) {
 		t.Errorf("stdout = %q, want %q", out.CaptureSources[ExecSourceStdout], "stdin-input")
 	}
 }
+
+func TestIntegrationExecContainerFiles(t *testing.T) {
+	svc := getSharedService(t)
+	session, stop := startExecSession(t, svc)
+	defer stop()
+
+	execExec := &ExecExecutor{Session: session}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	step := Step{
+		Exec: &ExecRequest{
+			Command: "cat /tmp/octog-test/config.yaml",
+			Files: map[string]string{
+				"/tmp/octog-test/config.yaml": "key: integration-value",
+			},
+		},
+	}
+	out, err := execExec.Execute(ctx, step, nil)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if out.CaptureSources[ExecSourceExitCode] != "0" {
+		t.Errorf("exitcode = %q, want %q", out.CaptureSources[ExecSourceExitCode], "0")
+	}
+	if strings.TrimSpace(out.CaptureSources[ExecSourceStdout]) != "key: integration-value" {
+		t.Errorf("stdout = %q, want %q", out.CaptureSources[ExecSourceStdout], "key: integration-value")
+	}
+}

--- a/internal/scenario/exec_test.go
+++ b/internal/scenario/exec_test.go
@@ -3,6 +3,8 @@ package scenario
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -298,6 +300,159 @@ func TestExecContainerSessionPassesOptions(t *testing.T) {
 	}
 	if gotOpts.Timeout != 5*time.Second {
 		t.Errorf("expected timeout 5s, got %v", gotOpts.Timeout)
+	}
+}
+
+func TestExecExecutorFilesLocal(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "hello.txt")
+
+	executor := &ExecExecutor{}
+	step := Step{
+		Exec: &ExecRequest{
+			Command: "cat " + filePath,
+			Files:   map[string]string{filePath: "file content"},
+		},
+	}
+
+	output, err := executor.Execute(context.Background(), step, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(output.CaptureSources[ExecSourceStdout], "file content") {
+		t.Errorf("expected file content in stdout, got: %s", output.CaptureSources[ExecSourceStdout])
+	}
+
+	// Verify the file has the expected permissions.
+	info, err := os.Stat(filePath)
+	if err != nil {
+		t.Fatalf("stat file: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("expected file mode 0600, got %o", info.Mode().Perm())
+	}
+}
+
+func TestExecExecutorFilesLocalVarSubstitution(t *testing.T) {
+	dir := t.TempDir()
+
+	executor := &ExecExecutor{}
+	vars := map[string]string{
+		"dir":  dir,
+		"name": "world",
+	}
+	step := Step{
+		Exec: &ExecRequest{
+			Command: "cat {dir}/greeting.txt",
+			Files:   map[string]string{"{dir}/greeting.txt": "hello {name}"},
+		},
+	}
+
+	output, err := executor.Execute(context.Background(), step, vars)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(output.CaptureSources[ExecSourceStdout], "hello world") {
+		t.Errorf("expected substituted content in stdout, got: %s", output.CaptureSources[ExecSourceStdout])
+	}
+}
+
+func TestExecExecutorFilesContainer(t *testing.T) {
+	type call struct {
+		command string
+		stdin   string
+	}
+	var calls []call
+
+	session := &mockContainerSession{
+		execFn: func(_ context.Context, command string, opts container.ExecOptions) (container.ExecResult, error) {
+			calls = append(calls, call{command: command, stdin: opts.Stdin})
+			return container.ExecResult{ExitCode: 0, Stdout: "ok"}, nil
+		},
+	}
+
+	executor := &ExecExecutor{Session: session}
+	step := Step{
+		Exec: &ExecRequest{
+			Command: "echo done",
+			Files:   map[string]string{"/tmp/config.yaml": "key: value"},
+		},
+	}
+
+	_, err := executor.Execute(context.Background(), step, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Expect 2 calls: one for the file write, one for the command.
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 exec calls, got %d", len(calls))
+	}
+	// First call should be the mkdir+cat command.
+	if !strings.Contains(calls[0].command, "mkdir -p") || !strings.Contains(calls[0].command, "cat >") {
+		t.Errorf("expected mkdir+cat command, got: %s", calls[0].command)
+	}
+	if calls[0].stdin != "key: value" {
+		t.Errorf("expected stdin 'key: value', got %q", calls[0].stdin)
+	}
+	// Second call is the actual command.
+	if calls[1].command != "echo done" {
+		t.Errorf("expected command 'echo done', got %q", calls[1].command)
+	}
+}
+
+func TestExecExecutorFilesContainerWriteError(t *testing.T) {
+	callCount := 0
+	session := &mockContainerSession{
+		execFn: func(_ context.Context, _ string, _ container.ExecOptions) (container.ExecResult, error) {
+			callCount++
+			// File write fails with non-zero exit code.
+			return container.ExecResult{ExitCode: 1}, nil
+		},
+	}
+
+	executor := &ExecExecutor{Session: session}
+	step := Step{
+		Exec: &ExecRequest{
+			Command: "echo done",
+			Files:   map[string]string{"/tmp/config.yaml": "content"},
+		},
+	}
+
+	_, err := executor.Execute(context.Background(), step, nil)
+	if err == nil {
+		t.Fatal("expected error from failed file write")
+	}
+	if !errors.Is(err, errWriteFileFailed) {
+		t.Errorf("expected errWriteFileFailed, got: %v", err)
+	}
+	// Command must not have been executed.
+	if callCount != 1 {
+		t.Errorf("expected 1 exec call (file write only), got %d", callCount)
+	}
+}
+
+func TestExecExecutorFilesEmpty(t *testing.T) {
+	executor := &ExecExecutor{}
+
+	// nil files map — no-op.
+	step := Step{Exec: &ExecRequest{Command: "echo hi"}}
+	output, err := executor.Execute(context.Background(), step, nil)
+	if err != nil {
+		t.Fatalf("nil files: unexpected error: %v", err)
+	}
+	if output.CaptureSources[ExecSourceExitCode] != "0" {
+		t.Errorf("nil files: expected exit code 0, got %s", output.CaptureSources[ExecSourceExitCode])
+	}
+
+	// Empty files map — no-op.
+	step.Exec.Files = map[string]string{}
+	output, err = executor.Execute(context.Background(), step, nil)
+	if err != nil {
+		t.Fatalf("empty files: unexpected error: %v", err)
+	}
+	if output.CaptureSources[ExecSourceExitCode] != "0" {
+		t.Errorf("empty files: expected exit code 0, got %s", output.CaptureSources[ExecSourceExitCode])
 	}
 }
 

--- a/internal/scenario/types.go
+++ b/internal/scenario/types.go
@@ -107,6 +107,7 @@ type ExecRequest struct {
 	Stdin   string            `yaml:"stdin"`
 	Env     map[string]string `yaml:"env"`
 	Timeout string            `yaml:"timeout"`
+	Files   map[string]string `yaml:"files"` // absolute path → content; written before command execution
 }
 
 // BrowserRequest describes a browser automation action.

--- a/schemas/scenario.json
+++ b/schemas/scenario.json
@@ -140,6 +140,11 @@
           "type": "string",
           "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)+$",
           "description": "Command timeout as a Go duration (e.g. '30s', '5m', '100ms'). Default: 30s."
+        },
+        "files": {
+          "type": "object",
+          "additionalProperties": { "type": "string" },
+          "description": "Map of absolute file path to content. Written before command execution. Both paths and contents may contain {variable} references."
         }
       }
     },


### PR DESCRIPTION
Closes #55

## Changes

1. **`internal/scenario/types.go`** — Add `Files map[string]string \`yaml:"files"\`` to `ExecRequest`.

2. **`internal/scenario/exec.go`** — Add `writeFiles` helper called before `runContainer`/`runLocal`:
   - Apply `substituteVars()` to both keys (paths) and values (content).
   - Sort keys with `slices.Sorted(maps.Keys(...))`.
   - Container mode: use existing `e.Session.Exec()` with `[]string{"sh", "-c", "mkdir -p \"$1\" && cat > \"$2\"", "_", dir, path}` and content as stdin.
   - Local mode: `os.MkdirAll(dir, 0o700)` + `os.WriteFile(path, content, 0o600)`.
   - Add sentinel `var errWriteFileFailed = errors.New("write file failed")`.
   - No changes to `containerSession` interface.

3. **`internal/lint/scenario.go`** — Extend `lintExec()`:
   - Validate `files` is a mapping node.
   - Each key must be absolute (starts with `/`) — error if not.
   - Apply `checkVarRefs()` to each value for variable reference validation.
   - Apply `checkVarRefs()` to each key as well (paths may contain vars).

4. **`schemas/scenario.json`** — Add `"files"` property to `exec_request`:
   ```json
   "files": {
     "type": "object",
     "additionalProperties": { "type": "string" },
     "description": "Map of absolute file path to content. Written before command execution. Both paths and contents may contain {variable} references."
   }
   ```

## Review Findings
- Errors: 0
- Warnings: 2
- Nits: 5
- Assessment: **PASS** — The warnings are both edge-case concerns rather than bugs. The code is well-structured: proper error wrapping with sentinel errors, shell injection prevention via `shellQuote`, deterministic file ordering, thorough test coverage (local, container, error, empty, var substitution, lint), and correct context propagation. The feature is a clean, minimal addition to the exec step type.
