### PR TITLE
feat(scenario): WebSocket step type

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ Minimize — stdlib first. Allowed exceptions:
 - `github.com/jhump/protoreflect/v2` — dynamic gRPC via server reflection (no compiled protos)
 - `go.opentelemetry.io/otel` + related packages — OpenTelemetry tracing (spans for LLM calls,
   container ops, attractor loop)
+- `github.com/coder/websocket` — WebSocket client for scenario ws steps (context-native, pure Go)
 
 ## Design Invariants
 

--- a/cmd/octog/main.go
+++ b/cmd/octog/main.go
@@ -319,7 +319,12 @@ func runAttractorLoop(ctx context.Context, logger *slog.Logger, llmClient llm.Cl
 
 	instrumentedLLM := observability.NewTracingLLMClient(llmClient, tp)
 	instrumentedContainer := observability.NewTracingContainerManager(containerMgr, tp)
-	validateFn := buildValidateFn(scenarios, instrumentedLLM, logger, p.JudgeModel, sessionGetter, caps.NeedsBrowser, grpcTargetGetter)
+	validateFn := buildValidateFn(scenarios, instrumentedLLM, p.JudgeModel, executorOpts{
+		logger:        logger,
+		sessionGetter: sessionGetter,
+		needsBrowser:  caps.NeedsBrowser,
+		needsWS:       caps.NeedsWS,
+	}, grpcTargetGetter)
 	instrumentedValidate := observability.WrapValidateFn(validateFn, tp)
 
 	att := attractor.New(instrumentedLLM, instrumentedContainer, logger, tp)
@@ -373,6 +378,9 @@ func detectStepCaps(caps *attractor.ScenarioCapabilities, step scenario.Step) {
 		caps.NeedsBrowser = true
 	case "grpc":
 		caps.NeedsGRPC = true
+	case "ws":
+		caps.NeedsHTTP = true
+		caps.NeedsWS = true
 	}
 }
 
@@ -494,7 +502,14 @@ func validateCmd(ctx context.Context, logger *slog.Logger, args []string) error 
 	if caps.NeedsGRPC && *grpcTarget == "" {
 		logger.Warn("scenarios contain gRPC steps but --grpc-target is not set; gRPC steps will fail")
 	}
-	agg, err := runAndScore(ctx, scenarios, *target, clients.client, logger, *judgeModel, func() *container.Session { return nil }, caps.NeedsBrowser, *grpcTarget)
+	agg, err := runAndScore(ctx, scenarios, executorOpts{
+		targetURL:     *target,
+		logger:        logger,
+		sessionGetter: func() *container.Session { return nil },
+		needsBrowser:  caps.NeedsBrowser,
+		needsWS:       caps.NeedsWS,
+		grpcTarget:    *grpcTarget,
+	}, clients.client, *judgeModel)
 	if err != nil {
 		return fmt.Errorf("validate: %w", err)
 	}
@@ -785,6 +800,7 @@ type executorOpts struct {
 	logger        *slog.Logger
 	sessionGetter func() *container.Session
 	needsBrowser  bool
+	needsWS       bool
 	grpcTarget    string
 }
 
@@ -806,6 +822,11 @@ func buildExecutors(opts executorOpts) (map[string]scenario.StepExecutor, func()
 		executors["grpc"] = grpcExec
 		closers = append(closers, grpcExec.Close)
 	}
+	if opts.needsWS {
+		wsExec := &scenario.WSExecutor{BaseURL: opts.targetURL, Logger: opts.logger}
+		executors["ws"] = wsExec
+		closers = append(closers, wsExec.Close)
+	}
 	cleanup := func() {
 		for _, fn := range closers {
 			fn()
@@ -814,7 +835,7 @@ func buildExecutors(opts executorOpts) (map[string]scenario.StepExecutor, func()
 	return executors, cleanup
 }
 
-func runAndScore(ctx context.Context, scenarios []scenario.Scenario, targetURL string, llmClient llm.Client, logger *slog.Logger, judgeModel string, sessionGetter func() *container.Session, needsBrowser bool, grpcTarget string) (scenario.AggregateResult, error) {
+func runAndScore(ctx context.Context, scenarios []scenario.Scenario, opts executorOpts, llmClient llm.Client, judgeModel string) (scenario.AggregateResult, error) {
 	type indexedResult struct {
 		index int
 		ss    scenario.ScoredScenario
@@ -831,16 +852,10 @@ func runAndScore(ctx context.Context, scenarios []scenario.Scenario, targetURL s
 	for i, sc := range scenarios {
 		g.Go(func() error {
 			// Each goroutine gets its own Runner (independent variable capture state) and Judge.
-			executors, cleanup := buildExecutors(executorOpts{
-				targetURL:     targetURL,
-				logger:        logger,
-				sessionGetter: sessionGetter,
-				needsBrowser:  needsBrowser,
-				grpcTarget:    grpcTarget,
-			})
+			executors, cleanup := buildExecutors(opts)
 			defer cleanup()
-			runner := scenario.NewRunner(executors, logger)
-			judge := scenario.NewJudge(llmClient, judgeModel, logger)
+			runner := scenario.NewRunner(executors, opts.logger)
+			judge := scenario.NewJudge(llmClient, judgeModel, opts.logger)
 
 			result, err := runner.Run(gctx, sc)
 			if err != nil {
@@ -853,7 +868,7 @@ func runAndScore(ctx context.Context, scenarios []scenario.Scenario, targetURL s
 				if sc.Weight != nil {
 					weight = *sc.Weight
 				}
-				logger.Warn("scenario setup failed", "scenario", sc.ID, "error", err)
+				opts.logger.Warn("scenario setup failed", "scenario", sc.ID, "error", err)
 				mu.Lock()
 				results = append(results, indexedResult{index: i, ss: scenario.ScoredScenario{
 					ScenarioID: sc.ID,
@@ -890,9 +905,12 @@ func runAndScore(ctx context.Context, scenarios []scenario.Scenario, targetURL s
 	return scenario.Aggregate(scored), nil
 }
 
-func buildValidateFn(scenarios []scenario.Scenario, llmClient llm.Client, logger *slog.Logger, judgeModel string, sessionGetter func() *container.Session, needsBrowser bool, grpcTargetGetter func() string) attractor.ValidateFn {
+func buildValidateFn(scenarios []scenario.Scenario, llmClient llm.Client, judgeModel string, baseOpts executorOpts, grpcTargetGetter func() string) attractor.ValidateFn {
 	return func(ctx context.Context, url string) (float64, []string, float64, error) {
-		agg, err := runAndScore(ctx, scenarios, url, llmClient, logger, judgeModel, sessionGetter, needsBrowser, grpcTargetGetter())
+		opts := baseOpts
+		opts.targetURL = url
+		opts.grpcTarget = grpcTargetGetter()
+		agg, err := runAndScore(ctx, scenarios, opts, llmClient, judgeModel)
 		if err != nil {
 			return 0, nil, 0, err
 		}

--- a/cmd/octog/main_test.go
+++ b/cmd/octog/main_test.go
@@ -84,7 +84,11 @@ func TestRunAndScore(t *testing.T) {
 		},
 	}
 
-	agg, err := runAndScore(context.Background(), scenarios, srv.URL, mock, testLogger(), "claude-haiku-4-5-20251001", func() *container.Session { return nil }, false, "")
+	agg, err := runAndScore(context.Background(), scenarios, executorOpts{
+		targetURL:     srv.URL,
+		logger:        testLogger(),
+		sessionGetter: func() *container.Session { return nil },
+	}, mock, "claude-haiku-4-5-20251001")
 	if err != nil {
 		t.Fatalf("runAndScore: %v", err)
 	}
@@ -132,7 +136,11 @@ func TestRunAndScoreSetupFailure(t *testing.T) {
 
 	mock := &mockLLMClient{}
 	// Use unreachable address to deterministically cause connection errors.
-	agg, err := runAndScore(context.Background(), scenarios, "http://127.0.0.1:1", mock, testLogger(), "claude-haiku-4-5-20251001", func() *container.Session { return nil }, false, "")
+	agg, err := runAndScore(context.Background(), scenarios, executorOpts{
+		targetURL:     "http://127.0.0.1:1",
+		logger:        testLogger(),
+		sessionGetter: func() *container.Session { return nil },
+	}, mock, "claude-haiku-4-5-20251001")
 	if err != nil {
 		t.Fatalf("runAndScore: %v", err)
 	}
@@ -304,7 +312,11 @@ func TestValidateThreshold(t *testing.T) {
 				},
 			}
 
-			agg, err := runAndScore(context.Background(), scenarios, srv.URL, mock, testLogger(), "claude-haiku-4-5-20251001", func() *container.Session { return nil }, false, "")
+			agg, err := runAndScore(context.Background(), scenarios, executorOpts{
+				targetURL:     srv.URL,
+				logger:        testLogger(),
+				sessionGetter: func() *container.Session { return nil },
+			}, mock, "claude-haiku-4-5-20251001")
 			if err != nil {
 				t.Fatalf("runAndScore: %v", err)
 			}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -140,7 +140,7 @@ import (
 )
 
 var (
-	errUnknownStepType = errors.New("step has no recognized step type (need request, exec, browser, or grpc)")
+	errUnknownStepType = errors.New("step has no recognized step type (need request, exec, browser, grpc, or ws)")
 	errNoCapture       = errors.New("capture has neither source nor jsonpath")
 )
 
@@ -198,6 +198,7 @@ type Step struct {
 	Exec        *ExecRequest    `yaml:"exec"`
 	Browser     *BrowserRequest `yaml:"browser"`
 	GRPC        *GRPCRequest    `yaml:"grpc"`
+	WS          *WSRequest      `yaml:"ws"`
 	Retry       *Retry          `yaml:"retry"`
 	Expect      string          `yaml:"expect"` // natural language, judged by LLM
 	Capture     []Capture       `yaml:"capture"`
@@ -210,7 +211,7 @@ type Retry struct {
 	Timeout  string `yaml:"timeout"`  // overall timeout cap (optional)
 }
 
-// StepType returns the step type key: "request", "exec", "browser", "grpc", or "" if unknown.
+// StepType returns the step type key: "request", "exec", "browser", "grpc", "ws", or "" if unknown.
 func (s Step) StepType() string {
 	if s.Request != nil {
 		return "request"
@@ -223,6 +224,9 @@ func (s Step) StepType() string {
 	}
 	if s.GRPC != nil {
 		return "grpc"
+	}
+	if s.WS != nil {
+		return "ws"
 	}
 	return ""
 }
@@ -285,6 +289,20 @@ type Capture struct {
 	Name     string `yaml:"name"`     // variable name
 	JSONPath string `yaml:"jsonpath"` // path into response body
 	Source   string `yaml:"source"`   // capture source (e.g. "stdout", "stderr", "exitcode")
+}
+
+// WSRequest describes a WebSocket step: connect, send, and/or receive.
+type WSRequest struct {
+	URL     string     `yaml:"url"`     // path to connect (e.g. /ws/bids); omit to reuse existing conn
+	ID      string     `yaml:"id"`      // connection ID for multi-conn scenarios; defaults to "default"
+	Send    string     `yaml:"send"`    // message to send (optional)
+	Receive *WSReceive `yaml:"receive"` // receive config (optional; nil = send-only)
+}
+
+// WSReceive configures how to receive WebSocket messages.
+type WSReceive struct {
+	Timeout string `yaml:"timeout"` // receive timeout (default: 5s)
+	Count   int    `yaml:"count"`   // number of messages to collect (default: 1)
 }
 ```
 

--- a/examples/auction-house/scenarios/01-create-auction.yaml
+++ b/examples/auction-house/scenarios/01-create-auction.yaml
@@ -1,0 +1,23 @@
+id: create-auction
+description: Create an auction item and verify it is returned with the starting price
+type: api
+steps:
+  - description: Create a new auction item
+    request:
+      method: POST
+      path: /auctions
+      headers:
+        Content-Type: application/json
+      body:
+        item: "Vintage Clock"
+        starting_price: 100
+    expect: The response includes the auction ID, item name, and starting price
+    capture:
+      - name: auction_id
+        jsonpath: $.id
+
+  - description: Retrieve the auction and verify initial state
+    request:
+      method: GET
+      path: /auctions/{auction_id}
+    expect: The auction shows the correct item and current price equal to the starting price

--- a/examples/auction-house/scenarios/02-websocket-bid-broadcast.yaml
+++ b/examples/auction-house/scenarios/02-websocket-bid-broadcast.yaml
@@ -1,0 +1,40 @@
+id: websocket-bid-broadcast
+description: Place a bid via HTTP and verify the WebSocket subscriber receives the broadcast
+type: api
+weight: 2
+setup:
+  - description: Create an auction to bid on
+    request:
+      method: POST
+      path: /auctions
+      headers:
+        Content-Type: application/json
+      body:
+        item: "Antique Vase"
+        starting_price: 50
+    capture:
+      - name: auction_id
+        jsonpath: $.id
+
+steps:
+  - description: Subscribe to live bid updates via WebSocket
+    ws:
+      url: /ws/auctions/{auction_id}
+    expect: WebSocket connection is established successfully
+
+  - description: Place a winning bid via HTTP
+    request:
+      method: POST
+      path: /auctions/{auction_id}/bid
+      headers:
+        Content-Type: application/json
+      body:
+        amount: 75
+    expect: The bid is accepted with amount 75
+
+  - description: Receive the bid broadcast on the WebSocket connection
+    ws:
+      receive:
+        timeout: 5s
+        count: 1
+    expect: The WebSocket message contains a bid event with amount 75

--- a/examples/auction-house/scenarios/03-bid-rejected.yaml
+++ b/examples/auction-house/scenarios/03-bid-rejected.yaml
@@ -1,0 +1,33 @@
+id: bid-rejected
+description: Bids at or below the current price are rejected
+type: api
+setup:
+  - description: Create an auction with a starting price
+    request:
+      method: POST
+      path: /auctions
+      headers:
+        Content-Type: application/json
+      body:
+        item: "Rare Coin"
+        starting_price: 200
+    capture:
+      - name: auction_id
+        jsonpath: $.id
+
+steps:
+  - description: Place a bid equal to the starting price (should be rejected)
+    request:
+      method: POST
+      path: /auctions/{auction_id}/bid
+      headers:
+        Content-Type: application/json
+      body:
+        amount: 200
+    expect: The bid is rejected because it is not strictly greater than the current price
+
+  - description: Verify the current price has not changed
+    request:
+      method: GET
+      path: /auctions/{auction_id}
+    expect: The auction current price is still 200 (the starting price)

--- a/examples/auction-house/spec.md
+++ b/examples/auction-house/spec.md
@@ -1,0 +1,38 @@
+# Auction House
+
+A real-time auction platform where users place bids via WebSocket and the current highest bid is
+broadcast to all connected clients.
+
+## Overview
+
+The auction house service manages items up for auction. Clients connect via WebSocket to receive
+live bid updates. Bids can also be placed via HTTP. The service broadcasts the new highest bid to
+all WebSocket subscribers whenever a bid is accepted.
+
+## Endpoints
+
+### HTTP
+
+- `POST /auctions` — Create a new auction item. Request body:
+  `{"item": "string", "starting_price": number}` Response:
+  `{"id": "string", "item": "string", "current_price": number}`
+
+- `GET /auctions/{id}` — Get the current state of an auction. Response:
+  `{"id": "string", "item": "string", "current_price": number, "bids": number}`
+
+- `POST /auctions/{id}/bid` — Place a bid on an auction item. Request body: `{"amount": number}`
+  Response 200: `{"accepted": true, "amount": number}` if the bid is higher than the current price.
+  Response 400: `{"accepted": false, "reason": "string"}` if the bid is too low.
+
+### WebSocket
+
+- `GET /ws/auctions/{id}` — Subscribe to live bid updates for an auction. The server sends a JSON
+  message whenever a new highest bid is accepted:
+  `{"event": "bid", "amount": number, "bids": number}`
+
+## Behavior
+
+- When a bid is accepted via HTTP, the service immediately broadcasts a `bid` event to all WebSocket
+  subscribers for that auction.
+- Bids must be strictly greater than the current price to be accepted.
+- The service must handle multiple concurrent WebSocket connections per auction.

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/anthropics/anthropic-sdk-go v1.26.0
 	github.com/chromedp/cdproto v0.0.0-20250724212937-08a3db8b4327
 	github.com/chromedp/chromedp v0.14.2
+	github.com/coder/websocket v1.8.14
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/docker/go-connections v0.6.0
 	github.com/jhump/protoreflect/v2 v2.0.0-beta.2

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/chromedp/chromedp v0.14.2 h1:r3b/WtwM50RsBZHMUm9fsNhhzRStTHrKdr2zmwbZ
 github.com/chromedp/chromedp v0.14.2/go.mod h1:rHzAv60xDE7VNy/MYtTUrYreSc0ujt2O1/C3bzctYBo=
 github.com/chromedp/sysutil v1.1.0 h1:PUFNv5EcprjqXZD9nJb9b/c9ibAbxiYo4exNWZyipwM=
 github.com/chromedp/sysutil v1.1.0/go.mod h1:WiThHUdltqCNKGc4gaU50XgYjwjYIhKWoHGPTUfWTJ8=
+github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
+github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
 github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=

--- a/internal/attractor/attractor.go
+++ b/internal/attractor/attractor.go
@@ -82,6 +82,7 @@ type ScenarioCapabilities struct {
 	NeedsExec    bool // any scenario has exec steps
 	NeedsBrowser bool // any scenario has browser steps
 	NeedsGRPC    bool // any scenario has grpc steps
+	NeedsWS      bool // any scenario has ws steps (modifier on NeedsHTTP — same port 8080)
 }
 
 // ContainerManager is the interface to Docker container operations.

--- a/internal/attractor/prompts.go
+++ b/internal/attractor/prompts.go
@@ -143,9 +143,19 @@ func buildCapabilitySuffix(caps ScenarioCapabilities, language string) string {
 	return b.String()
 }
 
+// wsSupplementaryInstruction returns the extra line appended when WS is needed.
+// It is injected after the primary HTTP instruction, not as a new switch case.
+func wsSupplementaryInstruction(caps ScenarioCapabilities) string {
+	if caps.NeedsWS {
+		return "\n- The HTTP server must also handle WebSocket upgrade requests on port 8080"
+	}
+	return ""
+}
+
 // capabilityInstructions returns the core instruction text for the given capabilities.
 func capabilityInstructions(caps ScenarioCapabilities) string {
 	needsHTTP := caps.NeedsHTTP || caps.NeedsBrowser
+	ws := wsSupplementaryInstruction(caps)
 	switch {
 	case needsHTTP && caps.NeedsGRPC:
 		return `- Generate ALL files needed for a working application that serves both HTTP and gRPC
@@ -153,7 +163,7 @@ func capabilityInstructions(caps ScenarioCapabilities) string {
 - The application MUST listen on port 8080 for HTTP requests
 - The application MUST serve gRPC on port 50051
 - The gRPC server MUST enable server reflection so clients can discover services at runtime
-- Include .proto files defining the service and compile them as part of the Docker build`
+- Include .proto files defining the service and compile them as part of the Docker build` + ws
 	case caps.NeedsExec && caps.NeedsGRPC:
 		return `- Generate ALL files needed for a working application that serves both as a CLI tool and a gRPC server
 - Include a Dockerfile that builds the application and installs it in PATH
@@ -171,14 +181,14 @@ func capabilityInstructions(caps ScenarioCapabilities) string {
 		return `- Generate ALL files needed for a working application that serves both as an HTTP server AND a command-line tool
 - Include a Dockerfile that builds the application and installs it in PATH
 - The application MUST listen on port 8080 for HTTP requests
-- The application must also support command-line invocation for CLI operations`
+- The application must also support command-line invocation for CLI operations` + ws
 	case caps.NeedsExec:
 		return `- Generate ALL files needed for a working command-line application
 - Include a Dockerfile that builds the application. The built binary must be available in PATH inside the container.
 - Do NOT start a server or listen on any port. The application is a CLI tool invoked via command-line arguments.`
 	default:
 		return `- Generate ALL files needed for a working application
-- Include a Dockerfile that builds and runs the application on port 8080`
+- Include a Dockerfile that builds and runs the application on port 8080` + ws
 	}
 }
 

--- a/internal/lint/rules.go
+++ b/internal/lint/rules.go
@@ -138,8 +138,8 @@ var ScenarioRules = []Rule{
 	{
 		ID:          "SC015",
 		Level:       Error,
-		Summary:     "step must have exactly one step type (request, exec, browser, or grpc)",
-		MsgContains: "exactly one of request, exec, browser, or grpc is required",
+		Summary:     "step must have exactly one step type (request, exec, browser, grpc, or ws)",
+		MsgContains: "exactly one of request, exec, browser, grpc, or ws is required",
 	},
 	{
 		ID:          "SC016",
@@ -245,7 +245,7 @@ var ScenarioRules = []Rule{
 		ID:          "SC032",
 		Level:       Error,
 		Summary:     "step must not have multiple step types",
-		MsgContains: "step has multiple step types; exactly one of request, exec, browser, or grpc is required",
+		MsgContains: "step has multiple step types; exactly one of request, exec, browser, grpc, or ws is required",
 	},
 	{
 		ID:          "SC033",
@@ -386,5 +386,30 @@ var ScenarioRules = []Rule{
 		Level:       Error,
 		Summary:     "grpc receive timeout must be a valid Go duration",
 		MsgContains: "grpc receive timeout",
+	},
+	// WebSocket step rules.
+	{
+		ID:          "SC060",
+		Level:       Error,
+		Summary:     "ws must be a YAML mapping",
+		MsgContains: "ws must be a mapping",
+	},
+	{
+		ID:          "SC061",
+		Level:       Warning,
+		Summary:     "ws step missing url; no prior connection may exist",
+		MsgContains: "ws step missing url",
+	},
+	{
+		ID:          "SC062",
+		Level:       Error,
+		Summary:     "ws receive timeout must be a valid Go duration",
+		MsgContains: "ws receive timeout: invalid duration",
+	},
+	{
+		ID:          "SC063",
+		Level:       Error,
+		Summary:     "ws receive count must be a positive integer",
+		MsgContains: "ws receive count must be a positive integer",
 	},
 }

--- a/internal/lint/rules_test.go
+++ b/internal/lint/rules_test.go
@@ -161,6 +161,14 @@ func TestScenarioRulesSync(t *testing.T) {
 		"id: test\nsteps:\n  - description: d\n    grpc:\n      service: svc.Service\n      method: Stream\n      stream:\n        messages: notarray\n    expect: ok\n",
 		// SC055: grpc receive timeout invalid
 		"id: test\nsteps:\n  - description: d\n    grpc:\n      service: svc.Service\n      method: Watch\n      stream:\n        receive:\n          timeout: badvalue\n    expect: ok\n",
+		// SC060: ws not a mapping
+		"id: test\nsteps:\n  - description: d\n    ws: notamapping\n    expect: ok\n",
+		// SC061: ws missing url
+		"id: test\nsteps:\n  - description: d\n    ws:\n      receive:\n        count: 1\n    expect: ok\n",
+		// SC062: ws receive timeout invalid
+		"id: test\nsteps:\n  - description: d\n    ws:\n      url: /ws\n      receive:\n        timeout: badvalue\n    expect: ok\n",
+		// SC063: ws receive count zero
+		"id: test\nsteps:\n  - description: d\n    ws:\n      url: /ws\n      receive:\n        count: 0\n    expect: ok\n",
 	}
 
 	// Rules that can only be triggered by dir-level checks.

--- a/internal/lint/scenario.go
+++ b/internal/lint/scenario.go
@@ -317,8 +317,9 @@ func lintStepType(path string, node *yaml.Node, fields map[string]*fieldEntry, c
 	execFE, hasExec := fields["exec"]
 	browserFE, hasBrowser := fields["browser"]
 	grpcFE, hasGRPC := fields["grpc"]
+	wsFE, hasWS := fields["ws"]
 
-	typeCount := countTrue(hasReq, hasExec, hasBrowser, hasGRPC)
+	typeCount := countTrue(hasReq, hasExec, hasBrowser, hasGRPC, hasWS)
 
 	switch {
 	case typeCount > 1:
@@ -326,14 +327,14 @@ func lintStepType(path string, node *yaml.Node, fields map[string]*fieldEntry, c
 			File:    path,
 			Line:    node.Line,
 			Level:   Error,
-			Message: "step has multiple step types; exactly one of request, exec, browser, or grpc is required",
+			Message: "step has multiple step types; exactly one of request, exec, browser, grpc, or ws is required",
 		}}
 	case typeCount == 0:
 		return "", []Diagnostic{{
 			File:    path,
 			Line:    node.Line,
 			Level:   Error,
-			Message: "step missing step type: exactly one of request, exec, browser, or grpc is required",
+			Message: "step missing step type: exactly one of request, exec, browser, grpc, or ws is required",
 		}}
 	case hasReq:
 		return "request", lintRequest(path, reqFE.value, cs)
@@ -343,6 +344,8 @@ func lintStepType(path string, node *yaml.Node, fields map[string]*fieldEntry, c
 		return "browser", lintBrowser(path, browserFE.value, cs)
 	case hasGRPC:
 		return "grpc", lintGRPC(path, grpcFE.value, cs)
+	case hasWS:
+		return "ws", lintWS(path, wsFE.value, cs)
 	default:
 		return "", nil
 	}
@@ -899,6 +902,85 @@ func lintCaptureName(path string, fields map[string]*fieldEntry, capNode *yaml.N
 		})
 	}
 	cs.add(name, path, nameFE.value.Line)
+	return diags
+}
+
+func lintWS(path string, node *yaml.Node, cs *captureSet) []Diagnostic {
+	if node.Kind != yaml.MappingNode {
+		return []Diagnostic{{
+			File:    path,
+			Line:    node.Line,
+			Level:   Error,
+			Message: "ws must be a mapping",
+		}}
+	}
+
+	var diags []Diagnostic
+	fields := nodeFields(node)
+
+	// Warn if url is absent (executor will fail at runtime if no prior connection exists).
+	urlFE, hasURL := fields["url"]
+	if !hasURL || urlFE.value.Value == "" {
+		diags = append(diags, Diagnostic{
+			File:    path,
+			Line:    node.Line,
+			Level:   Warning,
+			Message: "ws step missing url; connection must have been established in a prior step",
+		})
+	} else {
+		diags = append(diags, checkVarRefs(extractVarRefs(urlFE.value.Value), cs, path, urlFE.value.Line)...)
+	}
+
+	// Check var refs in id and send.
+	if idFE, ok := fields["id"]; ok {
+		diags = append(diags, checkVarRefs(extractVarRefs(idFE.value.Value), cs, path, idFE.value.Line)...)
+	}
+	if sendFE, ok := fields["send"]; ok {
+		diags = append(diags, checkVarRefs(extractVarRefs(sendFE.value.Value), cs, path, sendFE.value.Line)...)
+	}
+
+	// Check receive (optional mapping with timeout and count).
+	if recvFE, ok := fields["receive"]; ok && recvFE.value.Kind == yaml.MappingNode {
+		diags = append(diags, lintWSReceive(path, recvFE.value)...)
+	}
+
+	return diags
+}
+
+func lintWSReceive(path string, node *yaml.Node) []Diagnostic {
+	recvFields := nodeFields(node)
+	var diags []Diagnostic
+
+	if timeoutFE, ok := recvFields["timeout"]; ok && timeoutFE.value.Value != "" {
+		if _, err := time.ParseDuration(timeoutFE.value.Value); err != nil {
+			diags = append(diags, Diagnostic{
+				File:    path,
+				Line:    timeoutFE.value.Line,
+				Level:   Error,
+				Message: fmt.Sprintf("ws receive timeout: invalid duration %q", timeoutFE.value.Value),
+			})
+		}
+	}
+
+	if countFE, ok := recvFields["count"]; ok {
+		var c int
+		if err := countFE.value.Decode(&c); err != nil {
+			diags = append(diags, Diagnostic{
+				File:    path,
+				Line:    countFE.value.Line,
+				Level:   Error,
+				Message: fmt.Sprintf("ws receive count must be a positive integer: %s", err),
+			})
+		} else if c <= 0 {
+			diags = append(diags, Diagnostic{
+				File:    path,
+				Line:    countFE.value.Line,
+				Level:   Error,
+				Message: "ws receive count must be a positive integer",
+			})
+		}
+	}
+
 	return diags
 }
 

--- a/internal/lint/scenario_test.go
+++ b/internal/lint/scenario_test.go
@@ -86,7 +86,7 @@ steps:
     expect: "ok"
 `,
 			wantErrors: 1,
-			wantMsg:    "exactly one of request, exec, browser, or grpc is required",
+			wantMsg:    "exactly one of request, exec, browser, grpc, or ws is required",
 		},
 		{
 			name: "missing method",
@@ -1264,6 +1264,94 @@ steps:
 `,
 			wantErrors: 1,
 			wantMsg:    "grpc receive timeout",
+		},
+		{
+			name: "valid ws step with url",
+			yaml: `id: test
+steps:
+  - description: Connect and receive
+    ws:
+      url: /ws/bids
+      receive:
+        timeout: 5s
+        count: 1
+    expect: "Received a bid"
+`,
+			wantErrors: 0,
+			wantWarns:  0,
+		},
+		{
+			name: "ws step missing url warns",
+			yaml: `id: test
+steps:
+  - description: Receive only
+    ws:
+      receive:
+        timeout: 1s
+        count: 1
+    expect: "ok"
+`,
+			wantErrors: 0,
+			wantWarns:  1,
+			wantMsg:    "ws step missing url",
+		},
+		{
+			name: "ws receive timeout invalid",
+			yaml: `id: test
+steps:
+  - description: Connect
+    ws:
+      url: /ws
+      receive:
+        timeout: notaduration
+        count: 1
+    expect: "ok"
+`,
+			wantErrors: 1,
+			wantMsg:    "ws receive timeout: invalid duration",
+		},
+		{
+			name: "ws receive count zero errors",
+			yaml: `id: test
+steps:
+  - description: Connect
+    ws:
+      url: /ws
+      receive:
+        count: 0
+    expect: "ok"
+`,
+			wantErrors: 1,
+			wantMsg:    "ws receive count must be a positive integer",
+		},
+		{
+			name: "ws step with multiple types errors",
+			yaml: `id: test
+steps:
+  - description: Both ws and request
+    ws:
+      url: /ws
+    request:
+      method: GET
+      path: /items
+    expect: "ok"
+`,
+			wantErrors: 1,
+			wantMsg:    "step has multiple step types",
+		},
+		{
+			name: "ws send with undefined var ref warns",
+			yaml: `id: test
+steps:
+  - description: Connect
+    ws:
+      url: /ws
+      send: "{missing_var}"
+    expect: "ok"
+`,
+			wantErrors: 0,
+			wantWarns:  1,
+			wantMsg:    "missing_var",
 		},
 	}
 

--- a/internal/scenario/types.go
+++ b/internal/scenario/types.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	errUnknownStepType = errors.New("step has no recognized step type (need request, exec, browser, or grpc)")
+	errUnknownStepType = errors.New("step has no recognized step type (need request, exec, browser, grpc, or ws)")
 	errNoCapture       = errors.New("capture has neither source nor jsonpath")
 )
 
@@ -64,6 +64,7 @@ type Step struct {
 	Exec        *ExecRequest    `yaml:"exec"`
 	Browser     *BrowserRequest `yaml:"browser"`
 	GRPC        *GRPCRequest    `yaml:"grpc"`
+	WS          *WSRequest      `yaml:"ws"`
 	Retry       *Retry          `yaml:"retry"`
 	Expect      string          `yaml:"expect"` // natural language, judged by LLM
 	Capture     []Capture       `yaml:"capture"`
@@ -76,7 +77,7 @@ type Retry struct {
 	Timeout  string `yaml:"timeout"`  // overall timeout cap (optional)
 }
 
-// StepType returns the step type key: "request", "exec", "browser", "grpc", or "" if unknown.
+// StepType returns the step type key: "request", "exec", "browser", "grpc", "ws", or "" if unknown.
 func (s Step) StepType() string {
 	if s.Request != nil {
 		return "request"
@@ -89,6 +90,9 @@ func (s Step) StepType() string {
 	}
 	if s.GRPC != nil {
 		return "grpc"
+	}
+	if s.WS != nil {
+		return "ws"
 	}
 	return ""
 }
@@ -151,4 +155,18 @@ type Capture struct {
 	Name     string `yaml:"name"`     // variable name
 	JSONPath string `yaml:"jsonpath"` // path into response body
 	Source   string `yaml:"source"`   // capture source (e.g. "stdout", "stderr", "exitcode")
+}
+
+// WSRequest describes a WebSocket step: connect, send, and/or receive.
+type WSRequest struct {
+	URL     string     `yaml:"url"`     // path to connect (e.g. /ws/bids); omit to reuse existing conn
+	ID      string     `yaml:"id"`      // connection ID for multi-conn scenarios; defaults to "default"
+	Send    string     `yaml:"send"`    // message to send (optional)
+	Receive *WSReceive `yaml:"receive"` // receive config (optional; nil = send-only)
+}
+
+// WSReceive configures how to receive WebSocket messages.
+type WSReceive struct {
+	Timeout string `yaml:"timeout"` // receive timeout (default: 5s)
+	Count   int    `yaml:"count"`   // number of messages to collect (default: 1)
 }

--- a/internal/scenario/ws.go
+++ b/internal/scenario/ws.go
@@ -1,0 +1,278 @@
+package scenario
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+const (
+	defaultWSReceiveTimeout = 5 * time.Second
+	defaultWSConnID         = "default"
+	wsMessageBufferCap      = 1000
+)
+
+var errWSConnNotFound = errors.New("ws connection not found for id")
+
+// WSExecutor executes WebSocket steps.
+// Each WSExecutor instance is per-scenario (not shared across concurrent runs).
+// WSExecutor is NOT safe for concurrent use from multiple goroutines.
+type WSExecutor struct {
+	BaseURL string
+	Logger  *slog.Logger
+
+	conns map[string]*wsConn
+}
+
+// wsConn wraps a WebSocket connection with a buffered message reader goroutine.
+type wsConn struct {
+	conn     *websocket.Conn
+	mu       sync.Mutex
+	messages []string
+	readErr  error
+	cancel   context.CancelFunc
+	done     chan struct{}
+}
+
+// ValidCaptureSources returns nil — WS steps use JSONPath on CaptureBody only.
+func (e *WSExecutor) ValidCaptureSources() []string { return nil }
+
+// Execute dispatches a WebSocket step: connect (if needed), send, and/or receive.
+func (e *WSExecutor) Execute(ctx context.Context, step Step, vars map[string]string) (StepOutput, error) {
+	req := substituteWSRequest(*step.WS, vars)
+
+	connID := req.ID
+	if connID == "" {
+		connID = defaultWSConnID
+	}
+
+	// Connect if URL is provided.
+	if req.URL != "" {
+		wsURL, err := e.buildWSURL(req.URL)
+		if err != nil {
+			return StepOutput{}, fmt.Errorf("ws: build url: %w", err)
+		}
+		if err := e.connect(ctx, connID, wsURL); err != nil {
+			return StepOutput{}, fmt.Errorf("ws: connect %s: %w", wsURL, err)
+		}
+	}
+
+	conn, ok := e.getConn(connID)
+	if !ok {
+		return StepOutput{}, fmt.Errorf("ws: connection %q: %w", connID, errWSConnNotFound)
+	}
+
+	// Send message if provided.
+	if req.Send != "" {
+		if err := conn.conn.Write(ctx, websocket.MessageText, []byte(req.Send)); err != nil {
+			return StepOutput{}, fmt.Errorf("ws: write to %q: %w", connID, err)
+		}
+	}
+
+	// Receive messages if configured.
+	if req.Receive == nil {
+		// No receive configured — send-only or connect-only step.
+		var observed string
+		if req.Send != "" {
+			observed = fmt.Sprintf("WebSocket [%s]: sent %d bytes", connID, len(req.Send))
+		} else {
+			observed = fmt.Sprintf("WebSocket [%s]: connected", connID)
+		}
+		return StepOutput{Observed: observed, CaptureBody: "null"}, nil
+	}
+
+	messages, err := e.receiveMessages(conn, req.Receive)
+	if err != nil {
+		return StepOutput{}, fmt.Errorf("ws: receive from %q: %w", connID, err)
+	}
+
+	return buildWSOutput(connID, req.Send, messages), nil
+}
+
+// Close closes all WebSocket connections and cancels background readers.
+// Safe to call on a never-initialized executor.
+func (e *WSExecutor) Close() {
+	for _, c := range e.conns {
+		// Close the connection first so the background reader's conn.Read() returns,
+		// then cancel and wait. Canceling first races with conn.Close().
+		_ = c.conn.Close(websocket.StatusNormalClosure, "")
+		c.cancel()
+		<-c.done
+	}
+	e.conns = nil
+}
+
+func (e *WSExecutor) connect(ctx context.Context, connID, wsURL string) error {
+	if e.conns == nil {
+		e.conns = make(map[string]*wsConn)
+	}
+
+	// Close existing connection with same ID before reconnecting.
+	if existing, ok := e.conns[connID]; ok {
+		// Close the connection first so the background reader returns cleanly.
+		_ = existing.conn.Close(websocket.StatusNormalClosure, "")
+		existing.cancel()
+		<-existing.done
+		delete(e.conns, connID)
+	}
+
+	conn, _, err := websocket.Dial(ctx, wsURL, nil) //nolint:bodyclose // websocket.Dial manages its own response body
+	if err != nil {
+		return fmt.Errorf("dial %s: %w", wsURL, err)
+	}
+	conn.SetReadLimit(10 * 1024 * 1024) // 10 MB
+
+	bgCtx, cancel := context.WithCancel(context.Background()) //nolint:containedctx // background reader needs a long-lived context
+	c := &wsConn{
+		conn:   conn,
+		cancel: cancel,
+		done:   make(chan struct{}),
+	}
+	e.conns[connID] = c
+
+	go func() {
+		defer close(c.done)
+		for {
+			_, data, err := conn.Read(bgCtx)
+			if err != nil {
+				c.mu.Lock()
+				c.readErr = err
+				c.mu.Unlock()
+				return
+			}
+			c.mu.Lock()
+			if len(c.messages) < wsMessageBufferCap {
+				c.messages = append(c.messages, string(data))
+			}
+			c.mu.Unlock()
+		}
+	}()
+
+	return nil
+}
+
+func (e *WSExecutor) getConn(connID string) (*wsConn, bool) {
+	if e.conns == nil {
+		return nil, false
+	}
+	c, ok := e.conns[connID]
+	return c, ok
+}
+
+func (e *WSExecutor) receiveMessages(c *wsConn, recv *WSReceive) ([]string, error) {
+	recvTimeout, err := parseStepTimeout(recv.Timeout, defaultWSReceiveTimeout)
+	if err != nil {
+		e.Logger.Warn("ws: invalid receive timeout, using default",
+			"timeout", recv.Timeout,
+			"default", defaultWSReceiveTimeout,
+			"error", err,
+		)
+		recvTimeout = defaultWSReceiveTimeout
+	}
+
+	count := recv.Count
+	if count <= 0 {
+		count = 1
+	}
+
+	timer := time.NewTimer(recvTimeout)
+	defer timer.Stop()
+
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	messages := make([]string, 0, count)
+loop:
+	for len(messages) < count {
+		c.mu.Lock()
+		available := len(c.messages)
+		if available > 0 {
+			take := min(available, count-len(messages))
+			taken := make([]string, take)
+			copy(taken, c.messages[:take])
+			messages = append(messages, taken...)
+			c.messages = c.messages[take:]
+		}
+		readErr := c.readErr
+		c.mu.Unlock()
+
+		if len(messages) >= count {
+			break
+		}
+		if readErr != nil {
+			break
+		}
+
+		select {
+		case <-timer.C:
+			break loop
+		case <-ticker.C:
+		}
+	}
+
+	return messages, nil
+}
+
+func (e *WSExecutor) buildWSURL(path string) (string, error) {
+	base := e.BaseURL
+
+	// Convert http → ws, https → wss. Match longer prefix first.
+	base = strings.NewReplacer("https://", "wss://", "http://", "ws://").Replace(base)
+
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", fmt.Errorf("parse base url: %w", err)
+	}
+
+	u.Path = path
+	return u.String(), nil
+}
+
+func substituteWSRequest(req WSRequest, vars map[string]string) WSRequest {
+	return WSRequest{
+		URL:     substituteVars(req.URL, vars),
+		ID:      substituteVars(req.ID, vars),
+		Send:    substituteVars(req.Send, vars),
+		Receive: req.Receive,
+	}
+}
+
+func buildWSOutput(connID, sent string, messages []string) StepOutput {
+	var observed strings.Builder
+	fmt.Fprintf(&observed, "WebSocket [%s]", connID)
+	if sent != "" {
+		fmt.Fprintf(&observed, ": sent %d bytes", len(sent))
+	}
+	fmt.Fprintf(&observed, ": received %d messages", len(messages))
+	if len(messages) > 0 {
+		fmt.Fprintf(&observed, "\n%s", strings.Join(messages, "\n"))
+	}
+
+	// CaptureBody: JSON array of messages for JSONPath extraction.
+	// When there are no messages (e.g. timeout with 0 received), return "[]" rather than
+	// leaving captureBody empty, which would break downstream JSONPath extraction.
+	// Note: individual messages are used as-is; if a message is not valid JSON, the
+	// resulting array form ("[msg1,msg2]") will be malformed JSON — this matches the
+	// single-message case where the raw string is also passed through unchanged.
+	var captureBody string
+	switch {
+	case len(messages) == 0:
+		captureBody = "[]"
+	case len(messages) == 1:
+		captureBody = messages[0]
+	default:
+		captureBody = "[" + strings.Join(messages, ",") + "]"
+	}
+
+	return StepOutput{
+		Observed:    observed.String(),
+		CaptureBody: captureBody,
+	}
+}

--- a/internal/scenario/ws_test.go
+++ b/internal/scenario/ws_test.go
@@ -1,0 +1,400 @@
+package scenario
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/coder/websocket"
+)
+
+// newWSServer creates a test WebSocket server that:
+// - echoes incoming messages prefixed with "echo: "
+// - sends an initial message "hello" on connect if sendHello is true
+func newWSServer(t *testing.T, sendHello bool) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+		if err != nil {
+			return
+		}
+		defer conn.CloseNow()
+
+		if sendHello {
+			if err := conn.Write(r.Context(), websocket.MessageText, []byte(`{"msg":"hello"}`)); err != nil {
+				return
+			}
+		}
+
+		for {
+			_, data, err := conn.Read(r.Context())
+			if err != nil {
+				return
+			}
+			if err := conn.Write(r.Context(), websocket.MessageText, append([]byte("echo: "), data...)); err != nil {
+				return
+			}
+		}
+	}))
+	return srv
+}
+
+func newWSExecutor(baseURL string) *WSExecutor {
+	return &WSExecutor{
+		BaseURL: baseURL,
+		Logger:  newTestLogger(),
+	}
+}
+
+func TestWSExecutorConnectSendReceive(t *testing.T) {
+	srv := newWSServer(t, false)
+	defer srv.Close()
+
+	exec := newWSExecutor(srv.URL)
+	defer exec.Close()
+
+	step := Step{WS: &WSRequest{
+		URL:     "/ws",
+		Send:    "ping",
+		Receive: &WSReceive{Timeout: "1s", Count: 1},
+	}}
+
+	out, err := exec.Execute(context.Background(), step, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(out.Observed, "received 1 messages") {
+		t.Errorf("unexpected observed: %s", out.Observed)
+	}
+	if !strings.Contains(out.CaptureBody, "echo: ping") {
+		t.Errorf("unexpected capture body: %s", out.CaptureBody)
+	}
+}
+
+func TestWSExecutorConnectionReuseByID(t *testing.T) {
+	srv := newWSServer(t, false)
+	defer srv.Close()
+
+	exec := newWSExecutor(srv.URL)
+	defer exec.Close()
+
+	// Step 1: connect and send.
+	step1 := Step{WS: &WSRequest{
+		URL:  "/ws",
+		ID:   "myconn",
+		Send: "first",
+	}}
+	if _, err := exec.Execute(context.Background(), step1, nil); err != nil {
+		t.Fatalf("step1 error: %v", err)
+	}
+
+	// Step 2: reuse connection by ID (no URL), receive echo from first send.
+	step2 := Step{WS: &WSRequest{
+		ID:      "myconn",
+		Receive: &WSReceive{Timeout: "1s", Count: 1},
+	}}
+	out, err := exec.Execute(context.Background(), step2, nil)
+	if err != nil {
+		t.Fatalf("step2 error: %v", err)
+	}
+	if !strings.Contains(out.CaptureBody, "echo: first") {
+		t.Errorf("expected echo, got: %s", out.CaptureBody)
+	}
+}
+
+func TestWSExecutorMultipleConnections(t *testing.T) {
+	srv := newWSServer(t, false)
+	defer srv.Close()
+
+	exec := newWSExecutor(srv.URL)
+	defer exec.Close()
+
+	stepA := Step{WS: &WSRequest{
+		URL:     "/ws",
+		ID:      "conn-a",
+		Send:    "msg-a",
+		Receive: &WSReceive{Timeout: "1s", Count: 1},
+	}}
+	stepB := Step{WS: &WSRequest{
+		URL:     "/ws",
+		ID:      "conn-b",
+		Send:    "msg-b",
+		Receive: &WSReceive{Timeout: "1s", Count: 1},
+	}}
+
+	outA, err := exec.Execute(context.Background(), stepA, nil)
+	if err != nil {
+		t.Fatalf("stepA error: %v", err)
+	}
+	outB, err := exec.Execute(context.Background(), stepB, nil)
+	if err != nil {
+		t.Fatalf("stepB error: %v", err)
+	}
+
+	if !strings.Contains(outA.CaptureBody, "msg-a") {
+		t.Errorf("conn-a expected msg-a echo, got: %s", outA.CaptureBody)
+	}
+	if !strings.Contains(outB.CaptureBody, "msg-b") {
+		t.Errorf("conn-b expected msg-b echo, got: %s", outB.CaptureBody)
+	}
+}
+
+func TestWSExecutorReceiveTimeout(t *testing.T) {
+	// Server that never sends anything.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+		if err != nil {
+			return
+		}
+		defer conn.CloseNow()
+		// Block until context done (test ends).
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	exec := newWSExecutor(srv.URL)
+	defer exec.Close()
+
+	step := Step{WS: &WSRequest{
+		URL:     "/ws",
+		Receive: &WSReceive{Timeout: "50ms", Count: 3},
+	}}
+
+	out, err := exec.Execute(context.Background(), step, nil)
+	if err != nil {
+		t.Fatalf("unexpected error (timeout should return empty, not error): %v", err)
+	}
+
+	// Should return empty messages (timeout, not error).
+	if strings.Contains(out.Observed, "received 3") {
+		t.Errorf("should not have received 3 messages: %s", out.Observed)
+	}
+}
+
+func TestWSExecutorReceiveCount(t *testing.T) {
+	// Server that sends N messages on connect.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+		if err != nil {
+			return
+		}
+		defer conn.CloseNow()
+		for i := range 5 {
+			msg := strings.Repeat("x", i+1)
+			if err := conn.Write(r.Context(), websocket.MessageText, []byte(msg)); err != nil {
+				return
+			}
+		}
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	exec := newWSExecutor(srv.URL)
+	defer exec.Close()
+
+	step := Step{WS: &WSRequest{
+		URL:     "/ws",
+		Receive: &WSReceive{Timeout: "1s", Count: 3},
+	}}
+
+	out, err := exec.Execute(context.Background(), step, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out.Observed, "received 3 messages") {
+		t.Errorf("expected 3 messages, got: %s", out.Observed)
+	}
+}
+
+func TestWSExecutorSendOnly(t *testing.T) {
+	srv := newWSServer(t, false)
+	defer srv.Close()
+
+	exec := newWSExecutor(srv.URL)
+	defer exec.Close()
+
+	step := Step{WS: &WSRequest{
+		URL:  "/ws",
+		Send: "fire-and-forget",
+		// No Receive.
+	}}
+
+	out, err := exec.Execute(context.Background(), step, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out.Observed, "sent") {
+		t.Errorf("expected sent in observed: %s", out.Observed)
+	}
+}
+
+func TestWSExecutorReceiveOnly(t *testing.T) {
+	srv := newWSServer(t, true) // sends "hello" on connect
+	defer srv.Close()
+
+	exec := newWSExecutor(srv.URL)
+	defer exec.Close()
+
+	// Connect first.
+	step1 := Step{WS: &WSRequest{URL: "/ws"}}
+	if _, err := exec.Execute(context.Background(), step1, nil); err != nil {
+		t.Fatalf("connect error: %v", err)
+	}
+
+	// Receive the buffered "hello".
+	step2 := Step{WS: &WSRequest{
+		Receive: &WSReceive{Timeout: "1s", Count: 1},
+	}}
+	out, err := exec.Execute(context.Background(), step2, nil)
+	if err != nil {
+		t.Fatalf("receive error: %v", err)
+	}
+	if !strings.Contains(out.CaptureBody, "hello") {
+		t.Errorf("expected hello in capture body: %s", out.CaptureBody)
+	}
+}
+
+func TestWSExecutorVariableSubstitution(t *testing.T) {
+	srv := newWSServer(t, false)
+	defer srv.Close()
+
+	exec := newWSExecutor(srv.URL)
+	defer exec.Close()
+
+	step := Step{WS: &WSRequest{
+		URL:     "{path}",
+		ID:      "{conn_id}",
+		Send:    "hello {name}",
+		Receive: &WSReceive{Timeout: "1s", Count: 1},
+	}}
+
+	vars := map[string]string{
+		"path":    "/ws",
+		"conn_id": "my-conn",
+		"name":    "world",
+	}
+
+	out, err := exec.Execute(context.Background(), step, vars)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out.CaptureBody, "hello world") {
+		t.Errorf("expected substituted message, got: %s", out.CaptureBody)
+	}
+}
+
+func TestWSExecutorCloseCleanup(t *testing.T) {
+	srv := newWSServer(t, false)
+	defer srv.Close()
+
+	exec := newWSExecutor(srv.URL)
+
+	// Open two connections.
+	for _, id := range []string{"c1", "c2"} {
+		step := Step{WS: &WSRequest{URL: "/ws", ID: id}}
+		if _, err := exec.Execute(context.Background(), step, nil); err != nil {
+			t.Fatalf("connect %s: %v", id, err)
+		}
+	}
+
+	// Close should not panic and should clean up.
+	exec.Close()
+
+	if exec.conns != nil {
+		t.Error("expected conns to be nil after Close")
+	}
+}
+
+func TestWSExecutorInvalidURL(t *testing.T) {
+	exec := newWSExecutor("http://localhost:0")
+	defer exec.Close()
+
+	step := Step{WS: &WSRequest{
+		URL: "/ws",
+	}}
+
+	_, err := exec.Execute(context.Background(), step, nil)
+	if err == nil {
+		t.Fatal("expected error for unreachable server")
+	}
+}
+
+func TestWSExecutorDefaultID(t *testing.T) {
+	srv := newWSServer(t, false)
+	defer srv.Close()
+
+	exec := newWSExecutor(srv.URL)
+	defer exec.Close()
+
+	// Connect without specifying ID.
+	step := Step{WS: &WSRequest{URL: "/ws", Send: "test"}}
+	if _, err := exec.Execute(context.Background(), step, nil); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+
+	// Should be accessible via "default" ID.
+	if _, ok := exec.conns[defaultWSConnID]; !ok {
+		t.Errorf("expected conn with id %q", defaultWSConnID)
+	}
+}
+
+func TestWSExecutorNoConnectionNoURL(t *testing.T) {
+	exec := newWSExecutor("http://localhost:8080")
+	defer exec.Close()
+
+	step := Step{WS: &WSRequest{
+		Send:    "hello",
+		Receive: &WSReceive{Timeout: "100ms", Count: 1},
+	}}
+
+	_, err := exec.Execute(context.Background(), step, nil)
+	if err == nil {
+		t.Fatal("expected error when no connection and no URL")
+	}
+	if !errors.Is(err, errWSConnNotFound) {
+		t.Errorf("expected errWSConnNotFound, got: %v", err)
+	}
+}
+
+func TestWSRunnerDispatch(t *testing.T) {
+	srv := newWSServer(t, false)
+	defer srv.Close()
+
+	wsExec := newWSExecutor(srv.URL)
+	runner := NewRunner(map[string]StepExecutor{
+		"ws": wsExec,
+	}, newTestLogger())
+
+	sc := Scenario{
+		ID: "ws-dispatch",
+		Steps: []Step{
+			{
+				Description: "Send and receive",
+				WS: &WSRequest{
+					URL:     "/ws",
+					Send:    "hi",
+					Receive: &WSReceive{Timeout: "1s", Count: 1},
+				},
+				Expect: "Echo received",
+			},
+		},
+	}
+
+	result, err := runner.Run(context.Background(), sc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Steps) != 1 {
+		t.Fatalf("got %d steps, want 1", len(result.Steps))
+	}
+	if result.Steps[0].Err != nil {
+		t.Fatalf("step error: %v", result.Steps[0].Err)
+	}
+	if result.Steps[0].StepType != "ws" {
+		t.Errorf("step type = %q, want ws", result.Steps[0].StepType)
+	}
+}

--- a/schemas/scenario-format.md
+++ b/schemas/scenario-format.md
@@ -21,7 +21,7 @@ Violations prevent the scenario from being loaded.
 | SC012 | steps must be a non-empty array |
 | SC013 | setup must be an array |
 | SC014 | each step must be a YAML mapping |
-| SC015 | step must have exactly one step type (request, exec, browser, or grpc) |
+| SC015 | step must have exactly one step type (request, exec, browser, grpc, or ws) |
 | SC018 | request must be a YAML mapping |
 | SC019 | request must have a method |
 | SC020 | HTTP method must be valid — Allowed: GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS. |
@@ -57,6 +57,9 @@ Violations prevent the scenario from being loaded.
 | SC053 | grpc timeout must be a valid Go duration |
 | SC054 | grpc stream messages must be an array |
 | SC055 | grpc receive timeout must be a valid Go duration |
+| SC060 | ws must be a YAML mapping |
+| SC062 | ws receive timeout must be a valid Go duration |
+| SC063 | ws receive count must be a positive integer |
 
 ## SHOULD (Warnings)
 
@@ -72,6 +75,7 @@ Violations are reported but do not block loading.
 | SC027 | capture name shadows an earlier capture |
 | SC030 | variable reference has no matching capture — Variables use {name} syntax and must be captured in a prior step. |
 | SC048 | browser assert should have assertion fields |
+| SC061 | ws step missing url; no prior connection may exist |
 
 ## Notes
 

--- a/schemas/scenario.json
+++ b/schemas/scenario.json
@@ -50,7 +50,8 @@
         { "required": ["request"] },
         { "required": ["exec"] },
         { "required": ["browser"] },
-        { "required": ["grpc"] }
+        { "required": ["grpc"] },
+        { "required": ["ws"] }
       ],
       "properties": {
         "description": {
@@ -61,6 +62,7 @@
         "exec": { "$ref": "#/$defs/exec_request" },
         "browser": { "$ref": "#/$defs/browser_request" },
         "grpc": { "$ref": "#/$defs/grpc_request" },
+        "ws": { "$ref": "#/$defs/ws_request" },
         "expect": {
           "type": "string",
           "description": "Natural-language expectation judged by the LLM."
@@ -237,6 +239,43 @@
         "id": {
           "type": "string",
           "description": "Reference a named background stream to collect buffered messages."
+        }
+      }
+    },
+    "ws_request": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "WebSocket path to connect (e.g. /ws/bids). Omit to reuse an existing connection. May contain {variable} references."
+        },
+        "id": {
+          "type": "string",
+          "description": "Connection ID for multi-connection scenarios. Defaults to 'default'. May contain {variable} references."
+        },
+        "send": {
+          "type": "string",
+          "description": "Message to send. May contain {variable} references."
+        },
+        "receive": {
+          "$ref": "#/$defs/ws_receive",
+          "description": "Receive configuration. Omit for send-only steps."
+        }
+      }
+    },
+    "ws_receive": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "timeout": {
+          "type": "string",
+          "description": "Receive timeout as a Go duration (e.g. '5s', '1m'). Default: 5s."
+        },
+        "count": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Number of messages to collect. Default: 1."
         }
       }
     },


### PR DESCRIPTION
Closes #36

## Changes

**1. `internal/scenario/types.go`**
- Add `WS *WSRequest` field to `Step` with `yaml:"ws"` tag
- Add `WSRequest` struct: `URL string` (path, like `/ws/bids`), `ID string`, `Send string`, `Receive *WSReceive`
- Add `WSReceive` struct: `Timeout string`, `Count int`
- Update `StepType()` to return `"ws"` when `s.WS != nil`
- Update `errUnknownStepType` to include `ws`

**2. `internal/scenario/ws.go`** — New file: WebSocket executor
- `WSExecutor` struct: `BaseURL string`, `Logger *slog.Logger`, `conns map[string]*wsConn`
- `wsConn`: wraps `*websocket.Conn`, `sync.Mutex`, `messages []string` buffer, background reader goroutine
- `Execute(ctx, step, vars)`: connect (if URL + new ID), send, receive with timeout/count
- `Close()`: close all connections
- `ValidCaptureSources() → nil`
- Default ID: `"default"` when not specified
- Background reader per connection (same pattern as gRPC `backgroundStream`)
- Buffer cap: 1000 messages to prevent unbounded growth

**3. `internal/attractor/attractor.go`**
- Add `NeedsWS bool` to `ScenarioCapabilities` (lightweight modifier, not a full capability axis)

**4. `internal/attractor/prompts.go`**
- When `NeedsWS` is true, append a line to the HTTP instructions: "The HTTP server must also handle WebSocket upgrade requests on port 8080"
- Do NOT add WS as a new top-level switch case — keep it as a modifier on HTTP cases

**5. `cmd/octog/main.go`**
- `detectStepCaps`: `case "ws"` sets `caps.NeedsHTTP = true` AND `caps.NeedsWS = true`
- Add `needsWS bool` to `executorOpts`
- In `buildExecutors`: create `WSExecutor` when `opts.needsWS`, using `opts.targetURL` with `http→ws` scheme conversion; add `Close()` to closers
- Thread `needsWS` through `buildValidateFn` → `runAndScore` → `buildExecutors`

**6. `internal/lint/scenario.go`**
- Add `hasWS` to step type detection
- `lintWS(path, node, cs)`: validate mapping; warn if `url` absent; check var refs in `url`, `send`, `id`; validate `receive.timeout` as duration, `receive.count` as positive int
- Update step type list strings to include `ws`

**7. `schemas/scenario.json`**
- Add `ws` to step `oneOf`, properties, and `$defs`

**8. `examples/auction-house/spec.md`** — New example

**9. `examples/auction-house/scenarios/*.yaml`** — New example scenarios

**10. `go.mod` / `go.sum`** — `go get nhooyr.io/websocket`

## Review Findings
- Errors: 0
- Warnings: 4
- Nits: 4
- Assessment: **NEEDS CHANGES**

The most impactful fix is #2 (empty CaptureBody on timeout). A receive step that times out will produce `""` as CaptureBody, which will break any downstream JSONPath capture. The close ordering (#1) and growing positional-bool signature (#4) are worth addressing too.
