### PR TITLE
feat(attractor): track per-scenario score regression across iterations

### DIFF
--- a/cmd/octog/main.go
+++ b/cmd/octog/main.go
@@ -135,6 +135,7 @@ func runCmd(ctx context.Context, logger *slog.Logger, args []string) error {
 	language := fs.String("language", "go", "target language: go, python, node, rust, or auto")
 	genesFlag := fs.String("genes", "", "path to genes.json file produced by octog extract")
 	patchMode := fs.Bool("patch", false, "enable incremental patch mode (iteration 2+ sends only changed files)")
+	blockOnRegression := fs.Bool("block-on-regression", false, "block convergence when any scenario regresses below threshold in the current iteration")
 	contextBudget := fs.Int("context-budget", 0, "max estimated tokens for spec in system prompt; 0 = unlimited")
 	otelEndpoint := fs.String("otel-endpoint", "", "OTLP/HTTP endpoint for tracing (e.g. localhost:4318); disabled if empty")
 
@@ -189,18 +190,19 @@ func runCmd(ctx context.Context, logger *slog.Logger, args []string) error {
 	}
 
 	return runAttractorLoop(ctx, logger, clients.client, runLoopParams{
-		SpecPath:      *specFlag,
-		ScenariosPath: *scenariosFlag,
-		Model:         *model,
-		JudgeModel:    *judgeModel,
-		Budget:        *budget,
-		Threshold:     *threshold,
-		PatchMode:     *patchMode,
-		ContextBudget: *contextBudget,
-		OTELEndpoint:  endpoint,
-		Language:      langForOpts,
-		GenesGuide:    genesGuide,
-		GeneLanguage:  genesLanguage,
+		SpecPath:          *specFlag,
+		ScenariosPath:     *scenariosFlag,
+		Model:             *model,
+		JudgeModel:        *judgeModel,
+		Budget:            *budget,
+		Threshold:         *threshold,
+		PatchMode:         *patchMode,
+		BlockOnRegression: *blockOnRegression,
+		ContextBudget:     *contextBudget,
+		OTELEndpoint:      endpoint,
+		Language:          langForOpts,
+		GenesGuide:        genesGuide,
+		GeneLanguage:      genesLanguage,
 	})
 }
 
@@ -238,18 +240,19 @@ func isFlagSet(fs *flag.FlagSet, name string) bool {
 
 // runLoopParams bundles the parameters for runAttractorLoop.
 type runLoopParams struct {
-	SpecPath      string
-	ScenariosPath string
-	Model         string
-	JudgeModel    string
-	Budget        float64
-	Threshold     float64
-	PatchMode     bool
-	ContextBudget int
-	OTELEndpoint  string
-	Language      string
-	GenesGuide    string
-	GeneLanguage  string
+	SpecPath          string
+	ScenariosPath     string
+	Model             string
+	JudgeModel        string
+	Budget            float64
+	Threshold         float64
+	PatchMode         bool
+	BlockOnRegression bool
+	ContextBudget     int
+	OTELEndpoint      string
+	Language          string
+	GenesGuide        string
+	GeneLanguage      string
 }
 
 func runAttractorLoop(ctx context.Context, logger *slog.Logger, llmClient llm.Client, p runLoopParams) error {
@@ -331,16 +334,17 @@ func runAttractorLoop(ctx context.Context, logger *slog.Logger, llmClient llm.Cl
 
 	att := attractor.New(instrumentedLLM, instrumentedContainer, logger, tp)
 	opts := attractor.RunOptions{
-		Model:         p.Model,
-		BudgetUSD:     p.Budget,
-		Threshold:     p.Threshold,
-		PatchMode:     p.PatchMode,
-		ContextBudget: p.ContextBudget,
-		Language:      p.Language,
-		Progress:      progressFn(ctx, logger, st),
-		Capabilities:  caps,
-		Genes:         p.GenesGuide,
-		GeneLanguage:  p.GeneLanguage,
+		Model:             p.Model,
+		BudgetUSD:         p.Budget,
+		Threshold:         p.Threshold,
+		PatchMode:         p.PatchMode,
+		BlockOnRegression: p.BlockOnRegression,
+		ContextBudget:     p.ContextBudget,
+		Language:          p.Language,
+		Progress:          progressFn(ctx, logger, st),
+		Capabilities:      caps,
+		Genes:             p.GenesGuide,
+		GeneLanguage:      p.GeneLanguage,
 	}
 
 	startedAt := time.Now()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -493,20 +493,21 @@ type ValidateFn func(ctx context.Context, url string) (satisfaction float64, fai
 ```go
 // RunOptions configures the attractor loop.
 type RunOptions struct {
-	Model         string
-	Language      string               // language hint: "go", "python", "node", "rust", or "" (auto)
-	BudgetUSD     float64              // 0 = unlimited
-	Threshold     float64              // default 95
-	MaxIterations int                  // default 10
-	StallLimit    int                  // default 3
-	WorkspaceDir  string               // default "./workspace"
-	HealthTimeout time.Duration        // default 30s
-	Progress      ProgressFunc         // optional per-iteration callback
-	PatchMode     bool                 // if true, iteration 2+ sends prev best files + failures
-	ContextBudget int                  // max estimated tokens for spec in system prompt; 0 = unlimited
-	Capabilities  ScenarioCapabilities // detected from loaded scenarios
-	Genes         string               // extracted pattern guide to inject into system prompt (empty = no genes)
-	GeneLanguage  string               // source language of the gene exemplar (for cross-language note)
+	Model             string
+	Language          string               // language hint: "go", "python", "node", "rust", or "" (auto)
+	BudgetUSD         float64              // 0 = unlimited
+	Threshold         float64              // default 95
+	MaxIterations     int                  // default 10
+	StallLimit        int                  // default 3
+	WorkspaceDir      string               // default "./workspace"
+	HealthTimeout     time.Duration        // default 30s
+	Progress          ProgressFunc         // optional per-iteration callback
+	PatchMode         bool                 // if true, iteration 2+ sends prev best files + failures
+	BlockOnRegression bool                 // if true, convergence is blocked when per-scenario regressions are detected
+	ContextBudget     int                  // max estimated tokens for spec in system prompt; 0 = unlimited
+	Capabilities      ScenarioCapabilities // detected from loaded scenarios
+	Genes             string               // extracted pattern guide to inject into system prompt (empty = no genes)
+	GeneLanguage      string               // source language of the gene exemplar (for cross-language note)
 }
 ```
 

--- a/internal/attractor/attractor.go
+++ b/internal/attractor/attractor.go
@@ -111,20 +111,21 @@ type Attractor struct {
 
 // RunOptions configures the attractor loop.
 type RunOptions struct {
-	Model         string
-	Language      string               // language hint: "go", "python", "node", "rust", or "" (auto)
-	BudgetUSD     float64              // 0 = unlimited
-	Threshold     float64              // default 95
-	MaxIterations int                  // default 10
-	StallLimit    int                  // default 3
-	WorkspaceDir  string               // default "./workspace"
-	HealthTimeout time.Duration        // default 30s
-	Progress      ProgressFunc         // optional per-iteration callback
-	PatchMode     bool                 // if true, iteration 2+ sends prev best files + failures
-	ContextBudget int                  // max estimated tokens for spec in system prompt; 0 = unlimited
-	Capabilities  ScenarioCapabilities // detected from loaded scenarios
-	Genes         string               // extracted pattern guide to inject into system prompt (empty = no genes)
-	GeneLanguage  string               // source language of the gene exemplar (for cross-language note)
+	Model             string
+	Language          string               // language hint: "go", "python", "node", "rust", or "" (auto)
+	BudgetUSD         float64              // 0 = unlimited
+	Threshold         float64              // default 95
+	MaxIterations     int                  // default 10
+	StallLimit        int                  // default 3
+	WorkspaceDir      string               // default "./workspace"
+	HealthTimeout     time.Duration        // default 30s
+	Progress          ProgressFunc         // optional per-iteration callback
+	PatchMode         bool                 // if true, iteration 2+ sends prev best files + failures
+	BlockOnRegression bool                 // if true, convergence is blocked when per-scenario regressions are detected
+	ContextBudget     int                  // max estimated tokens for spec in system prompt; 0 = unlimited
+	Capabilities      ScenarioCapabilities // detected from loaded scenarios
+	Genes             string               // extracted pattern guide to inject into system prompt (empty = no genes)
+	GeneLanguage      string               // source language of the gene exemplar (for cross-language note)
 }
 
 // RunResult holds the outcome of an attractor run.
@@ -147,27 +148,29 @@ type GRPCTargetProviderFn func(target string)
 
 // runState holds mutable state across iterations of the attractor loop.
 type runState struct {
-	runID                string
-	opts                 RunOptions
-	baseDir              string
-	bestDir              string
-	totalCost            float64
-	bestSatisfaction     float64
-	stallCount           int
-	history              []iterationFeedback
-	scoreHistory         []float64
-	lastOutcome          IterationOutcome
-	lastSatisfaction     float64
-	lastInputTokens      int
-	lastOutputTokens     int
-	lastFailures         []string
-	startTime            time.Time
-	bestFiles            map[string]string       // files from the best-scoring iteration
-	patchActive          bool                    // patch mode currently in effect (may disable on regression)
-	patchRegressionCount int                     // consecutive regressions while patch mode active
-	summarized           *specpkg.SummarizedSpec // nil if spec fits budget or budget is 0
-	sessionProvider      SessionProviderFn       // callback to set the current session
-	grpcTargetProvider   GRPCTargetProviderFn    // callback to set the gRPC target
+	runID                  string
+	opts                   RunOptions
+	baseDir                string
+	bestDir                string
+	totalCost              float64
+	bestSatisfaction       float64
+	stallCount             int
+	history                []iterationFeedback
+	scoreHistory           []float64
+	lastOutcome            IterationOutcome
+	lastSatisfaction       float64
+	lastInputTokens        int
+	lastOutputTokens       int
+	lastFailures           []string
+	startTime              time.Time
+	bestFiles              map[string]string       // files from the best-scoring iteration
+	patchActive            bool                    // patch mode currently in effect (may disable on regression)
+	patchRegressionCount   int                     // consecutive regressions while patch mode active
+	summarized             *specpkg.SummarizedSpec // nil if spec fits budget or budget is 0
+	sessionProvider        SessionProviderFn       // callback to set the current session
+	grpcTargetProvider     GRPCTargetProviderFn    // callback to set the gRPC target
+	scenarioScores         map[string]float64      // per-scenario scores from the last validated iteration
+	scenarioScoreIteration int                     // iteration number corresponding to scenarioScores
 }
 
 func (s *runState) result(iter int, status string) *RunResult {
@@ -552,7 +555,35 @@ func (a *Attractor) processValidation(iter int, satisfaction float64, failures [
 	s.lastSatisfaction = satisfaction
 	s.scoreHistory = append(s.scoreHistory, satisfaction)
 
-	if satisfaction >= s.opts.Threshold {
+	// Detect per-scenario regressions before the convergence check.
+	currentScores := parseAllScenarios(failures)
+	if len(failures) > 0 && len(currentScores) == 0 {
+		// No scenario lines parsed from non-empty output — likely a format change in
+		// validator output. Log at debug level to aid diagnosis of unexpected
+		// "no regressions detected" situations.
+		a.logger.Debug("parseAllScenarios: non-empty failures slice yielded zero parsed scenarios; regression detection disabled for this iteration", "iteration", iter, "entry_count", len(failures))
+	}
+	regressions := detectRegressions(s.scenarioScores, s.scenarioScoreIteration, currentScores, iter, s.opts.Threshold)
+	if len(regressions) > 0 {
+		body := formatRegressions(regressions)
+		s.history = append(s.history, iterationFeedback{
+			iteration: iter,
+			kind:      feedbackRegression,
+			message:   body,
+		})
+		a.logger.Info("scenario regressions detected", "iteration", iter, "count", len(regressions))
+	}
+
+	// Full replacement (not merge) avoids stale scores for renamed or removed scenarios.
+	s.scenarioScores = currentScores
+	s.scenarioScoreIteration = iter
+
+	// Converge only when at/above threshold and not blocked by a regression.
+	converge := satisfaction >= s.opts.Threshold
+	if converge && s.opts.BlockOnRegression && len(regressions) > 0 {
+		converge = false
+	}
+	if converge {
 		if err := writeFiles(s.bestDir, files); err != nil {
 			return nil, fmt.Errorf("attractor: write best files: %w", err)
 		}

--- a/internal/attractor/attractor_test.go
+++ b/internal/attractor/attractor_test.go
@@ -1468,3 +1468,114 @@ func TestMinimalismPromptProgression(t *testing.T) {
 		t.Errorf("req 3 should contain minimalism prompt (score 85 > 80), got:\n%s", thirdContent)
 	}
 }
+
+// TestRegressionFeedbackInjected verifies that when a scenario passes in one iteration
+// and then fails in the next, a REGRESSIONS feedback entry is injected into the messages
+// for the following iteration.
+func TestRegressionFeedbackInjected(t *testing.T) {
+	// Iter 1: aggregate below threshold so run continues; scenario-a scores above threshold.
+	// Iter 2: scenario-a drops below threshold → regression detected.
+	// Iter 3: Generate call should contain "REGRESSIONS" in messages.
+	iter1Failures := []string{"✓ scenario-a (98/100)"}
+	iter2Failures := []string{"✗ scenario-a (45/100)"}
+
+	// capturedMsgs is appended from generateFn without synchronization.
+	// This is safe because the attractor loop calls Generate sequentially (never concurrently).
+	var capturedMsgs [][]llm.Message
+	var validateCount atomic.Int32
+	client := &mockLLMClient{
+		generateFn: func(_ context.Context, req llm.GenerateRequest) (llm.GenerateResponse, error) {
+			capturedMsgs = append(capturedMsgs, req.Messages)
+			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
+		},
+	}
+	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+		n := validateCount.Add(1)
+		switch n {
+		case 1:
+			// aggregate 60 < threshold 95 — does not converge; scenario-a is at 98.
+			return 60, iter1Failures, 0.005, nil
+		case 2:
+			// scenario-a dropped from 98 to 45 → regression.
+			return 50, iter2Failures, 0.005, nil
+		default:
+			return 100, nil, 0.005, nil
+		}
+	}
+
+	a := New(client, &mockContainerMgr{}, testLogger(), nil)
+	result, err := a.Run(context.Background(), "Build an app", defaultOpts(t), validate, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != StatusConverged {
+		t.Errorf("expected converged, got %q", result.Status)
+	}
+	if len(capturedMsgs) < 3 {
+		t.Fatalf("expected at least 3 Generate calls, got %d", len(capturedMsgs))
+	}
+
+	// Iter 3 messages should contain REGRESSIONS feedback.
+	msgsContain := func(msgs []llm.Message, sub string) bool {
+		for _, m := range msgs {
+			if strings.Contains(m.Content, sub) {
+				return true
+			}
+		}
+		return false
+	}
+	if !msgsContain(capturedMsgs[2], "REGRESSIONS") {
+		t.Errorf("iteration 3 Generate call should contain REGRESSIONS feedback, got: %v", capturedMsgs[2])
+	}
+	if !msgsContain(capturedMsgs[2], "scenario-a") {
+		t.Errorf("iteration 3 Generate call should mention the regressed scenario, got: %v", capturedMsgs[2])
+	}
+}
+
+// TestBlockOnRegressionPreventsConvergence verifies that when BlockOnRegression is true,
+// the loop does not converge if a per-scenario regression is detected in the same iteration
+// that the aggregate score meets the threshold.
+func TestBlockOnRegressionPreventsConvergence(t *testing.T) {
+	// Iter 1: aggregate below threshold; scenario-a scores above threshold per-scenario.
+	// Iter 2: aggregate meets threshold but scenario-a regressed → BlockOnRegression blocks.
+	// Iter 3: aggregate meets threshold with no regressions → converge.
+	iter1Failures := []string{"✓ scenario-a (98/100)", "✓ scenario-b (100/100)"}
+	iter2Failures := []string{"✗ scenario-a (45/100)", "✓ scenario-b (100/100)"}
+
+	var validateCount atomic.Int32
+	client := &mockLLMClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
+		},
+	}
+	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+		n := validateCount.Add(1)
+		switch n {
+		case 1:
+			// aggregate 60 < threshold 95 — does not converge; scenario-a is at 98.
+			return 60, iter1Failures, 0.005, nil
+		case 2:
+			// Aggregate meets threshold, but scenario-a regressed from 98 to 45.
+			return 97, iter2Failures, 0.005, nil
+		default:
+			return 100, nil, 0.005, nil
+		}
+	}
+
+	opts := defaultOpts(t)
+	opts.BlockOnRegression = true
+
+	a := New(client, &mockContainerMgr{}, testLogger(), nil)
+	result, err := a.Run(context.Background(), "Build an app", opts, validate, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should not have converged on iteration 2 due to regression blocking.
+	// Iteration 3 has no regression and aggregate 100 → converged.
+	if result.Status != StatusConverged {
+		t.Errorf("expected converged (on iteration 3), got %q", result.Status)
+	}
+	if result.Iterations < 3 {
+		t.Errorf("expected at least 3 iterations (regression blocked iter 2), got %d", result.Iterations)
+	}
+}

--- a/internal/attractor/prompts.go
+++ b/internal/attractor/prompts.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"maps"
 	"slices"
-	"strconv"
 	"strings"
 	"unicode/utf8"
 
@@ -16,6 +15,7 @@ const (
 	feedbackBuildError  = "build_error"
 	feedbackHealthError = "health_error"
 	feedbackParseError  = "parse_error"
+	feedbackRegression  = "regression"
 	feedbackRunError    = "run_error"
 	feedbackValidation  = "validation"
 )
@@ -55,6 +55,8 @@ func feedbackHeader(kind string) string {
 		return "HEALTH CHECK FAILURE"
 	case feedbackParseError:
 		return "PARSE ERROR"
+	case feedbackRegression:
+		return "REGRESSIONS"
 	case feedbackRunError:
 		return "RUN FAILURE"
 	case feedbackValidation:
@@ -561,30 +563,13 @@ func parseFailedScenarios(failures []string) map[string]float64 {
 		firstLine, _, _ := strings.Cut(entry, "\n")
 		firstLine = strings.TrimSpace(firstLine)
 
-		// Only parse failing scenarios; skip passing ones.
-		// Use strings.CutPrefix to avoid implicit byte-length arithmetic on the Unicode prefix.
-		rest, ok := strings.CutPrefix(firstLine, failScenarioPrefix)
+		// Parse the line first; malformed or unrecognized entries are skipped.
+		id, score, ok := parseScenarioLine(firstLine)
 		if !ok {
 			continue
 		}
-
-		// Split on the last "(" to separate the scenario ID from the score.
-		parenIdx := strings.LastIndex(rest, "(")
-		if parenIdx < 0 {
-			continue
-		}
-		id := strings.TrimSpace(rest[:parenIdx])
-		scoreStr := rest[parenIdx+1:]
-
-		// scoreStr is now "score/100)" — strip the "/100)" suffix.
-		slashIdx := strings.Index(scoreStr, "/100)")
-		if slashIdx < 0 {
-			continue
-		}
-		scoreStr = scoreStr[:slashIdx]
-
-		score, err := strconv.ParseFloat(scoreStr, 64)
-		if err != nil {
+		// Only collect failing scenarios (✗ prefix); skip passing ones (✓ prefix).
+		if !strings.HasPrefix(firstLine, failScenarioPrefix) {
 			continue
 		}
 		if result == nil {

--- a/internal/attractor/regression.go
+++ b/internal/attractor/regression.go
@@ -1,0 +1,125 @@
+package attractor
+
+import (
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+// passScenarioPrefix identifies a passing scenario summary line.
+// cmd/octog uses "✓ id (score/100)" format for passing entries;
+// this constant defines the parse-side counterpart to that convention.
+const passScenarioPrefix = "✓ "
+
+// Regression records a per-scenario regression across two consecutive validated iterations.
+// A regression occurs when a scenario was at or above the convergence threshold in a prior
+// iteration but drops below it in the current iteration.
+type Regression struct {
+	ScenarioID    string
+	PrevScore     float64
+	CurrScore     float64
+	PrevIteration int
+	CurrIteration int
+}
+
+// parseScenarioLine parses a single scenario summary line in the format
+// "✓ id (score/100)" or "✗ id (score/100)". Returns id, score, and ok=true
+// on success. Returns ("", 0, false) for any malformed or unrecognized line.
+func parseScenarioLine(line string) (id string, score float64, ok bool) {
+	// Strip either pass or fail prefix.
+	rest, hasFail := strings.CutPrefix(line, failScenarioPrefix)
+	if !hasFail {
+		rest2, hasPass := strings.CutPrefix(line, passScenarioPrefix)
+		if !hasPass {
+			return "", 0, false
+		}
+		rest = rest2
+	}
+
+	// rest is now "id (score/100)" — split on last "(" to separate id from score.
+	parenIdx := strings.LastIndex(rest, "(")
+	if parenIdx < 0 {
+		return "", 0, false
+	}
+	id = strings.TrimSpace(rest[:parenIdx])
+	scoreStr := rest[parenIdx+1:]
+
+	// scoreStr is now "score/100)" — strip the "/100)" suffix.
+	slashIdx := strings.Index(scoreStr, "/100)")
+	if slashIdx < 0 {
+		return "", 0, false
+	}
+	scoreStr = scoreStr[:slashIdx]
+
+	s, err := strconv.ParseFloat(scoreStr, 64)
+	if err != nil {
+		return "", 0, false
+	}
+	return id, s, true
+}
+
+// parseAllScenarios parses the mixed pass/fail slice returned by ValidateFn and
+// returns a map of scenario ID → score for all scenarios (passing and failing).
+// Malformed or unrecognized entries are silently skipped.
+func parseAllScenarios(failures []string) map[string]float64 {
+	result := make(map[string]float64)
+	for _, entry := range failures {
+		firstLine, _, _ := strings.Cut(entry, "\n")
+		firstLine = strings.TrimSpace(firstLine)
+		id, score, ok := parseScenarioLine(firstLine)
+		if !ok {
+			continue
+		}
+		result[id] = score
+	}
+	return result
+}
+
+// detectRegressions compares two snapshots of per-scenario scores and returns
+// regressions: scenarios that were at or above threshold in the previous iteration
+// and dropped below threshold in the current iteration.
+//
+// prevScores may be nil or empty (e.g. on the first validated iteration), in which
+// case no regressions are reported. Results are sorted by ScenarioID for determinism.
+func detectRegressions(prevScores map[string]float64, prevIteration int, currScores map[string]float64, currIteration int, threshold float64) []Regression {
+	if len(prevScores) == 0 {
+		return nil
+	}
+	var regressions []Regression
+	for id, curr := range currScores {
+		prev, ok := prevScores[id]
+		if !ok {
+			continue
+		}
+		if prev >= threshold && curr < threshold {
+			regressions = append(regressions, Regression{
+				ScenarioID:    id,
+				PrevScore:     prev,
+				CurrScore:     curr,
+				PrevIteration: prevIteration,
+				CurrIteration: currIteration,
+			})
+		}
+	}
+	slices.SortFunc(regressions, func(a, b Regression) int {
+		return strings.Compare(a.ScenarioID, b.ScenarioID)
+	})
+	return regressions
+}
+
+// formatRegressions formats a slice of regressions as body text for inclusion in
+// iteration feedback. Returns one line per regression, sorted by ScenarioID.
+// Returns an empty string when regressions is empty.
+// Callers must pass regressions pre-sorted by ScenarioID (as returned by detectRegressions).
+func formatRegressions(regressions []Regression) string {
+	if len(regressions) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, r := range regressions {
+		fmt.Fprintf(&b, "scenario '%s' dropped from %.0f → %.0f (iteration %d → %d)\n",
+			r.ScenarioID, r.PrevScore, r.CurrScore, r.PrevIteration, r.CurrIteration)
+	}
+	return b.String()
+}

--- a/internal/attractor/regression_test.go
+++ b/internal/attractor/regression_test.go
@@ -1,0 +1,379 @@
+package attractor
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseScenarioLine(t *testing.T) {
+	tests := []struct {
+		name      string
+		line      string
+		wantID    string
+		wantScore float64
+		wantOK    bool
+	}{
+		{
+			name:      "passing scenario",
+			line:      "✓ login flow (98/100)",
+			wantID:    "login flow",
+			wantScore: 98,
+			wantOK:    true,
+		},
+		{
+			name:      "failing scenario",
+			line:      "✗ login flow (45/100)",
+			wantID:    "login flow",
+			wantScore: 45,
+			wantOK:    true,
+		},
+		{
+			name:      "failing scenario with zero score",
+			line:      "✗ auth flow (0/100)",
+			wantID:    "auth flow",
+			wantScore: 0,
+			wantOK:    true,
+		},
+		{
+			name:      "passing scenario with decimal score",
+			line:      "✓ crud items (72/100)",
+			wantID:    "crud items",
+			wantScore: 72,
+			wantOK:    true,
+		},
+		{
+			name:   "malformed — no prefix",
+			line:   "login flow (98/100)",
+			wantOK: false,
+		},
+		{
+			name:   "malformed — missing score paren",
+			line:   "✓ login flow",
+			wantOK: false,
+		},
+		{
+			name:   "malformed — missing /100) suffix",
+			line:   "✓ login flow (98)",
+			wantOK: false,
+		},
+		{
+			name:   "malformed — non-numeric score",
+			line:   "✓ login flow (abc/100)",
+			wantOK: false,
+		},
+		{
+			name:   "empty string",
+			line:   "",
+			wantOK: false,
+		},
+		{
+			name:   "indented step line",
+			line:   "  ✓ step: GET /health",
+			wantOK: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			id, score, ok := parseScenarioLine(tc.line)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !tc.wantOK {
+				return
+			}
+			if id != tc.wantID {
+				t.Errorf("id = %q, want %q", id, tc.wantID)
+			}
+			if score != tc.wantScore {
+				t.Errorf("score = %v, want %v", score, tc.wantScore)
+			}
+		})
+	}
+}
+
+func TestParseAllScenarios(t *testing.T) {
+	tests := []struct {
+		name     string
+		failures []string
+		want     map[string]float64
+	}{
+		{
+			name:     "empty input returns empty map",
+			failures: nil,
+			want:     map[string]float64{},
+		},
+		{
+			name: "mixed passing and failing entries",
+			failures: []string{
+				"✓ login flow (98/100)\n  ✓ GET /login (100/100)",
+				"✗ auth flow (45/100)\n  ✗ POST /auth (45/100)",
+			},
+			want: map[string]float64{
+				"login flow": 98,
+				"auth flow":  45,
+			},
+		},
+		{
+			name: "all passing",
+			failures: []string{
+				"✓ scenario-a (100/100)",
+				"✓ scenario-b (80/100)",
+			},
+			want: map[string]float64{
+				"scenario-a": 100,
+				"scenario-b": 80,
+			},
+		},
+		{
+			name: "all failing",
+			failures: []string{
+				"✗ scenario-a (20/100)",
+				"✗ scenario-b (0/100)",
+			},
+			want: map[string]float64{
+				"scenario-a": 20,
+				"scenario-b": 0,
+			},
+		},
+		{
+			name: "malformed entries skipped",
+			failures: []string{
+				"✓ good scenario (90/100)",
+				"this is not a scenario line",
+				"",
+			},
+			want: map[string]float64{
+				"good scenario": 90,
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseAllScenarios(tc.failures)
+			if len(got) != len(tc.want) {
+				t.Fatalf("len(got) = %d, want %d: got=%v", len(got), len(tc.want), got)
+			}
+			for id, wantScore := range tc.want {
+				gotScore, ok := got[id]
+				if !ok {
+					t.Errorf("missing scenario %q in result", id)
+					continue
+				}
+				if gotScore != wantScore {
+					t.Errorf("scenario %q: score = %v, want %v", id, gotScore, wantScore)
+				}
+			}
+		})
+	}
+}
+
+func TestDetectRegressions(t *testing.T) {
+	const threshold = 95.0
+
+	tests := []struct {
+		name          string
+		prevScores    map[string]float64
+		prevIteration int
+		currScores    map[string]float64
+		currIteration int
+		threshold     float64
+		wantIDs       []string // nil = expect no regressions
+	}{
+		{
+			name:          "no regression when scores improve",
+			prevScores:    map[string]float64{"scenario-a": 60},
+			prevIteration: 1,
+			currScores:    map[string]float64{"scenario-a": 80},
+			currIteration: 2,
+			threshold:     threshold,
+			wantIDs:       nil,
+		},
+		{
+			name:          "regression when prev >= threshold and curr < threshold",
+			prevScores:    map[string]float64{"login flow": 98},
+			prevIteration: 1,
+			currScores:    map[string]float64{"login flow": 45},
+			currIteration: 2,
+			threshold:     threshold,
+			wantIDs:       []string{"login flow"},
+		},
+		{
+			name:          "no regression on first iteration (prev nil)",
+			prevScores:    nil,
+			prevIteration: 0,
+			currScores:    map[string]float64{"scenario-a": 45},
+			currIteration: 1,
+			threshold:     threshold,
+			wantIDs:       nil,
+		},
+		{
+			name:          "no regression on first iteration (prev empty)",
+			prevScores:    map[string]float64{},
+			prevIteration: 0,
+			currScores:    map[string]float64{"scenario-a": 45},
+			currIteration: 1,
+			threshold:     threshold,
+			wantIDs:       nil,
+		},
+		{
+			name:          "no regression for scenario already below threshold",
+			prevScores:    map[string]float64{"scenario-a": 80},
+			prevIteration: 1,
+			currScores:    map[string]float64{"scenario-a": 50},
+			currIteration: 2,
+			threshold:     threshold,
+			wantIDs:       nil,
+		},
+		{
+			name: "all scenarios regress simultaneously",
+			prevScores: map[string]float64{
+				"scenario-a": 98,
+				"scenario-b": 96,
+			},
+			prevIteration: 1,
+			currScores: map[string]float64{
+				"scenario-a": 20,
+				"scenario-b": 10,
+			},
+			currIteration: 2,
+			threshold:     threshold,
+			wantIDs:       []string{"scenario-a", "scenario-b"},
+		},
+		{
+			name:          "custom threshold: prev=85 curr=70 with threshold=80",
+			prevScores:    map[string]float64{"scenario-a": 85},
+			prevIteration: 1,
+			currScores:    map[string]float64{"scenario-a": 70},
+			currIteration: 2,
+			threshold:     80,
+			wantIDs:       []string{"scenario-a"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := detectRegressions(tc.prevScores, tc.prevIteration, tc.currScores, tc.currIteration, tc.threshold)
+
+			if len(tc.wantIDs) == 0 {
+				if len(got) != 0 {
+					t.Errorf("expected no regressions, got %v", got)
+				}
+				return
+			}
+
+			if len(got) != len(tc.wantIDs) {
+				t.Fatalf("len(regressions) = %d, want %d: got=%v", len(got), len(tc.wantIDs), got)
+			}
+			for i, r := range got {
+				if r.ScenarioID != tc.wantIDs[i] {
+					t.Errorf("regression[%d].ScenarioID = %q, want %q", i, r.ScenarioID, tc.wantIDs[i])
+				}
+				prev, ok := tc.prevScores[r.ScenarioID]
+				if !ok {
+					t.Errorf("regression[%d].ScenarioID %q not in prevScores", i, r.ScenarioID)
+					continue
+				}
+				if r.PrevScore != prev {
+					t.Errorf("regression[%d].PrevScore = %v, want %v", i, r.PrevScore, prev)
+				}
+				if r.CurrScore != tc.currScores[r.ScenarioID] {
+					t.Errorf("regression[%d].CurrScore = %v, want %v", i, r.CurrScore, tc.currScores[r.ScenarioID])
+				}
+				if r.PrevIteration != tc.prevIteration {
+					t.Errorf("regression[%d].PrevIteration = %d, want %d", i, r.PrevIteration, tc.prevIteration)
+				}
+				if r.CurrIteration != tc.currIteration {
+					t.Errorf("regression[%d].CurrIteration = %d, want %d", i, r.CurrIteration, tc.currIteration)
+				}
+			}
+		})
+	}
+}
+
+// TestDetectRegressionsOscillation simulates a scenario that oscillates:
+// passes → fails → passes across three consecutive detectRegressions calls.
+func TestDetectRegressionsOscillation(t *testing.T) {
+	const threshold = 95.0
+	runOscillationTest(t, threshold)
+}
+
+// runOscillationTest simulates a scenario that passes → fails → passes.
+func runOscillationTest(t *testing.T, threshold float64) {
+	t.Helper()
+
+	iter1Scores := map[string]float64{"scenario-a": 98} // passes (>= threshold)
+	iter2Scores := map[string]float64{"scenario-a": 40} // fails (< threshold)
+	iter3Scores := map[string]float64{"scenario-a": 97} // passes again
+
+	// Iter 1 → Iter 2: regression expected (98 → 40).
+	r12 := detectRegressions(iter1Scores, 1, iter2Scores, 2, threshold)
+	if len(r12) != 1 || r12[0].ScenarioID != "scenario-a" {
+		t.Errorf("iter1→iter2: expected regression for scenario-a, got %v", r12)
+	}
+
+	// Iter 2 → Iter 3: no regression (prev was 40 < threshold, so no regression).
+	r23 := detectRegressions(iter2Scores, 2, iter3Scores, 3, threshold)
+	if len(r23) != 0 {
+		t.Errorf("iter2→iter3: expected no regressions, got %v", r23)
+	}
+}
+
+func TestFormatRegressions(t *testing.T) {
+	tests := []struct {
+		name        string
+		regressions []Regression
+		wantEmpty   bool
+		wantContain []string
+		wantSorted  bool
+	}{
+		{
+			name:        "empty input returns empty string",
+			regressions: nil,
+			wantEmpty:   true,
+		},
+		{
+			name: "single regression includes id, old score, new score, iterations",
+			regressions: []Regression{
+				{ScenarioID: "login flow", PrevScore: 98, CurrScore: 45, PrevIteration: 1, CurrIteration: 2},
+			},
+			wantContain: []string{"login flow", "98", "45", "1", "2"},
+		},
+		{
+			// Input is pre-sorted as detectRegressions guarantees; verify output order is preserved.
+			name: "multiple regressions sorted by scenario ID",
+			regressions: []Regression{
+				{ScenarioID: "a-scenario", PrevScore: 100, CurrScore: 10, PrevIteration: 2, CurrIteration: 3},
+				{ScenarioID: "z-scenario", PrevScore: 95, CurrScore: 30, PrevIteration: 2, CurrIteration: 3},
+			},
+			wantContain: []string{"z-scenario", "a-scenario"},
+			wantSorted:  true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatRegressions(tc.regressions)
+
+			if tc.wantEmpty {
+				if got != "" {
+					t.Errorf("expected empty string, got %q", got)
+				}
+				return
+			}
+
+			for _, s := range tc.wantContain {
+				if !strings.Contains(got, s) {
+					t.Errorf("output missing %q: %q", s, got)
+				}
+			}
+
+			if tc.wantSorted && len(tc.regressions) > 1 {
+				// Verify a-scenario appears before z-scenario in the output.
+				aIdx := strings.Index(got, "a-scenario")
+				zIdx := strings.Index(got, "z-scenario")
+				if aIdx < 0 || zIdx < 0 || aIdx >= zIdx {
+					t.Errorf("expected a-scenario before z-scenario in output: %q", got)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #113

## Changes
1. **`internal/attractor/regression.go`** (new file)
   - `Regression` struct: `ScenarioID string`, `PrevScore float64`, `CurrScore float64`, `PrevIteration int`, `CurrIteration int`
   - `parseScenarioLine(line string) (id string, score float64, ok bool)` — shared helper that parses both `✓` and `✗` prefixed lines with `(score/100)` format
   - Refactor `parseFailedScenarios` (in attractor.go or fileparse.go) to use `parseScenarioLine` internally, or move it here
   - `parseAllScenarios(failures []string) map[string]float64` — uses `parseScenarioLine`, returns scores for all scenarios
   - `detectRegressions(prevScores map[string]float64, prevIteration int, currScores map[string]float64, currIteration int, threshold float64) []Regression` — returns regressions where prev ≥ threshold and curr < threshold. Takes threshold as parameter, not hardcoded.
   - `formatRegressions(regressions []Regression) string` — body lines only (no header), one line per regression, sorted by scenario ID. Empty string for empty input.

2. **`internal/attractor/attractor.go`** (modify)
   - Add `scenarioScores map[string]float64` and `scenarioScoreIteration int` to `runState`
   - Add `BlockOnRegression bool` to `RunOptions`
   - In `processValidation()`:
     - After recording `s.scoreHistory`, call `parseAllScenarios(failures)`
     - Call `detectRegressions(s.scenarioScores, s.scenarioScoreIteration, currentScores, iter, s.opts.Threshold)`
     - If regressions exist: format, append single `iterationFeedback` entry with kind `feedbackRegression` to `s.history`, log via `slog`
     - If `BlockOnRegression` and regressions exist: skip convergence check (continue loop)
     - **Full replace** `s.scenarioScores = currentScores` and update `s.scenarioScoreIteration`
     - Regression detection and gating run **before** the convergence check

3. **`internal/attractor/prompts.go`** (modify)
   - Add `feedbackRegression = "regression"` constant
   - Add `feedbackHeader` mapping for `feedbackRegression` → `"REGRESSIONS"`

4. **`cmd/octog/main.go`** — **deferred** (not in this PR). `BlockOnRegression` is available programmatically via `RunOptions` but no CLI flag yet. Document this in the PR description.

## Review Findings
- Errors: 0
- Warnings: 2
- Nits: 4
- Assessment: **NEEDS CHANGES**

The logic is correct and well-tested. The two warnings are: (1) `BlockOnRegression` has no CLI wiring so it's unreachable by users, and (2) silent degradation when scenario output format changes. Neither is a correctness bug, but both affect the feature's practical utility and debuggability.
