### PR TITLE
feat(attractor): stall steering injection on repeated failures

### DIFF
--- a/cmd/octog/main.go
+++ b/cmd/octog/main.go
@@ -943,6 +943,10 @@ func buildDetailedFailures(agg scenario.AggregateResult) []string {
 // formatFailedScenario formats a failing scenario as a multi-line string with
 // per-step detail. Failing steps include reasoning and observed output; passing
 // steps within a failing scenario appear as a single-line summary.
+//
+// NOTE: The first line format "✗ id (score/100)" is parsed by
+// internal/attractor.parseFailedScenarios. If this format changes, update that
+// parser accordingly.
 func formatFailedScenario(s scenario.ScoredScenario) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "✗ %s (%.0f/100)", s.ScenarioID, s.Score)

--- a/internal/attractor/attractor.go
+++ b/internal/attractor/attractor.go
@@ -568,9 +568,10 @@ func (a *Attractor) processValidation(iter int, satisfaction float64, failures [
 	}
 
 	s.history = append(s.history, iterationFeedback{
-		iteration: iter,
-		kind:      feedbackValidation,
-		message:   formatValidationFeedback(satisfaction, failures),
+		iteration:       iter,
+		kind:            feedbackValidation,
+		message:         formatValidationFeedback(satisfaction, failures),
+		failedScenarios: parseFailedScenarios(failures),
 	})
 
 	if s.stallCount >= s.opts.StallLimit {

--- a/internal/attractor/prompts.go
+++ b/internal/attractor/prompts.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"strconv"
 	"strings"
 	"unicode/utf8"
 
@@ -49,9 +50,10 @@ func feedbackHeader(kind string) string {
 
 // iterationFeedback captures what happened in one iteration for building the next prompt.
 type iterationFeedback struct {
-	iteration int
-	kind      string
-	message   string
+	iteration       int
+	kind            string
+	message         string
+	failedScenarios map[string]float64 // populated for feedbackValidation entries; nil otherwise
 }
 
 const systemPromptPrefix = `You are a code generation agent. Your task is to generate a complete, working application based on the following specification.
@@ -283,6 +285,12 @@ func buildMessages(iter int, history []iterationFeedback) []llm.Message {
 	var b strings.Builder
 	b.WriteString("The previous attempt did not fully satisfy the specification. Here is the feedback:\n\n")
 
+	// Inject steering for scenarios stalling across consecutive iterations (full history).
+	if steeringText := buildSteeringText(history); steeringText != "" {
+		b.WriteString(steeringText)
+		b.WriteString("\n")
+	}
+
 	// Include last 3 feedback entries with categorized headers.
 	start := max(len(history)-maxFeedbackEntries, 0)
 	writeCategorizedFeedback(&b, history[start:])
@@ -304,6 +312,12 @@ func buildPatchMessages(history []iterationFeedback, bestFiles map[string]string
 	paths := slices.Sorted(maps.Keys(bestFiles))
 	for _, p := range paths {
 		fmt.Fprintf(&b, "=== FILE: %s ===\n%s=== END FILE ===\n\n", p, bestFiles[p])
+	}
+
+	// Inject steering for scenarios stalling across consecutive iterations (full history).
+	if steeringText := buildSteeringText(history); steeringText != "" {
+		b.WriteString(steeringText)
+		b.WriteString("\n")
 	}
 
 	if len(history) > 0 {
@@ -369,4 +383,98 @@ func extractFailureStrings(history []iterationFeedback) []string {
 		}
 	}
 	return failures
+}
+
+// parseFailedScenarios parses the mixed pass/fail slice returned by ValidateFn into a
+// map of scenario ID → score for failing scenarios only.
+//
+// Each element is a full scenario result string (possibly multi-line). Passing entries
+// start with "✓"; failing entries start with "✗ id (score/100)" on the first line.
+// Indented sub-lines (step detail) are part of the same element and are ignored here.
+//
+// NOTE: The expected format is "✗ id (score/100)" as produced by formatFailedScenario
+// in cmd/octog/main.go. If that format changes, this parser will silently stop matching.
+func parseFailedScenarios(failures []string) map[string]float64 {
+	result := make(map[string]float64, len(failures))
+	for _, entry := range failures {
+		// Take only the first line of each entry (sub-lines are step detail).
+		firstLine, _, _ := strings.Cut(entry, "\n")
+		firstLine = strings.TrimSpace(firstLine)
+
+		// Only parse failing scenarios; skip passing ones.
+		const failPrefix = "✗ "
+		if !strings.HasPrefix(firstLine, failPrefix) {
+			continue
+		}
+
+		rest := firstLine[len(failPrefix):]
+
+		// Split on the last "(" to separate the scenario ID from the score.
+		parenIdx := strings.LastIndex(rest, "(")
+		if parenIdx < 0 {
+			continue
+		}
+		id := strings.TrimSpace(rest[:parenIdx])
+		scoreStr := rest[parenIdx+1:]
+
+		// scoreStr is now "score/100)" — strip the "/100)" suffix.
+		slashIdx := strings.Index(scoreStr, "/100)")
+		if slashIdx < 0 {
+			continue
+		}
+		scoreStr = scoreStr[:slashIdx]
+
+		score, err := strconv.ParseFloat(scoreStr, 64)
+		if err != nil {
+			continue
+		}
+		result[id] = score
+	}
+	return result
+}
+
+// buildSteeringText inspects the full iteration history and returns a steering notice
+// for scenarios that have failed in 2 or more consecutive validation iterations.
+// Non-validation entries (build/health/parse/run errors) do not break failure streaks.
+// Returns an empty string when no stalling scenarios are detected.
+func buildSteeringText(history []iterationFeedback) string {
+	streaks := make(map[string]int)
+	lastScore := make(map[string]float64)
+
+	for _, fb := range history {
+		if fb.kind != feedbackValidation {
+			continue
+		}
+		// Reset streaks for scenarios that did not fail in this validation entry.
+		for id := range streaks {
+			if _, failed := fb.failedScenarios[id]; !failed {
+				streaks[id] = 0
+			}
+		}
+		// Increment streaks for scenarios that failed in this entry.
+		for id, score := range fb.failedScenarios {
+			streaks[id]++
+			lastScore[id] = score
+		}
+	}
+
+	// Collect scenarios stalling across 2+ consecutive iterations.
+	stalling := make([]string, 0, len(streaks))
+	for id, streak := range streaks {
+		if streak >= 2 {
+			stalling = append(stalling, id)
+		}
+	}
+	if len(stalling) == 0 {
+		return ""
+	}
+	slices.Sort(stalling)
+
+	var b strings.Builder
+	b.WriteString("STALL NOTICE: The following scenario(s) have failed in multiple consecutive attempts. ")
+	b.WriteString("Try a fundamentally different implementation approach for each:\n")
+	for _, id := range stalling {
+		fmt.Fprintf(&b, "- %s (score: %.0f/100, failing %d iterations in a row)\n", id, lastScore[id], streaks[id])
+	}
+	return b.String()
 }

--- a/internal/attractor/prompts_test.go
+++ b/internal/attractor/prompts_test.go
@@ -680,6 +680,288 @@ func TestBuildSystemPromptBackwardsCompat(t *testing.T) {
 	}
 }
 
+func TestParseFailedScenarios(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		wantKeys []string
+		wantNone []string
+	}{
+		{
+			name:     "single failure",
+			input:    []string{"✗ move-card (45/100)"},
+			wantKeys: []string{"move-card"},
+		},
+		{
+			name:     "passing scenario skipped",
+			input:    []string{"✓ add-task (100/100)"},
+			wantKeys: []string{},
+		},
+		{
+			name:     "multiple failures",
+			input:    []string{"✗ move-card (45/100)", "✗ add-task (30/100)"},
+			wantKeys: []string{"move-card", "add-task"},
+		},
+		{
+			name:     "mixed pass and fail",
+			input:    []string{"✓ health (100/100)", "✗ create-item (60/100)"},
+			wantKeys: []string{"create-item"},
+			wantNone: []string{"health"},
+		},
+		{
+			name: "indented sub-lines ignored",
+			input: []string{
+				"✗ move-card (45/100)\n  ✗ check status (20/100)\n    Reasoning: timeout\n    Observed: got 500",
+			},
+			wantKeys: []string{"move-card"},
+		},
+		{
+			name:     "empty input",
+			input:    []string{},
+			wantKeys: []string{},
+		},
+		{
+			name:     "malformed line gracefully skipped",
+			input:    []string{"✗ bad-scenario no-parens", "✗ move-card (45/100)"},
+			wantKeys: []string{"move-card"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseFailedScenarios(tt.input)
+			for _, key := range tt.wantKeys {
+				if _, ok := got[key]; !ok {
+					t.Errorf("expected key %q in result, got %v", key, got)
+				}
+			}
+			for _, key := range tt.wantNone {
+				if _, ok := got[key]; ok {
+					t.Errorf("unexpected key %q in result", key)
+				}
+			}
+		})
+	}
+}
+
+func TestParseFailedScenariosScores(t *testing.T) {
+	got := parseFailedScenarios([]string{"✗ move-card (45/100)", "✗ add-task (30/100)"})
+	if got["move-card"] != 45 {
+		t.Errorf("move-card score: got %v, want 45", got["move-card"])
+	}
+	if got["add-task"] != 30 {
+		t.Errorf("add-task score: got %v, want 30", got["add-task"])
+	}
+}
+
+func TestBuildSteeringText(t *testing.T) {
+	mkFeedback := func(kind string, failed map[string]float64) iterationFeedback {
+		return iterationFeedback{kind: kind, failedScenarios: failed}
+	}
+	mkVal := func(failed map[string]float64) iterationFeedback {
+		return mkFeedback(feedbackValidation, failed)
+	}
+	mkBuild := func() iterationFeedback {
+		return mkFeedback(feedbackBuildError, nil)
+	}
+
+	tests := []struct {
+		name      string
+		history   []iterationFeedback
+		wantEmpty bool
+		wantIDs   []string
+	}{
+		{
+			name:      "no history",
+			history:   nil,
+			wantEmpty: true,
+		},
+		{
+			name:      "single entry no steering",
+			history:   []iterationFeedback{mkVal(map[string]float64{"move-card": 45})},
+			wantEmpty: true,
+		},
+		{
+			name: "different scenarios each iteration",
+			history: []iterationFeedback{
+				mkVal(map[string]float64{"move-card": 45}),
+				mkVal(map[string]float64{"add-task": 30}),
+			},
+			wantEmpty: true,
+		},
+		{
+			name: "same scenario 2 consecutive iterations",
+			history: []iterationFeedback{
+				mkVal(map[string]float64{"move-card": 50}),
+				mkVal(map[string]float64{"move-card": 45}),
+			},
+			wantEmpty: false,
+			wantIDs:   []string{"move-card"},
+		},
+		{
+			name: "3 consecutive same scenario",
+			history: []iterationFeedback{
+				mkVal(map[string]float64{"move-card": 60}),
+				mkVal(map[string]float64{"move-card": 50}),
+				mkVal(map[string]float64{"move-card": 45}),
+			},
+			wantEmpty: false,
+			wantIDs:   []string{"move-card"},
+		},
+		{
+			name: "streak broken by passing",
+			history: []iterationFeedback{
+				mkVal(map[string]float64{"move-card": 50}),
+				mkVal(map[string]float64{}), // move-card passed
+				mkVal(map[string]float64{"move-card": 45}),
+			},
+			wantEmpty: true,
+		},
+		{
+			name: "non-validation entries don't break streaks",
+			history: []iterationFeedback{
+				mkVal(map[string]float64{"move-card": 50}),
+				mkBuild(),
+				mkVal(map[string]float64{"move-card": 45}),
+			},
+			wantEmpty: false,
+			wantIDs:   []string{"move-card"},
+		},
+		{
+			name: "multiple stalling scenarios",
+			history: []iterationFeedback{
+				mkVal(map[string]float64{"move-card": 50, "add-task": 40}),
+				mkVal(map[string]float64{"move-card": 45, "add-task": 35}),
+			},
+			wantEmpty: false,
+			wantIDs:   []string{"move-card", "add-task"},
+		},
+		{
+			name: "mixed repeated and new",
+			history: []iterationFeedback{
+				mkVal(map[string]float64{"move-card": 50}),
+				mkVal(map[string]float64{"move-card": 45, "add-task": 30}),
+			},
+			wantEmpty: false,
+			wantIDs:   []string{"move-card"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildSteeringText(tt.history)
+			if tt.wantEmpty {
+				if got != "" {
+					t.Errorf("expected empty steering text, got:\n%s", got)
+				}
+				return
+			}
+			if got == "" {
+				t.Fatal("expected non-empty steering text")
+			}
+			if !strings.Contains(got, "STALL NOTICE") {
+				t.Errorf("steering text should contain STALL NOTICE, got:\n%s", got)
+			}
+			for _, id := range tt.wantIDs {
+				if !strings.Contains(got, id) {
+					t.Errorf("steering text should mention scenario %q, got:\n%s", id, got)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildMessagesWithSteering(t *testing.T) {
+	// Two consecutive validation failures for the same scenario should inject steering.
+	history := []iterationFeedback{
+		{
+			iteration:       1,
+			kind:            feedbackValidation,
+			message:         "Satisfaction score: 50.0/100\nScenario results:\n✗ move-card (50/100)",
+			failedScenarios: map[string]float64{"move-card": 50},
+		},
+		{
+			iteration:       2,
+			kind:            feedbackValidation,
+			message:         "Satisfaction score: 45.0/100\nScenario results:\n✗ move-card (45/100)",
+			failedScenarios: map[string]float64{"move-card": 45},
+		},
+	}
+
+	msgs := buildMessages(3, history)
+	content := msgs[0].Content
+
+	if !strings.Contains(content, "STALL NOTICE") {
+		t.Errorf("messages should contain STALL NOTICE when scenario stalls, got:\n%s", content)
+	}
+	if !strings.Contains(content, "move-card") {
+		t.Errorf("messages should mention stalling scenario, got:\n%s", content)
+	}
+	// Steering should appear before the categorized feedback.
+	steerIdx := strings.Index(content, "STALL NOTICE")
+	feedbackIdx := strings.Index(content, "VALIDATION FAILURES")
+	if steerIdx > feedbackIdx {
+		t.Errorf("steering text should appear before categorized feedback")
+	}
+}
+
+func TestBuildMessagesNoSteeringWithoutConsecutive(t *testing.T) {
+	// Different scenarios each iteration: no steering expected.
+	history := []iterationFeedback{
+		{
+			iteration:       1,
+			kind:            feedbackValidation,
+			message:         "Satisfaction score: 50.0/100",
+			failedScenarios: map[string]float64{"move-card": 50},
+		},
+		{
+			iteration:       2,
+			kind:            feedbackValidation,
+			message:         "Satisfaction score: 45.0/100",
+			failedScenarios: map[string]float64{"add-task": 45},
+		},
+	}
+
+	msgs := buildMessages(3, history)
+	if strings.Contains(msgs[0].Content, "STALL NOTICE") {
+		t.Error("should not inject steering when scenarios differ each iteration")
+	}
+}
+
+func TestBuildPatchMessagesWithSteering(t *testing.T) {
+	history := []iterationFeedback{
+		{
+			iteration:       1,
+			kind:            feedbackValidation,
+			message:         "Satisfaction score: 50.0/100\nScenario results:\n✗ add-task (50/100)",
+			failedScenarios: map[string]float64{"add-task": 50},
+		},
+		{
+			iteration:       2,
+			kind:            feedbackValidation,
+			message:         "Satisfaction score: 40.0/100\nScenario results:\n✗ add-task (40/100)",
+			failedScenarios: map[string]float64{"add-task": 40},
+		},
+	}
+	bestFiles := map[string]string{"main.go": "package main\n"}
+
+	msgs := buildPatchMessages(history, bestFiles, 50.0)
+	content := msgs[0].Content
+
+	if !strings.Contains(content, "STALL NOTICE") {
+		t.Errorf("patch messages should contain STALL NOTICE when scenario stalls, got:\n%s", content)
+	}
+	if !strings.Contains(content, "add-task") {
+		t.Errorf("patch messages should mention stalling scenario, got:\n%s", content)
+	}
+	// Steering should appear before "Failures to fix".
+	steerIdx := strings.Index(content, "STALL NOTICE")
+	failIdx := strings.Index(content, "Failures to fix")
+	if steerIdx > failIdx {
+		t.Errorf("steering text should appear before 'Failures to fix' section")
+	}
+}
+
 // capsSuffix returns a short string describing capabilities for test names.
 func capsSuffix(caps ScenarioCapabilities) string {
 	switch {


### PR DESCRIPTION
Closes #103

## Changes

**`internal/attractor/prompts.go`**

1. Add `failedScenarios map[string]float64` field to `iterationFeedback` struct.

2. Add `parseFailedScenarios(failures []string) map[string]float64` — parse `✗ id (score/100)` headers from the mixed pass/fail slice. Skip `✓` lines and indented sub-lines. Use `strings.LastIndex` for the `(` delimiter.

3. Add `buildSteeringText(history []iterationFeedback) string` — walk `feedbackValidation` entries, track per-scenario consecutive failure streaks, format steering block for scenarios failing 2+ consecutive validation entries. Non-validation entries are transparent to streak counting.

4. Update `buildMessages` — call `buildSteeringText(history)` on the **full** history (not the truncated slice). Insert steering text after the "Here is the feedback:" preamble and before `writeCategorizedFeedback`.

5. Update `buildPatchMessages` — call `buildSteeringText(history)` on full history. Insert between current-files block and "Failures to fix:" section.

**`internal/attractor/attractor.go`**

6. Update `processValidation` (line 570-574) — populate `failedScenarios: parseFailedScenarios(failures)` in the appended `iterationFeedback`.

**`cmd/octog/main.go`** (documentation only)

7. Add a comment on `formatFailedScenario` noting the attractor package's `parseFailedScenarios` depends on this output format.

## Review Findings
- Errors: 0
- Warnings: 1
- Nits: 4
- Assessment: **NEEDS CHANGES**

The warning is about the cross-package string-format coupling. The code works today, but the `cmd/octog` → string → `internal/attractor` parsing pipeline is the kind of implicit contract that breaks silently during refactors. The bidirectional NOTE comments mitigate but don't eliminate the risk. Consider whether `ValidateFn` can return structured data instead.
