### PR TITLE
feat(attractor): detect oscillation (A→B cycling) in stall steering

### DIFF
--- a/internal/attractor/attractor.go
+++ b/internal/attractor/attractor.go
@@ -171,6 +171,7 @@ type runState struct {
 	grpcTargetProvider     GRPCTargetProviderFn    // callback to set the gRPC target
 	scenarioScores         map[string]float64      // per-scenario scores from the last validated iteration
 	scenarioScoreIteration int                     // iteration number corresponding to scenarioScores
+	codeHashes             []string                // SHA-256 hashes of generated file sets, in iteration order
 }
 
 func (s *runState) result(iter int, status string) *RunResult {
@@ -371,6 +372,12 @@ func (a *Attractor) iterate(ctx context.Context, rawSpec string, iter int, s *ru
 		return nil, err
 	}
 
+	// Inject oscillation steering when the last 4 code hashes form an A→B→A→B pattern.
+	// Appended after applyMinimalismSuffix for highest salience at the end of the message.
+	if detectOscillation(s.codeHashes) {
+		messages[len(messages)-1].Content += "\n\n" + buildOscillationSteering()
+	}
+
 	// Generate code via LLM.
 	genResp, err := a.llm.Generate(ctx, llm.GenerateRequest{
 		SystemPrompt: buildSystemPrompt(specContent, s.opts.Capabilities, s.opts.Language, s.opts.Genes, s.opts.GeneLanguage),
@@ -400,6 +407,9 @@ func (a *Attractor) iterate(ctx context.Context, rawSpec string, iter int, s *ru
 	if s.patchActive && s.bestFiles != nil && iter > 1 {
 		files = MergeFiles(files, s.bestFiles)
 	}
+
+	// Record the hash of the merged file set for oscillation detection.
+	s.codeHashes = append(s.codeHashes, hashFiles(files))
 
 	// Write files to iteration directory.
 	iterDir := filepath.Join(s.baseDir, fmt.Sprintf("iter_%d", iter))

--- a/internal/attractor/attractor_test.go
+++ b/internal/attractor/attractor_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1529,6 +1530,91 @@ func TestRegressionFeedbackInjected(t *testing.T) {
 	}
 	if !msgsContain(capturedMsgs[2], "scenario-a") {
 		t.Errorf("iteration 3 Generate call should mention the regressed scenario, got: %v", capturedMsgs[2])
+	}
+}
+
+// TestOscillationSteeringInjected verifies that oscillation steering is injected into the
+// Generate call once an A→B→A→B pattern is detected in the code hashes.
+func TestOscillationSteeringInjected(t *testing.T) {
+	// Two distinct valid LLM outputs that produce different file hashes.
+	outputA := `=== FILE: main.go ===
+package main
+
+func main() { /* version A */ }
+=== END FILE ===
+=== FILE: Dockerfile ===
+FROM scratch
+CMD ["./app"]
+=== END FILE ===`
+
+	outputB := `=== FILE: main.go ===
+package main
+
+func main() { /* version B */ }
+=== END FILE ===
+=== FILE: Dockerfile ===
+FROM scratch
+CMD ["./server"]
+=== END FILE ===`
+
+	var callCount atomic.Int32
+	var mu sync.Mutex
+	var capturedMsgs [][]llm.Message
+	client := &mockLLMClient{
+		generateFn: func(_ context.Context, req llm.GenerateRequest) (llm.GenerateResponse, error) {
+			mu.Lock()
+			capturedMsgs = append(capturedMsgs, req.Messages)
+			mu.Unlock()
+			n := callCount.Add(1)
+			if n%2 == 1 {
+				return llm.GenerateResponse{Content: outputA, CostUSD: 0.01}, nil
+			}
+			return llm.GenerateResponse{Content: outputB, CostUSD: 0.01}, nil
+		},
+	}
+
+	// Validation always fails — drives stall without converging.
+	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+		return 30, []string{"not good enough"}, 0.005, nil
+	}
+
+	opts := defaultOpts(t)
+	// StallLimit=4: iter 1 sets best (stallCount=0); iters 2,3,4,5 stall (stallCount 1,2,3,4).
+	// This produces exactly 5 Generate calls, giving oscillation detection a chance to fire on iter 5.
+	opts.StallLimit = 4
+
+	a := New(client, &mockContainerMgr{}, testLogger(), nil)
+	result, err := a.Run(context.Background(), "Build an app", opts, validate, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != StatusStalled {
+		t.Errorf("expected stalled status, got %q", result.Status)
+	}
+
+	if len(capturedMsgs) < 5 {
+		t.Fatalf("expected at least 5 Generate calls, got %d", len(capturedMsgs))
+	}
+
+	msgsContain := func(msgs []llm.Message, sub string) bool {
+		for _, m := range msgs {
+			if strings.Contains(m.Content, sub) {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Iterations 1–4 (indices 0–3): codeHashes has fewer than 4 ABAB entries → no oscillation.
+	for i := range 4 {
+		if msgsContain(capturedMsgs[i], "OSCILLATION DETECTED") {
+			t.Errorf("iteration %d (index %d) should not contain OSCILLATION DETECTED", i+1, i)
+		}
+	}
+
+	// Iteration 5 (index 4): codeHashes = [A,B,A,B] → oscillation detected → steering injected.
+	if !msgsContain(capturedMsgs[4], "OSCILLATION DETECTED") {
+		t.Errorf("iteration 5 (index 4) should contain OSCILLATION DETECTED; messages: %v", capturedMsgs[4])
 	}
 }
 

--- a/internal/attractor/oscillation.go
+++ b/internal/attractor/oscillation.go
@@ -1,0 +1,51 @@
+package attractor
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"maps"
+	"slices"
+)
+
+// hashFiles computes a deterministic SHA-256 hash of the given file map.
+// Files are sorted by path before hashing to ensure order independence.
+// Each entry is encoded as: path + \x00 + content; entries are separated by \x01.
+// Using distinct separators prevents path/content boundary confusion.
+func hashFiles(files map[string]string) string {
+	paths := slices.Sorted(maps.Keys(files))
+	h := sha256.New()
+	for _, p := range paths {
+		// sha256.Hash.Write never returns an error.
+		h.Write([]byte(p))
+		h.Write([]byte{0}) // \x00 separates path from content
+		h.Write([]byte(files[p]))
+		h.Write([]byte{1}) // \x01 separates entries
+	}
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+// detectOscillation returns true when the last 4 hashes form an A→B→A→B pattern.
+// This detects cases where the LLM alternates between two solutions without progress.
+// The degenerate A==A==A==A case also returns true, signaling a hard stall.
+func detectOscillation(hashes []string) bool {
+	n := len(hashes)
+	if n < 4 {
+		return false
+	}
+	return hashes[n-1] == hashes[n-3] && hashes[n-2] == hashes[n-4]
+}
+
+// oscillationSteeringText is injected into the next Generate call when oscillation is detected.
+const oscillationSteeringText = `OSCILLATION DETECTED: Your last several attempts have alternated between the same two implementations without making progress. This is a sign that you are stuck in a local loop.
+
+Break out by trying a fundamentally different approach:
+- Reconsider your core data structures or algorithm
+- Change the architecture rather than tweaking the same implementation
+- If you fixed something in a previous attempt that was then undone, keep that fix and build on it
+
+Do NOT revert to a previous implementation. Make a genuinely new attempt.`
+
+// buildOscillationSteering returns steering text to inject when oscillation is detected.
+func buildOscillationSteering() string {
+	return oscillationSteeringText
+}

--- a/internal/attractor/oscillation_test.go
+++ b/internal/attractor/oscillation_test.go
@@ -1,0 +1,94 @@
+package attractor
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHashFiles(t *testing.T) {
+	t.Run("deterministic", func(t *testing.T) {
+		files := map[string]string{"main.go": "package main"}
+		h1 := hashFiles(files)
+		h2 := hashFiles(files)
+		if h1 != h2 {
+			t.Errorf("expected same hash, got %q and %q", h1, h2)
+		}
+	})
+
+	t.Run("different content", func(t *testing.T) {
+		h1 := hashFiles(map[string]string{"main.go": "package main"})
+		h2 := hashFiles(map[string]string{"main.go": "package other"})
+		if h1 == h2 {
+			t.Error("expected different hashes for different content")
+		}
+	})
+
+	t.Run("order independent", func(t *testing.T) {
+		h1 := hashFiles(map[string]string{"a": "1", "b": "2"})
+		h2 := hashFiles(map[string]string{"b": "2", "a": "1"})
+		if h1 != h2 {
+			t.Errorf("expected same hash regardless of map iteration order, got %q and %q", h1, h2)
+		}
+	})
+
+	t.Run("empty file set", func(t *testing.T) {
+		h := hashFiles(map[string]string{})
+		if h == "" {
+			t.Error("expected non-empty hash for empty file set")
+		}
+	})
+
+	t.Run("nil map", func(t *testing.T) {
+		h := hashFiles(nil)
+		if h == "" {
+			t.Error("expected non-empty hash for nil map")
+		}
+		if h != hashFiles(map[string]string{}) {
+			t.Error("expected nil map to produce same hash as empty map")
+		}
+	})
+
+	t.Run("single file", func(t *testing.T) {
+		h := hashFiles(map[string]string{"file.go": "content"})
+		if h == "" {
+			t.Error("expected non-empty hash for single file")
+		}
+	})
+}
+
+func TestDetectOscillation(t *testing.T) {
+	cases := []struct {
+		name   string
+		hashes []string
+		want   bool
+	}{
+		{"empty", []string{}, false},
+		{"one hash", []string{"A"}, false},
+		{"two hashes", []string{"A", "B"}, false},
+		{"three hashes ABA", []string{"A", "B", "A"}, false},
+		{"four hashes no oscillation", []string{"A", "B", "C", "D"}, false},
+		{"four hashes partial match", []string{"A", "B", "A", "C"}, false},
+		{"four hashes ABAB", []string{"A", "B", "A", "B"}, true},
+		{"five hashes oscillation at end", []string{"C", "A", "B", "A", "B"}, true},
+		{"four identical hashes", []string{"A", "A", "A", "A"}, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := detectOscillation(tc.hashes)
+			if got != tc.want {
+				t.Errorf("detectOscillation(%v) = %v, want %v", tc.hashes, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildOscillationSteering(t *testing.T) {
+	text := buildOscillationSteering()
+	if !strings.Contains(text, "OSCILLATION DETECTED") {
+		t.Error("expected steering text to contain \"OSCILLATION DETECTED\"")
+	}
+	if strings.Contains(text, "STALL NOTICE") {
+		t.Error("expected steering text to not contain \"STALL NOTICE\"")
+	}
+}


### PR DESCRIPTION
Closes #112

## Changes
**1. Create `internal/attractor/oscillation.go`**
- `hashFiles(files map[string]string) string` — SHA-256 of null-delimited path+content pairs, sorted by path. Uses `slices.Sorted(maps.Keys(files))` consistent with existing patterns. Returns hex-encoded hash.
- `detectOscillation(hashes []string) bool` — returns true when `len(hashes) >= 4` and the last 4 entries form an A→B→A→B pattern (`hashes[n-1] == hashes[n-3] && hashes[n-2] == hashes[n-4]`).
- `buildOscillationSteering() string` — returns the oscillation-specific steering text (must not contain "STALL NOTICE"; must contain "OSCILLATION DETECTED").

**2. Modify `internal/attractor/attractor.go`**
- Add `codeHashes []string` field to `runState` struct (after `scenarioScoreIteration`, line 173).
- In `iterate()`, after `MergeFiles` (line 402) and before `writeFiles` (line 406): `s.codeHashes = append(s.codeHashes, hashFiles(files))`.
- In `iterate()`, after `applyMinimalismSuffix` (line 370–372): inject oscillation steering into messages if `detectOscillation(s.codeHashes)` returns true. Follow the same post-hoc pattern as `applyMinimalismSuffix`.

**No changes to `internal/attractor/prompts.go`** — oscillation injection happens in `iterate()`, not in the message builder functions.

## Review Findings
- Errors: 1
- Warnings: 2
- Nits: 3
- Assessment: **NEEDS CHANGES**

The core logic (`detectOscillation`, `hashFiles`, steering injection placement) is correct and well-tested. The primary issue is the misplaced doc comment that will confuse future readers. The hash delimiter weakness is worth hardening but unlikely to cause real collisions.
