### PR TITLE
feat(attractor): per-scenario feedback with observed output

### DIFF
--- a/cmd/octog/main.go
+++ b/cmd/octog/main.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"golang.org/x/sync/errgroup"
 
@@ -35,9 +36,14 @@ import (
 )
 
 // stepPassThreshold is the per-step score below which a step is labeled FAIL
-// in validation output. This is purely cosmetic — the --threshold flag on
-// validateCmd controls the aggregate satisfaction gate.
+// in validation output and considered failing for detailed feedback. This is
+// purely cosmetic — the --threshold flag on validateCmd controls the aggregate
+// satisfaction gate.
 const stepPassThreshold = 80
+
+// maxObservedBytes is the maximum bytes of step observed output included in
+// detailed failure feedback. Longer output is truncated with a … suffix.
+const maxObservedBytes = 500
 
 var (
 	errSpecAndScenariosRequired   = errors.New("--spec and --scenarios are required")
@@ -914,8 +920,69 @@ func buildValidateFn(scenarios []scenario.Scenario, llmClient llm.Client, judgeM
 		if err != nil {
 			return 0, nil, 0, err
 		}
-		return agg.Satisfaction, agg.Failures, agg.TotalCostUSD, nil
+		return agg.Satisfaction, buildDetailedFailures(agg), agg.TotalCostUSD, nil
 	}
+}
+
+// buildDetailedFailures converts an AggregateResult into a slice of feedback strings
+// for the attractor loop. Passing scenarios produce a single summary line; failing
+// scenarios expand to include per-step detail with reasoning and observed output for
+// failing steps.
+func buildDetailedFailures(agg scenario.AggregateResult) []string {
+	out := make([]string, 0, len(agg.Scenarios))
+	for _, sc := range agg.Scenarios {
+		if sc.Score >= float64(stepPassThreshold) {
+			out = append(out, fmt.Sprintf("✓ %s (%.0f/100)", sc.ScenarioID, sc.Score))
+		} else {
+			out = append(out, formatFailedScenario(sc))
+		}
+	}
+	return out
+}
+
+// formatFailedScenario formats a failing scenario as a multi-line string with
+// per-step detail. Failing steps include reasoning and observed output; passing
+// steps within a failing scenario appear as a single-line summary.
+func formatFailedScenario(s scenario.ScoredScenario) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "✗ %s (%.0f/100)", s.ScenarioID, s.Score)
+	for _, step := range s.Steps {
+		if step.StepScore.Score >= stepPassThreshold {
+			fmt.Fprintf(&b, "\n  ✓ %s (%d/100)", step.StepResult.Description, step.StepScore.Score)
+			continue
+		}
+		fmt.Fprintf(&b, "\n  ✗ %s (%d/100)", step.StepResult.Description, step.StepScore.Score)
+		if step.StepScore.Reasoning != "" {
+			fmt.Fprintf(&b, "\n    Reasoning: %s", step.StepScore.Reasoning)
+		}
+		if step.StepResult.Observed != "" {
+			obs := step.StepResult.Observed
+			label := "Observed"
+			if len(obs) > maxObservedBytes {
+				obs = truncateObserved(obs, maxObservedBytes)
+				label = fmt.Sprintf("Observed (%dB)", maxObservedBytes)
+			}
+			fmt.Fprintf(&b, "\n    %s: %s", label, obs)
+		}
+	}
+	return b.String()
+}
+
+// truncateObserved truncates observed output to max bytes, removing any incomplete
+// UTF-8 rune at the cut point and appending a … suffix.
+func truncateObserved(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	truncated := s[:max]
+	for len(truncated) > 0 {
+		r, size := utf8.DecodeLastRuneInString(truncated)
+		if r != utf8.RuneError || size != 1 {
+			break
+		}
+		truncated = truncated[:len(truncated)-1]
+	}
+	return truncated + "…"
 }
 
 //nolint:gosec // G705 false positive: w is os.Stdout or test buffer, not an HTTP response

--- a/cmd/octog/main_test.go
+++ b/cmd/octog/main_test.go
@@ -1187,6 +1187,227 @@ func TestLoadGenesEmptyPath(t *testing.T) {
 	}
 }
 
+func TestBuildDetailedFailures(t *testing.T) {
+	tests := []struct {
+		name      string
+		agg       scenario.AggregateResult
+		wantLen   int
+		wantCheck func(t *testing.T, out []string)
+	}{
+		{
+			name:    "zero scenarios",
+			agg:     scenario.AggregateResult{},
+			wantLen: 0,
+		},
+		{
+			name: "all passing",
+			agg: scenario.AggregateResult{
+				Scenarios: []scenario.ScoredScenario{
+					{ScenarioID: "crud", Score: 95, Steps: []scenario.ScoredStep{
+						{StepScore: scenario.StepScore{Score: 95}, StepResult: scenario.StepResult{Description: "list items"}},
+					}},
+					{ScenarioID: "auth", Score: 100, Steps: []scenario.ScoredStep{
+						{StepScore: scenario.StepScore{Score: 100}, StepResult: scenario.StepResult{Description: "login"}},
+					}},
+				},
+			},
+			wantLen: 2,
+			wantCheck: func(t *testing.T, out []string) {
+				t.Helper()
+				if !strings.Contains(out[0], "✓") || !strings.Contains(out[0], "crud") {
+					t.Errorf("passing scenario should start with ✓ and contain name, got %q", out[0])
+				}
+				if !strings.Contains(out[1], "✓") || !strings.Contains(out[1], "auth") {
+					t.Errorf("passing scenario should start with ✓ and contain name, got %q", out[1])
+				}
+				// Passing scenarios: no step detail
+				if strings.Contains(out[0], "list items") {
+					t.Error("passing scenario should not include step detail")
+				}
+			},
+		},
+		{
+			name: "all failing",
+			agg: scenario.AggregateResult{
+				Scenarios: []scenario.ScoredScenario{
+					{ScenarioID: "crud", Score: 30, Steps: []scenario.ScoredStep{
+						{StepScore: scenario.StepScore{Score: 90}, StepResult: scenario.StepResult{Description: "list items"}},
+						{StepScore: scenario.StepScore{Score: 20, Reasoning: "wrong status"}, StepResult: scenario.StepResult{Description: "delete item", Observed: "got 500"}},
+					}},
+				},
+			},
+			wantLen: 1,
+			wantCheck: func(t *testing.T, out []string) {
+				t.Helper()
+				if !strings.Contains(out[0], "✗") || !strings.Contains(out[0], "crud") {
+					t.Errorf("failing scenario should contain ✗ and name, got %q", out[0])
+				}
+				// Passing step in failing scenario: single-line summary
+				if !strings.Contains(out[0], "✓") || !strings.Contains(out[0], "list items") {
+					t.Errorf("passing step should appear as single-line summary, got %q", out[0])
+				}
+				// Failing step: expanded detail
+				if !strings.Contains(out[0], "delete item") {
+					t.Errorf("failing step should include description, got %q", out[0])
+				}
+				if !strings.Contains(out[0], "wrong status") {
+					t.Errorf("failing step should include reasoning, got %q", out[0])
+				}
+				if !strings.Contains(out[0], "got 500") {
+					t.Errorf("failing step should include observed, got %q", out[0])
+				}
+			},
+		},
+		{
+			name: "mixed passing and failing",
+			agg: scenario.AggregateResult{
+				Scenarios: []scenario.ScoredScenario{
+					{ScenarioID: "ok", Score: 85},
+					{ScenarioID: "bad", Score: 50, Steps: []scenario.ScoredStep{
+						{StepScore: scenario.StepScore{Score: 50, Reasoning: "timeout"}, StepResult: scenario.StepResult{Description: "check health"}},
+					}},
+				},
+			},
+			wantLen: 2,
+			wantCheck: func(t *testing.T, out []string) {
+				t.Helper()
+				if !strings.Contains(out[0], "✓ ok") {
+					t.Errorf("passing scenario should be ✓, got %q", out[0])
+				}
+				if !strings.Contains(out[1], "✗ bad") {
+					t.Errorf("failing scenario should be ✗, got %q", out[1])
+				}
+				if !strings.Contains(out[1], "timeout") {
+					t.Errorf("failing step reasoning should appear, got %q", out[1])
+				}
+			},
+		},
+		{
+			name: "observed truncation in failing step",
+			agg: scenario.AggregateResult{
+				Scenarios: []scenario.ScoredScenario{
+					{ScenarioID: "trunc", Score: 10, Steps: []scenario.ScoredStep{
+						{StepScore: scenario.StepScore{Score: 10}, StepResult: scenario.StepResult{
+							Description: "big output",
+							Observed:    strings.Repeat("x", maxObservedBytes+100),
+						}},
+					}},
+				},
+			},
+			wantLen: 1,
+			wantCheck: func(t *testing.T, out []string) {
+				t.Helper()
+				if !strings.Contains(out[0], "Observed (500B)") {
+					t.Errorf("truncated observed should use byte-count label, got %q", out[0])
+				}
+				if !strings.Contains(out[0], "…") {
+					t.Errorf("truncated observed should end with ellipsis, got %q", out[0])
+				}
+			},
+		},
+		{
+			name: "no observed when empty",
+			agg: scenario.AggregateResult{
+				Scenarios: []scenario.ScoredScenario{
+					{ScenarioID: "noobs", Score: 10, Steps: []scenario.ScoredStep{
+						{StepScore: scenario.StepScore{Score: 10, Reasoning: "missing"}, StepResult: scenario.StepResult{
+							Description: "check",
+							Observed:    "",
+						}},
+					}},
+				},
+			},
+			wantLen: 1,
+			wantCheck: func(t *testing.T, out []string) {
+				t.Helper()
+				if strings.Contains(out[0], "Observed") {
+					t.Errorf("empty observed should not appear in output, got %q", out[0])
+				}
+				if !strings.Contains(out[0], "missing") {
+					t.Errorf("reasoning should still appear, got %q", out[0])
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := buildDetailedFailures(tt.agg)
+			if len(out) != tt.wantLen {
+				t.Fatalf("len = %d, want %d; out = %v", len(out), tt.wantLen, out)
+			}
+			if tt.wantCheck != nil {
+				tt.wantCheck(t, out)
+			}
+		})
+	}
+}
+
+func TestTruncateObserved(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		max        int
+		wantSuffix string
+		wantLen    int // expected len of result, 0 = not checked
+		unchanged  bool
+	}{
+		{
+			name:      "empty string",
+			input:     "",
+			max:       500,
+			unchanged: true,
+		},
+		{
+			name:      "under limit",
+			input:     "short",
+			max:       500,
+			unchanged: true,
+		},
+		{
+			name:      "exact boundary",
+			input:     strings.Repeat("x", 500),
+			max:       500,
+			unchanged: true,
+		},
+		{
+			name:       "over limit",
+			input:      strings.Repeat("x", 600),
+			max:        500,
+			wantSuffix: "…",
+		},
+		{
+			name:       "multi-byte UTF-8 at boundary",
+			input:      strings.Repeat("x", 499) + "\u2603" + "extra", // snowman = 3 bytes
+			max:        500,
+			wantSuffix: "…",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncateObserved(tt.input, tt.max)
+			if tt.unchanged {
+				if got != tt.input {
+					t.Errorf("expected unchanged input, got %q", got)
+				}
+				return
+			}
+			if !strings.HasSuffix(got, tt.wantSuffix) {
+				t.Errorf("result should end with %q, got %q", tt.wantSuffix, got)
+			}
+			// Result before the suffix must be valid UTF-8.
+			body := strings.TrimSuffix(got, "…")
+			for i, r := range body {
+				if r == '\uFFFD' {
+					t.Errorf("invalid UTF-8 at position %d in truncated output", i)
+					break
+				}
+			}
+		})
+	}
+}
+
 func TestRunCmdInvalidThreshold(t *testing.T) {
 	logger := testLogger()
 	ctx := context.Background()

--- a/internal/attractor/prompts.go
+++ b/internal/attractor/prompts.go
@@ -21,7 +21,9 @@ const (
 
 const (
 	// maxFeedbackBytes is the maximum size of a single feedback entry before truncation.
-	maxFeedbackBytes = 4096
+	// Increased to 12288 to accommodate detailed per-step scenario output; larger prompts
+	// are a deliberate cost tradeoff for richer feedback that drives faster convergence.
+	maxFeedbackBytes = 12288
 	// maxFeedbackEntries is the number of recent feedback entries included in iteration prompts.
 	maxFeedbackEntries = 3
 )
@@ -350,9 +352,9 @@ func formatValidationFeedback(satisfaction float64, failures []string) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "Satisfaction score: %.1f/100\n", satisfaction)
 	if len(failures) > 0 {
-		b.WriteString("Failures:\n")
+		b.WriteString("Scenario results:\n")
 		for _, f := range failures {
-			fmt.Fprintf(&b, "- %s\n", f)
+			fmt.Fprintf(&b, "%s\n", f)
 		}
 	}
 	return b.String()

--- a/internal/attractor/prompts_test.go
+++ b/internal/attractor/prompts_test.go
@@ -55,7 +55,7 @@ func TestBuildMessagesIteration1(t *testing.T) {
 func TestBuildMessagesCategorizedHeaders(t *testing.T) {
 	history := []iterationFeedback{
 		{iteration: 1, kind: feedbackBuildError, message: "Docker build failed: syntax error"},
-		{iteration: 2, kind: feedbackValidation, message: "Satisfaction score: 40.0/100\nFailures:\n- missing endpoint"},
+		{iteration: 2, kind: feedbackValidation, message: "Satisfaction score: 40.0/100\nScenario results:\n✗ api (40/100)"},
 	}
 	msgs := buildMessages(3, history)
 	content := msgs[0].Content
@@ -142,11 +142,15 @@ func TestFormatValidationFeedback(t *testing.T) {
 	if !strings.Contains(result, "72.5/100") {
 		t.Error("should contain score")
 	}
-	if !strings.Contains(result, "Failures:") {
-		t.Error("should contain Failures header")
+	if !strings.Contains(result, "Scenario results:") {
+		t.Error("should contain Scenario results header")
 	}
 	if !strings.Contains(result, "missing GET /items") {
 		t.Error("should contain failure detail")
+	}
+	// Entries should not be prefixed with "- "
+	if strings.Contains(result, "- missing GET /items") {
+		t.Error("entries should not have '- ' prefix")
 	}
 }
 
@@ -155,8 +159,23 @@ func TestFormatValidationFeedbackNoFailures(t *testing.T) {
 	if !strings.Contains(result, "95.0/100") {
 		t.Error("should contain score")
 	}
-	if strings.Contains(result, "Failures:") {
-		t.Error("should not contain Failures header when there are no failures")
+	if strings.Contains(result, "Scenario results:") {
+		t.Error("should not contain Scenario results header when there are no failures")
+	}
+}
+
+func TestFormatValidationFeedbackMultiLine(t *testing.T) {
+	// Multi-line entries should pass through verbatim without any "- " prefix added.
+	entry := "✗ my-scenario (45/100)\n  ✗ check health (20/100)\n    Reasoning: timeout\n    Observed: got 500"
+	result := formatValidationFeedback(45.0, []string{entry})
+	if !strings.Contains(result, "Scenario results:") {
+		t.Error("should contain Scenario results header")
+	}
+	if !strings.Contains(result, entry) {
+		t.Errorf("multi-line entry should appear verbatim, got:\n%s", result)
+	}
+	if strings.Contains(result, "- ✗") {
+		t.Error("multi-line entry should not have '- ' prefix")
 	}
 }
 


### PR DESCRIPTION
Closes #102

## Changes

1. **`cmd/octog/main.go`** — Add `buildDetailedFailures()` + `truncateObserved()` + wire in
   - Add `const maxObservedBytes = 500`
   - Add `const stepPassThreshold = 80` (if not already defined)
   - Add `func buildDetailedFailures(agg scenario.AggregateResult) []string` — for passing scenarios: single-line `✓ name (score/100)`; for failing scenarios: `✗ name (score/100)` header, then all steps listed — failing steps get expanded detail (reasoning + observed), passing steps get single-line summary
   - Add `func formatFailedScenario(s scenario.ScoredScenario) string` — extracted helper to keep cognitive complexity under 20
   - Add `func truncateObserved(s string, max int) string` — UTF-8 safe truncation following `truncateFeedback` pattern
   - In `buildValidateFn`: replace `agg.Failures` with `buildDetailedFailures(agg)`

2. **`internal/attractor/prompts.go`** — Increase budget + update formatting
   - Change `maxFeedbackBytes = 4096` → `maxFeedbackBytes = 12288`
   - In `formatValidationFeedback`: change header `"Failures:\n"` → `"Scenario results:\n"`; change entry format from `"- %s\n"` → `"%s\n"`

## Review Findings
- Errors: 0
- Warnings: 0
- Nits: 5
- Assessment: **PASS**

Clean, well-structured change. The new functions are well-decomposed (`buildDetailedFailures` → `formatFailedScenario` → `truncateObserved`), UTF-8 safety is handled correctly, tests are thorough and table-driven, and the code follows project conventions. No correctness issues found.
