### PR TITLE
feat(validator): run container tests before invoking LLM judge

### DIFF
--- a/cmd/octog/main.go
+++ b/cmd/octog/main.go
@@ -345,6 +345,7 @@ func runAttractorLoop(ctx context.Context, logger *slog.Logger, llmClient llm.Cl
 		Capabilities:      caps,
 		Genes:             p.GenesGuide,
 		GeneLanguage:      p.GeneLanguage,
+		TestCommand:       parsedSpec.TestCommand,
 	}
 
 	startedAt := time.Now()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -114,6 +114,7 @@ type Spec struct {
 	Description string
 	Sections    []Section
 	RawContent  string // full markdown, used for LLM prompt
+	TestCommand string // optional test command from "Test-Command: ..." in description
 }
 
 // Section represents a single heading and its content within a spec.
@@ -474,8 +475,9 @@ scores (using scenario `weight` field, default 1.0). See `Aggregate()` in
 // *container.Manager satisfies this automatically.
 type ContainerManager interface {
 	Build(ctx context.Context, dir, tag string) error
-	Run(ctx context.Context, tag string) (url string, stop container.StopFunc, err error)
+	Run(ctx context.Context, tag string) (container.RunResult, container.StopFunc, error)
 	RunMultiPort(ctx context.Context, tag string, extraPorts []string) (container.RunResult, container.StopFunc, error)
+	RunTest(ctx context.Context, containerID, command string) (container.ExecResult, error)
 	WaitHealthy(ctx context.Context, url string, timeout time.Duration) error
 	WaitPort(ctx context.Context, addr string, timeout time.Duration) error
 	StartSession(ctx context.Context, tag string) (session *container.Session, stop container.StopFunc, err error)
@@ -508,6 +510,7 @@ type RunOptions struct {
 	Capabilities      ScenarioCapabilities // detected from loaded scenarios
 	Genes             string               // extracted pattern guide to inject into system prompt (empty = no genes)
 	GeneLanguage      string               // source language of the gene exemplar (for cross-language note)
+	TestCommand       string               // optional shell command run inside HTTP container after health check; non-zero exit = test_fail
 }
 ```
 
@@ -559,6 +562,7 @@ const (
 	OutcomeRunFail    IterationOutcome = "run_fail"
 	OutcomeHealthFail IterationOutcome = "health_fail"
 	OutcomeParseFail  IterationOutcome = "parse_fail"
+	OutcomeTestFail   IterationOutcome = "test_fail"
 )
 ```
 

--- a/internal/attractor/attractor.go
+++ b/internal/attractor/attractor.go
@@ -50,6 +50,7 @@ const (
 	OutcomeRunFail    IterationOutcome = "run_fail"
 	OutcomeHealthFail IterationOutcome = "health_fail"
 	OutcomeParseFail  IterationOutcome = "parse_fail"
+	OutcomeTestFail   IterationOutcome = "test_fail"
 )
 
 // IterationProgress is passed to the progress callback after each iteration completes.
@@ -90,8 +91,9 @@ type ScenarioCapabilities struct {
 // *container.Manager satisfies this automatically.
 type ContainerManager interface {
 	Build(ctx context.Context, dir, tag string) error
-	Run(ctx context.Context, tag string) (url string, stop container.StopFunc, err error)
+	Run(ctx context.Context, tag string) (container.RunResult, container.StopFunc, error)
 	RunMultiPort(ctx context.Context, tag string, extraPorts []string) (container.RunResult, container.StopFunc, error)
+	RunTest(ctx context.Context, containerID, command string) (container.ExecResult, error)
 	WaitHealthy(ctx context.Context, url string, timeout time.Duration) error
 	WaitPort(ctx context.Context, addr string, timeout time.Duration) error
 	StartSession(ctx context.Context, tag string) (session *container.Session, stop container.StopFunc, err error)
@@ -126,6 +128,7 @@ type RunOptions struct {
 	Capabilities      ScenarioCapabilities // detected from loaded scenarios
 	Genes             string               // extracted pattern guide to inject into system prompt (empty = no genes)
 	GeneLanguage      string               // source language of the gene exemplar (for cross-language note)
+	TestCommand       string               // optional shell command run inside HTTP container after health check; non-zero exit = test_fail
 }
 
 // RunResult holds the outcome of an attractor run.
@@ -438,6 +441,7 @@ func (a *Attractor) buildRunValidate(ctx context.Context, iter int, iterDir stri
 
 	caps := s.opts.Capabilities
 	var url string
+	var containerID string
 
 	// When both HTTP and exec capabilities are needed, two containers run from the same image:
 	// - Session container: runs "sleep infinity" for docker exec commands
@@ -467,13 +471,12 @@ func (a *Attractor) buildRunValidate(ctx context.Context, iter int, iterDir stri
 		}
 		defer res.stop()
 		url = res.url
+		containerID = res.containerID
 		s.grpcTargetProvider(res.grpcTarget)
 		defer s.grpcTargetProvider("") // clear after validation
 	case caps.NeedsHTTP || caps.NeedsBrowser || !caps.NeedsExec:
 		// If only HTTP needed, or no capabilities detected (legacy), use Run + WaitHealthy.
-		var stop container.StopFunc
-		var err error
-		url, stop, err = a.containerMgr.Run(ctx, tag)
+		runRes, stop, err := a.containerMgr.Run(ctx, tag)
 		if err != nil {
 			a.logger.Warn("container run failed", "iteration", iter, "error", err)
 			s.lastOutcome = OutcomeRunFail
@@ -482,6 +485,8 @@ func (a *Attractor) buildRunValidate(ctx context.Context, iter int, iterDir stri
 			return a.checkStalled(iter, s), nil
 		}
 		defer stop()
+		url = runRes.URL
+		containerID = runRes.ContainerID
 
 		if err := a.containerMgr.WaitHealthy(ctx, url, s.opts.HealthTimeout); err != nil {
 			a.logger.Warn("health check failed", "iteration", iter, "error", err)
@@ -490,6 +495,11 @@ func (a *Attractor) buildRunValidate(ctx context.Context, iter int, iterDir stri
 			s.recordStall(iter, feedbackHealthError, fmt.Sprintf("Health check failed: %s", err))
 			return a.checkStalled(iter, s), nil
 		}
+	}
+
+	// Run test command before validation when configured and an HTTP container is available.
+	if skip, stall, err := a.runTestCommand(ctx, iter, containerID, s); err != nil || skip {
+		return stall, err
 	}
 
 	satisfaction, failures, valCost, err := validate(ctx, url)
@@ -504,12 +514,44 @@ func (a *Attractor) buildRunValidate(ctx context.Context, iter int, iterDir stri
 	return a.processValidation(iter, satisfaction, failures, files, s)
 }
 
+// runTestCommand executes the test command against the HTTP container when configured.
+// Returns (skip=true, stall, nil) when the test failed — caller must not call validate.
+// Returns (skip=false, nil, nil) when the test passed or test command is empty.
+// Returns (skip=false, nil, err) on hard error.
+func (a *Attractor) runTestCommand(ctx context.Context, iter int, containerID string, s *runState) (skip bool, stall *RunResult, err error) {
+	if s.opts.TestCommand == "" {
+		return false, nil, nil
+	}
+	if containerID == "" {
+		a.logger.Debug("skipping test command: no HTTP container", "iteration", iter)
+		return false, nil, nil
+	}
+	execRes, execErr := a.containerMgr.RunTest(ctx, containerID, s.opts.TestCommand)
+	if execErr != nil {
+		return false, nil, fmt.Errorf("attractor: run test iteration %d: %w", iter, execErr)
+	}
+	if execRes.ExitCode != 0 {
+		output := execRes.Stdout
+		if output != "" && execRes.Stderr != "" {
+			output += "\n"
+		}
+		output += execRes.Stderr
+		a.logger.Warn("test command failed", "iteration", iter, "exit_code", execRes.ExitCode)
+		s.lastOutcome = OutcomeTestFail
+		s.lastSatisfaction = 0
+		s.recordStall(iter, feedbackTestError, fmt.Sprintf("Test command exited %d:\n%s", execRes.ExitCode, truncateFeedback(output, maxFeedbackBytes)))
+		return true, a.checkStalled(iter, s), nil
+	}
+	return false, nil, nil
+}
+
 // grpcContainerResult holds the outputs of startGRPCContainer.
 type grpcContainerResult struct {
-	url        string
-	stop       container.StopFunc
-	grpcTarget string
-	stalled    *RunResult // non-nil if startup failed (stall, not error)
+	url         string
+	stop        container.StopFunc
+	grpcTarget  string
+	containerID string
+	stalled     *RunResult // non-nil if startup failed (stall, not error)
 }
 
 // startGRPCContainer launches a container with gRPC port exposed and waits for readiness.
@@ -530,7 +572,7 @@ func (a *Attractor) startGRPCContainer(ctx context.Context, iter int, tag string
 		return grpcContainerResult{stalled: stallResult}, nil
 	}
 
-	return grpcContainerResult{url: runResult.URL, stop: stop, grpcTarget: grpcTarget}, nil
+	return grpcContainerResult{url: runResult.URL, stop: stop, grpcTarget: grpcTarget, containerID: runResult.ContainerID}, nil
 }
 
 // waitGRPCHealth waits for either HTTP or gRPC port readiness depending on capabilities.

--- a/internal/attractor/attractor_test.go
+++ b/internal/attractor/attractor_test.go
@@ -33,8 +33,9 @@ func (m *mockLLMClient) Judge(_ context.Context, _ llm.JudgeRequest) (llm.JudgeR
 // mockContainerMgr is a configurable mock for ContainerManager.
 type mockContainerMgr struct {
 	buildFn        func(ctx context.Context, dir, tag string) error
-	runFn          func(ctx context.Context, tag string) (string, container.StopFunc, error)
+	runFn          func(ctx context.Context, tag string) (container.RunResult, container.StopFunc, error)
 	runMultiPortFn func(ctx context.Context, tag string, extraPorts []string) (container.RunResult, container.StopFunc, error)
+	runTestFn      func(ctx context.Context, containerID, command string) (container.ExecResult, error)
 	waitHealthyFn  func(ctx context.Context, url string, timeout time.Duration) error
 	waitPortFn     func(ctx context.Context, addr string, timeout time.Duration) error
 	startSessionFn func(ctx context.Context, tag string) (*container.Session, container.StopFunc, error)
@@ -47,11 +48,18 @@ func (m *mockContainerMgr) Build(ctx context.Context, dir, tag string) error {
 	return nil
 }
 
-func (m *mockContainerMgr) Run(ctx context.Context, tag string) (string, container.StopFunc, error) {
+func (m *mockContainerMgr) Run(ctx context.Context, tag string) (container.RunResult, container.StopFunc, error) {
 	if m.runFn != nil {
 		return m.runFn(ctx, tag)
 	}
-	return "http://127.0.0.1:9999", func() {}, nil
+	return container.RunResult{URL: "http://127.0.0.1:9999", ContainerID: "mock-container-id"}, func() {}, nil
+}
+
+func (m *mockContainerMgr) RunTest(ctx context.Context, containerID, command string) (container.ExecResult, error) {
+	if m.runTestFn != nil {
+		return m.runTestFn(ctx, containerID, command)
+	}
+	return container.ExecResult{ExitCode: 0}, nil
 }
 
 func (m *mockContainerMgr) RunMultiPort(ctx context.Context, tag string, extraPorts []string) (container.RunResult, container.StopFunc, error) {
@@ -465,12 +473,12 @@ func TestContainerRunFailure(t *testing.T) {
 		},
 	}
 	mgr := &mockContainerMgr{
-		runFn: func(_ context.Context, _ string) (string, container.StopFunc, error) {
+		runFn: func(_ context.Context, _ string) (container.RunResult, container.StopFunc, error) {
 			n := runCount.Add(1)
 			if n == 1 {
-				return "", nil, fmt.Errorf("port conflict")
+				return container.RunResult{}, nil, fmt.Errorf("port conflict")
 			}
-			return "http://127.0.0.1:9999", func() {}, nil
+			return container.RunResult{URL: "http://127.0.0.1:9999", ContainerID: "mock-container-id"}, func() {}, nil
 		},
 	}
 	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
@@ -495,9 +503,9 @@ func TestNeedsBrowserTriggersHTTPContainer(t *testing.T) {
 		},
 	}
 	mgr := &mockContainerMgr{
-		runFn: func(_ context.Context, _ string) (string, container.StopFunc, error) {
+		runFn: func(_ context.Context, _ string) (container.RunResult, container.StopFunc, error) {
 			runCalled = true
-			return "http://127.0.0.1:9999", func() {}, nil
+			return container.RunResult{URL: "http://127.0.0.1:9999", ContainerID: "mock-container-id"}, func() {}, nil
 		},
 		waitHealthyFn: func(_ context.Context, _ string, _ time.Duration) error {
 			waitHealthyCalled = true
@@ -1663,5 +1671,153 @@ func TestBlockOnRegressionPreventsConvergence(t *testing.T) {
 	}
 	if result.Iterations < 3 {
 		t.Errorf("expected at least 3 iterations (regression blocked iter 2), got %d", result.Iterations)
+	}
+}
+
+func TestTestCommandEmpty_SkipsMechanicalTest(t *testing.T) {
+	var runTestCalled bool
+	client := &mockLLMClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
+		},
+	}
+	mgr := &mockContainerMgr{
+		runTestFn: func(_ context.Context, _, _ string) (container.ExecResult, error) {
+			runTestCalled = true
+			return container.ExecResult{ExitCode: 0}, nil
+		},
+	}
+	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+		return 100, nil, 0.005, nil
+	}
+
+	opts := defaultOpts(t)
+	// TestCommand is empty — RunTest should never be called.
+	opts.TestCommand = ""
+
+	a := New(client, mgr, testLogger(), nil)
+	result, err := a.Run(context.Background(), "Build an app", opts, validate, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != StatusConverged {
+		t.Errorf("expected converged, got %q", result.Status)
+	}
+	if runTestCalled {
+		t.Error("RunTest should not be called when TestCommand is empty")
+	}
+}
+
+func TestTestCommandExitZero_ProceedsToJudge(t *testing.T) {
+	var validateCalled bool
+	client := &mockLLMClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
+		},
+	}
+	mgr := &mockContainerMgr{
+		runTestFn: func(_ context.Context, _, _ string) (container.ExecResult, error) {
+			return container.ExecResult{ExitCode: 0, Stdout: "ok\n"}, nil
+		},
+	}
+	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+		validateCalled = true
+		return 100, nil, 0.005, nil
+	}
+
+	opts := defaultOpts(t)
+	opts.TestCommand = "go test ./..."
+
+	a := New(client, mgr, testLogger(), nil)
+	result, err := a.Run(context.Background(), "Build an app", opts, validate, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != StatusConverged {
+		t.Errorf("expected converged, got %q", result.Status)
+	}
+	if !validateCalled {
+		t.Error("validate should be called when test command exits 0")
+	}
+}
+
+func TestTestCommandExitNonZero_SkipsJudge(t *testing.T) {
+	var validateCalled bool
+	var lastUserMsg string
+	var lastOutcome IterationOutcome
+	client := &mockLLMClient{
+		generateFn: func(_ context.Context, req llm.GenerateRequest) (llm.GenerateResponse, error) {
+			if len(req.Messages) > 0 {
+				lastUserMsg = req.Messages[0].Content
+			}
+			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
+		},
+	}
+	mgr := &mockContainerMgr{
+		runTestFn: func(_ context.Context, _, _ string) (container.ExecResult, error) {
+			return container.ExecResult{ExitCode: 1, Stderr: "FAIL: test_foo\n"}, nil
+		},
+	}
+	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+		validateCalled = true
+		return 100, nil, 0.005, nil
+	}
+
+	opts := defaultOpts(t)
+	opts.TestCommand = "go test ./..."
+	opts.Progress = func(p IterationProgress) {
+		lastOutcome = p.Outcome
+	}
+
+	a := New(client, mgr, testLogger(), nil)
+	result, err := a.Run(context.Background(), "Build an app", opts, validate, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != StatusStalled {
+		t.Errorf("expected stalled (all test_fail), got %q", result.Status)
+	}
+	if validateCalled {
+		t.Error("validate should NOT be called when test command exits non-zero")
+	}
+	if lastOutcome != OutcomeTestFail {
+		t.Errorf("expected outcome %q, got %q", OutcomeTestFail, lastOutcome)
+	}
+	// Second iteration prompt should contain TEST FAILURE header.
+	if !strings.Contains(lastUserMsg, "TEST FAILURE") {
+		t.Errorf("expected TEST FAILURE in user message, got: %s", lastUserMsg)
+	}
+}
+
+func TestTestCommandOutput_IncludedInFeedback(t *testing.T) {
+	const testOutput = "error: assertion failed in test_bar"
+	var lastUserMsg string
+	client := &mockLLMClient{
+		generateFn: func(_ context.Context, req llm.GenerateRequest) (llm.GenerateResponse, error) {
+			if len(req.Messages) > 0 {
+				lastUserMsg = req.Messages[0].Content
+			}
+			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
+		},
+	}
+	mgr := &mockContainerMgr{
+		runTestFn: func(_ context.Context, _, _ string) (container.ExecResult, error) {
+			return container.ExecResult{ExitCode: 1, Stdout: testOutput, Stderr: ""}, nil
+		},
+	}
+	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+		return 100, nil, 0.005, nil
+	}
+
+	opts := defaultOpts(t)
+	opts.TestCommand = "go test ./..."
+
+	a := New(client, mgr, testLogger(), nil)
+	_, err := a.Run(context.Background(), "Build an app", opts, validate, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(lastUserMsg, testOutput) {
+		t.Errorf("expected test output %q in user message, got: %s", testOutput, lastUserMsg)
 	}
 }

--- a/internal/attractor/prompts.go
+++ b/internal/attractor/prompts.go
@@ -17,6 +17,7 @@ const (
 	feedbackParseError  = "parse_error"
 	feedbackRegression  = "regression"
 	feedbackRunError    = "run_error"
+	feedbackTestError   = "test_error"
 	feedbackValidation  = "validation"
 )
 
@@ -59,6 +60,8 @@ func feedbackHeader(kind string) string {
 		return "REGRESSIONS"
 	case feedbackRunError:
 		return "RUN FAILURE"
+	case feedbackTestError:
+		return "TEST FAILURE"
 	case feedbackValidation:
 		return "VALIDATION FAILURES"
 	default:

--- a/internal/container/docker.go
+++ b/internal/container/docker.go
@@ -153,14 +153,14 @@ func parseBuildLog(r io.Reader, logger *slog.Logger) error {
 	return nil
 }
 
-// Run starts a container from the given image tag and returns the base URL and
+// Run starts a container from the given image tag and returns a RunResult and
 // a stop function. The container must expose port 8080.
 //
 // Cleanup on partial failure:
 //   - ContainerCreate fails  → return error (nothing to clean up)
 //   - ContainerStart fails   → ContainerRemove(force) the created container
 //   - ContainerInspect fails → ContainerStop + ContainerRemove
-func (m *Manager) Run(ctx context.Context, tag string) (url string, stop StopFunc, err error) {
+func (m *Manager) Run(ctx context.Context, tag string) (RunResult, StopFunc, error) {
 	const containerPort = nat.Port("8080/tcp")
 
 	createResp, err := m.docker.ContainerCreate(ctx,
@@ -176,26 +176,26 @@ func (m *Manager) Run(ctx context.Context, tag string) (url string, stop StopFun
 		nil, nil, "",
 	)
 	if err != nil {
-		return "", nil, fmt.Errorf("container: create: %w", err)
+		return RunResult{}, nil, fmt.Errorf("container: create: %w", err)
 	}
 	containerID := createResp.ID
 
 	if err := m.docker.ContainerStart(ctx, containerID, dockercontainer.StartOptions{}); err != nil {
 		// Container was created but never started — remove only, no stop needed.
 		_ = m.docker.ContainerRemove(context.Background(), containerID, dockercontainer.RemoveOptions{Force: true})
-		return "", nil, fmt.Errorf("container: start: %w", err)
+		return RunResult{}, nil, fmt.Errorf("container: start: %w", err)
 	}
 
 	inspectResp, err := m.docker.ContainerInspect(ctx, containerID)
 	if err != nil {
 		m.stopAndRemove(containerID)
-		return "", nil, fmt.Errorf("container: inspect: %w", err)
+		return RunResult{}, nil, fmt.Errorf("container: inspect: %w", err)
 	}
 
 	bindings, ok := inspectResp.NetworkSettings.Ports[containerPort]
 	if !ok || len(bindings) == 0 {
 		m.stopAndRemove(containerID)
-		return "", nil, errNoPortBinding
+		return RunResult{}, nil, errNoPortBinding
 	}
 
 	containerURL := "http://127.0.0.1:" + bindings[0].HostPort
@@ -206,7 +206,7 @@ func (m *Manager) Run(ctx context.Context, tag string) (url string, stop StopFun
 		shortID = shortID[:12]
 	}
 	m.logger.Info("container started", "id", shortID, "url", containerURL)
-	return containerURL, stopFn, nil
+	return RunResult{URL: containerURL, ContainerID: containerID}, stopFn, nil
 }
 
 // stopAndRemove stops and forcibly removes a running container.
@@ -217,10 +217,11 @@ func (m *Manager) stopAndRemove(containerID string) {
 	_ = m.docker.ContainerRemove(ctx, containerID, dockercontainer.RemoveOptions{Force: true})
 }
 
-// RunResult holds the container URL and any extra port bindings.
+// RunResult holds the container URL, container ID, and any extra port bindings.
 type RunResult struct {
-	URL        string            // HTTP base URL (port 8080)
-	ExtraPorts map[string]string // e.g. "50051/tcp" -> "127.0.0.1:54321"
+	URL         string            // HTTP base URL (port 8080)
+	ContainerID string            // Docker container ID
+	ExtraPorts  map[string]string // e.g. "50051/tcp" -> "127.0.0.1:54321"
 }
 
 // RunMultiPort starts a container exposing port 8080 (optional) plus additional ports.
@@ -266,7 +267,8 @@ func (m *Manager) RunMultiPort(ctx context.Context, tag string, extraPorts []str
 	}
 
 	result := RunResult{
-		ExtraPorts: make(map[string]string, len(extraPorts)),
+		ContainerID: containerID,
+		ExtraPorts:  make(map[string]string, len(extraPorts)),
 	}
 
 	// HTTP port is optional: populate URL only if 8080 is bound.
@@ -590,6 +592,18 @@ func (m *Manager) StartSession(ctx context.Context, tag string) (*Session, StopF
 	}
 	stopFn := func() { m.stopAndRemove(containerID) }
 	return session, stopFn, nil
+}
+
+// RunTest executes a shell command inside a running container and returns the result.
+// It creates an ephemeral exec against an existing containerID using sh -c.
+// The timeout defaults to 60 seconds.
+func (m *Manager) RunTest(ctx context.Context, containerID, command string) (ExecResult, error) {
+	session := &Session{
+		containerID: containerID,
+		docker:      m.docker,
+		logger:      m.logger,
+	}
+	return session.Exec(ctx, command, ExecOptions{Timeout: 60 * time.Second})
 }
 
 // copyFileToTar opens path and writes its contents to tw.

--- a/internal/container/docker_integration_test.go
+++ b/internal/container/docker_integration_test.go
@@ -51,18 +51,18 @@ func TestIntegrationBuildRunWaitHealthy(t *testing.T) {
 	}
 
 	t.Logf("starting container")
-	url, stop, err := m.Run(context.Background(), tag)
+	result, stop, err := m.Run(context.Background(), tag)
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
 	defer stop()
 
-	t.Logf("waiting for container at %s", url)
-	if err := m.WaitHealthy(context.Background(), url, 30*time.Second); err != nil {
+	t.Logf("waiting for container at %s", result.URL)
+	if err := m.WaitHealthy(context.Background(), result.URL, 30*time.Second); err != nil {
 		t.Fatalf("WaitHealthy: %v", err)
 	}
 
-	resp, err := http.Get(url + "/") //nolint:gosec,noctx // integration test, URL is controlled local container
+	resp, err := http.Get(result.URL + "/") //nolint:gosec,noctx // integration test, URL is controlled local container
 	if err != nil {
 		t.Fatalf("GET /: %v", err)
 	}
@@ -72,4 +72,61 @@ func TestIntegrationBuildRunWaitHealthy(t *testing.T) {
 		t.Errorf("GET / returned status %d, want < 500", resp.StatusCode)
 	}
 	t.Logf("container responded with %d", resp.StatusCode)
+}
+
+func TestIntegrationRunTest(t *testing.T) {
+	logger := newTestLogger()
+	m, err := NewManager(logger)
+	if err != nil {
+		t.Skipf("Docker not available: %v", err)
+	}
+	defer func() { _ = m.Close() }()
+
+	type pinger interface {
+		Ping(context.Context) (dockertypes.Ping, error)
+	}
+	if p, ok := m.docker.(pinger); ok {
+		if _, err := p.Ping(context.Background()); err != nil {
+			t.Skipf("Docker daemon not available: %v", err)
+		}
+	}
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte(integrationDockerfile), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	tag := fmt.Sprintf("octopusgarden-integration-runtest:%d", time.Now().UnixNano())
+	if err := m.Build(context.Background(), dir, tag); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	result, stop, err := m.Run(context.Background(), tag)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	defer stop()
+
+	if err := m.WaitHealthy(context.Background(), result.URL, 30*time.Second); err != nil {
+		t.Fatalf("WaitHealthy: %v", err)
+	}
+
+	// Test command that exits 1 — verifies non-zero exit is captured.
+	execResult, err := m.RunTest(context.Background(), result.ContainerID, "exit 1")
+	if err != nil {
+		t.Fatalf("RunTest: %v", err)
+	}
+	if execResult.ExitCode != 1 {
+		t.Errorf("expected exit code 1, got %d", execResult.ExitCode)
+	}
+	t.Logf("RunTest exit code: %d", execResult.ExitCode)
+
+	// Test command that exits 0 — verifies success path works.
+	execResult, err = m.RunTest(context.Background(), result.ContainerID, "echo hello")
+	if err != nil {
+		t.Fatalf("RunTest echo: %v", err)
+	}
+	if execResult.ExitCode != 0 {
+		t.Errorf("expected exit code 0, got %d", execResult.ExitCode)
+	}
 }

--- a/internal/container/docker_test.go
+++ b/internal/container/docker_test.go
@@ -313,15 +313,18 @@ func defaultRunMock(hostPort string) *mockDockerAPI {
 
 func TestRunSuccess(t *testing.T) {
 	m := newManager(defaultRunMock("49152"), nil, newTestLogger())
-	url, stop, err := m.Run(context.Background(), "test:latest")
+	result, stop, err := m.Run(context.Background(), "test:latest")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	defer stop()
 
 	want := "http://127.0.0.1:49152"
-	if url != want {
-		t.Errorf("url = %q, want %q", url, want)
+	if result.URL != want {
+		t.Errorf("url = %q, want %q", result.URL, want)
+	}
+	if result.ContainerID != testContainerID {
+		t.Errorf("ContainerID = %q, want %q", result.ContainerID, testContainerID)
 	}
 }
 
@@ -735,6 +738,60 @@ func TestSessionExecCreateError(t *testing.T) {
 	}
 	if !errors.Is(err, errExecFailed) {
 		t.Errorf("expected errExecFailed, got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RunTest tests
+// ---------------------------------------------------------------------------
+
+func TestRunTestSuccess(t *testing.T) {
+	mock := defaultSessionMock()
+	mock.containerExecCreateFunc = func(_ context.Context, _ string, _ dockercontainer.ExecOptions) (dockercontainer.ExecCreateResponse, error) {
+		return dockercontainer.ExecCreateResponse{ID: "exec-test-123"}, nil
+	}
+	mock.containerExecAttachFunc = func(_ context.Context, _ string, _ dockercontainer.ExecAttachOptions) (dockertypes.HijackedResponse, error) {
+		return fakeHijackedResponse(buildMuxStream("all tests passed\n", "")), nil
+	}
+	mock.containerExecInspectFunc = func(_ context.Context, _ string) (dockercontainer.ExecInspect, error) {
+		return dockercontainer.ExecInspect{ExitCode: 0}, nil
+	}
+
+	m := newManager(mock, nil, newTestLogger())
+	result, err := m.RunTest(context.Background(), testContainerID, "go test ./...")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0", result.ExitCode)
+	}
+	if !strings.Contains(result.Stdout, "all tests passed") {
+		t.Errorf("expected stdout to contain 'all tests passed', got %q", result.Stdout)
+	}
+}
+
+func TestRunTestNonZeroExit(t *testing.T) {
+	mock := defaultSessionMock()
+	mock.containerExecCreateFunc = func(_ context.Context, _ string, _ dockercontainer.ExecOptions) (dockercontainer.ExecCreateResponse, error) {
+		return dockercontainer.ExecCreateResponse{ID: "exec-test-456"}, nil
+	}
+	mock.containerExecAttachFunc = func(_ context.Context, _ string, _ dockercontainer.ExecAttachOptions) (dockertypes.HijackedResponse, error) {
+		return fakeHijackedResponse(buildMuxStream("", "FAIL: test_foo\n")), nil
+	}
+	mock.containerExecInspectFunc = func(_ context.Context, _ string) (dockercontainer.ExecInspect, error) {
+		return dockercontainer.ExecInspect{ExitCode: 1}, nil
+	}
+
+	m := newManager(mock, nil, newTestLogger())
+	result, err := m.RunTest(context.Background(), testContainerID, "go test ./...")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ExitCode != 1 {
+		t.Errorf("ExitCode = %d, want 1", result.ExitCode)
+	}
+	if !strings.Contains(result.Stderr, "FAIL: test_foo") {
+		t.Errorf("expected stderr to contain 'FAIL: test_foo', got %q", result.Stderr)
 	}
 }
 

--- a/internal/lint/gen/main.go
+++ b/internal/lint/gen/main.go
@@ -125,11 +125,21 @@ Violations are reported but do not block usage.
 | {{.ID}} | {{.Summary}}{{with .Detail}} — {{.}}{{end}} |
 {{- end}}
 
+## Metadata
+
+Optional key-value fields can appear in the description text (between the title heading and the
+next section heading). They use the format ` + "`Key: value`" + ` on their own line.
+
+| Key | Description |
+|-----|-------------|
+| ` + "`Test-Command`" + ` | Shell command run inside the HTTP container after a successful health check. A non-zero exit code is treated as a mechanical failure (like a build failure) and triggers another generation iteration. The command runs via ` + "`sh -c`" + ` with a 60-second timeout. Example: ` + "`Test-Command: go test ./...`" + ` |
+
 ## Notes
 
 - Headings inside fenced code blocks (` + "```" + ` or ` + "~~~" + `) are ignored by the parser.
 - The spec content is passed as a string to the attractor — file paths are never exposed.
 - Only ATX-style headings (` + "`# Title`" + `) are recognized; setext-style is not supported.
+- ` + "`Test-Command`" + ` requires an HTTP container (i.e. scenarios with HTTP request steps). It has no effect when only exec-only or gRPC containers are started.
 `
 
 var scenarioTmpl = `# Scenario Format Reference

--- a/internal/observability/container.go
+++ b/internal/observability/container.go
@@ -50,29 +50,47 @@ func (t *TracingContainerManager) Build(ctx context.Context, dir, tag string) er
 
 // Run delegates to the inner manager and records a container.run span.
 // The span covers the full container lifetime — it ends when the returned StopFunc is called.
-func (t *TracingContainerManager) Run(ctx context.Context, tag string) (string, container.StopFunc, error) {
+func (t *TracingContainerManager) Run(ctx context.Context, tag string) (container.RunResult, container.StopFunc, error) {
 	ctx, span := t.tracer.Start(ctx, "container.run", trace.WithAttributes(
 		attribute.String("container.tag", tag),
 	))
 
-	url, stop, err := t.inner.Run(ctx, tag)
+	result, stop, err := t.inner.Run(ctx, tag)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		span.SetAttributes(attribute.Bool("container.success", false))
 		span.End()
-		return url, stop, err
+		return result, stop, err
 	}
 
 	span.SetAttributes(
 		attribute.Bool("container.success", true),
-		attribute.String("container.url", url),
+		attribute.String("container.url", result.URL),
 	)
 	wrappedStop := func() {
 		stop()
 		span.End()
 	}
-	return url, wrappedStop, nil
+	return result, wrappedStop, nil
+}
+
+// RunTest delegates to the inner manager and records a container.run_test span.
+func (t *TracingContainerManager) RunTest(ctx context.Context, containerID, command string) (container.ExecResult, error) {
+	ctx, span := t.tracer.Start(ctx, "container.run_test", trace.WithAttributes(
+		attribute.String("container.id", containerID),
+	))
+	defer span.End()
+
+	result, err := t.inner.RunTest(ctx, containerID, command)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return result, err
+	}
+
+	span.SetAttributes(attribute.Int("container.exit_code", result.ExitCode))
+	return result, nil
 }
 
 // WaitHealthy delegates to the inner manager and records a container.health span.

--- a/internal/observability/container_test.go
+++ b/internal/observability/container_test.go
@@ -10,8 +10,9 @@ import (
 
 type mockContainerMgr struct {
 	buildFn        func(ctx context.Context, dir, tag string) error
-	runFn          func(ctx context.Context, tag string) (string, container.StopFunc, error)
+	runFn          func(ctx context.Context, tag string) (container.RunResult, container.StopFunc, error)
 	runMultiPortFn func(ctx context.Context, tag string, extraPorts []string) (container.RunResult, container.StopFunc, error)
+	runTestFn      func(ctx context.Context, containerID, command string) (container.ExecResult, error)
 	waitHealthyFn  func(ctx context.Context, url string, timeout time.Duration) error
 	waitPortFn     func(ctx context.Context, addr string, timeout time.Duration) error
 	startSessionFn func(ctx context.Context, tag string) (*container.Session, container.StopFunc, error)
@@ -21,8 +22,15 @@ func (m *mockContainerMgr) Build(ctx context.Context, dir, tag string) error {
 	return m.buildFn(ctx, dir, tag)
 }
 
-func (m *mockContainerMgr) Run(ctx context.Context, tag string) (string, container.StopFunc, error) {
+func (m *mockContainerMgr) Run(ctx context.Context, tag string) (container.RunResult, container.StopFunc, error) {
 	return m.runFn(ctx, tag)
+}
+
+func (m *mockContainerMgr) RunTest(ctx context.Context, containerID, command string) (container.ExecResult, error) {
+	if m.runTestFn != nil {
+		return m.runTestFn(ctx, containerID, command)
+	}
+	return container.ExecResult{ExitCode: 0}, nil
 }
 
 func (m *mockContainerMgr) RunMultiPort(ctx context.Context, tag string, extraPorts []string) (container.RunResult, container.StopFunc, error) {
@@ -103,8 +111,8 @@ func TestTracingContainerRun(t *testing.T) {
 			defer func() { _ = tp.Shutdown(context.Background()) }()
 
 			mgr := &mockContainerMgr{
-				runFn: func(_ context.Context, _ string) (string, container.StopFunc, error) {
-					return tt.url, func() {}, tt.err
+				runFn: func(_ context.Context, _ string) (container.RunResult, container.StopFunc, error) {
+					return container.RunResult{URL: tt.url, ContainerID: "test-id"}, func() {}, tt.err
 				},
 			}
 
@@ -301,6 +309,49 @@ func TestTracingContainerSession(t *testing.T) {
 			if spans[0].Name != "container.session" {
 				t.Errorf("expected span name container.session, got %q", spans[0].Name)
 			}
+		})
+	}
+}
+
+func TestTracingContainerRunTest(t *testing.T) {
+	tests := []struct {
+		name     string
+		exitCode int
+		err      error
+		wantErr  bool
+	}{
+		{name: "success exit 0", exitCode: 0},
+		{name: "non-zero exit", exitCode: 1},
+		{name: "error", err: errMock, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exp, tp := newTestTP()
+			defer func() { _ = tp.Shutdown(context.Background()) }()
+
+			mgr := &mockContainerMgr{
+				runTestFn: func(_ context.Context, _, _ string) (container.ExecResult, error) {
+					return container.ExecResult{ExitCode: tt.exitCode}, tt.err
+				},
+			}
+
+			traced := NewTracingContainerManager(mgr, tp)
+			_, err := traced.RunTest(context.Background(), "container-abc", "go test ./...")
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("wantErr=%v, got %v", tt.wantErr, err)
+			}
+
+			_ = tp.ForceFlush(context.Background())
+			spans := exp.GetSpans()
+			if len(spans) != 1 {
+				t.Fatalf("expected 1 span, got %d", len(spans))
+			}
+			if spans[0].Name != "container.run_test" {
+				t.Errorf("expected span name container.run_test, got %q", spans[0].Name)
+			}
+			assertHasAttr(t, spans[0].Attributes, "container.id")
 		})
 	}
 }

--- a/internal/spec/parser.go
+++ b/internal/spec/parser.go
@@ -65,6 +65,7 @@ func Parse(r io.Reader) (Spec, error) {
 		descEnd = headings[1].line
 	}
 	spec.Description = collectContent(lines, headings[0].line+1, descEnd)
+	spec.TestCommand = extractTestCommand(lines[headings[0].line+1 : descEnd])
 
 	// Build sections from all headings (including the first).
 	sections := make([]Section, 0, len(headings))
@@ -127,6 +128,19 @@ func parseHeading(line string) (int, string) {
 		return 0, ""
 	}
 	return level, text
+}
+
+// extractTestCommand scans lines for "Test-Command: <value>" and returns the value,
+// or empty string if not found. The key comparison is case-insensitive.
+func extractTestCommand(lines []string) string {
+	const testCommandPrefix = "test-command:"
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(strings.ToLower(trimmed), testCommandPrefix) {
+			return strings.TrimSpace(trimmed[len(testCommandPrefix):])
+		}
+	}
+	return ""
 }
 
 // collectContent joins lines[start:end], trimming leading/trailing blank lines.

--- a/internal/spec/parser_test.go
+++ b/internal/spec/parser_test.go
@@ -27,13 +27,14 @@ Each item has an id, name, description, and created_at timestamp.
 
 func TestParse(t *testing.T) {
 	tests := []struct {
-		name          string
-		input         string
-		wantTitle     string
-		wantDesc      string
-		wantSections  int
-		wantErr       error
-		checkSections func(t *testing.T, sections []Section)
+		name            string
+		input           string
+		wantTitle       string
+		wantDesc        string
+		wantSections    int
+		wantErr         error
+		wantTestCommand string
+		checkSections   func(t *testing.T, sections []Section)
 	}{
 		{
 			name:         "valid spec",
@@ -176,6 +177,30 @@ func TestParse(t *testing.T) {
 			wantTitle:    "",
 			wantSections: 0,
 		},
+		{
+			name:            "test command present",
+			input:           "# My App\n\nA description.\nTest-Command: go test ./...\n\n## Section\n\nContent\n",
+			wantTitle:       "My App",
+			wantDesc:        "A description.\nTest-Command: go test ./...",
+			wantSections:    2,
+			wantTestCommand: "go test ./...",
+		},
+		{
+			name:            "test command absent",
+			input:           "# My App\n\nA description.\n\n## Section\n\nContent\n",
+			wantTitle:       "My App",
+			wantDesc:        "A description.",
+			wantSections:    2,
+			wantTestCommand: "",
+		},
+		{
+			name:            "test command with special chars",
+			input:           "# My App\n\nDescription.\nTest-Command: npm test && exit 0\n",
+			wantTitle:       "My App",
+			wantDesc:        "Description.\nTest-Command: npm test && exit 0",
+			wantSections:    1,
+			wantTestCommand: "npm test && exit 0",
+		},
 	}
 
 	for _, tt := range tests {
@@ -195,6 +220,9 @@ func TestParse(t *testing.T) {
 			}
 			if got.Description != tt.wantDesc {
 				t.Errorf("Description = %q, want %q", got.Description, tt.wantDesc)
+			}
+			if got.TestCommand != tt.wantTestCommand {
+				t.Errorf("TestCommand = %q, want %q", got.TestCommand, tt.wantTestCommand)
 			}
 			if len(got.Sections) != tt.wantSections {
 				t.Errorf("len(Sections) = %d, want %d", len(got.Sections), tt.wantSections)

--- a/internal/spec/types.go
+++ b/internal/spec/types.go
@@ -6,6 +6,7 @@ type Spec struct {
 	Description string
 	Sections    []Section
 	RawContent  string // full markdown, used for LLM prompt
+	TestCommand string // optional test command from "Test-Command: ..." in description
 }
 
 // Section represents a single heading and its content within a spec.

--- a/schemas/spec-format.md
+++ b/schemas/spec-format.md
@@ -25,8 +25,18 @@ Violations are reported but do not block usage.
 | S005 | headings at the same level should be unique |
 | S006 | fenced code blocks should be closed |
 
+## Metadata
+
+Optional key-value fields can appear in the description text (between the title heading and the
+next section heading). They use the format `Key: value` on their own line.
+
+| Key | Description |
+|-----|-------------|
+| `Test-Command` | Shell command run inside the HTTP container after a successful health check. A non-zero exit code is treated as a mechanical failure (like a build failure) and triggers another generation iteration. The command runs via `sh -c` with a 60-second timeout. Example: `Test-Command: go test ./...` |
+
 ## Notes
 
 - Headings inside fenced code blocks (``` or ~~~) are ignored by the parser.
 - The spec content is passed as a string to the attractor — file paths are never exposed.
 - Only ATX-style headings (`# Title`) are recognized; setext-style is not supported.
+- `Test-Command` requires an HTTP container (i.e. scenarios with HTTP request steps). It has no effect when only exec-only or gRPC containers are started.


### PR DESCRIPTION
Closes #115

## Changes
**`internal/spec/types.go`** — Add `TestCommand string` field to `Spec`.

**`internal/spec/parser.go`** — After computing `spec.Description`, scan description lines for `Test-Command: <value>`. Extract into `spec.TestCommand`. If absent, remains empty.

**`internal/container/docker.go`** — Three changes:
1. Add `ContainerID string` field to `RunResult`.
2. Change `Run` to return `(RunResult, StopFunc, error)` instead of `(string, StopFunc, error)`. Populate `RunResult.URL` and `RunResult.ContainerID`. This unifies return types.
3. Populate `ContainerID` in `RunMultiPort`.
4. Add `RunTest(ctx, containerID, command string) (ExecResult, error)` to `Manager`. Implementation: construct a `Session{containerID, m.docker, m.logger}` and call `session.Exec(ctx, command, ExecOptions{Timeout: 60 * time.Second})`. No code duplication.

**`internal/attractor/attractor.go`** — Four changes:
1. Add `TestCommand string` to `RunOptions`.
2. Add `OutcomeTestFail IterationOutcome = "test_fail"`.
3. Add `RunTest(ctx, containerID, command string) (container.ExecResult, error)` to `ContainerManager` interface.
4. In `buildRunValidate`, after health check passes, if `opts.TestCommand` is non-empty: call `containerMgr.RunTest(ctx, containerID, testCommand)`. If exit code != 0, set outcome to `OutcomeTestFail`, score 0, record stall with `feedbackTestError` kind, truncate output to `maxFeedbackBytes`, skip `validate()`, return. Get `containerID` from `RunResult.ContainerID` (both `Run` and `RunMultiPort` paths). For the gRPC path, get it from `RunMultiPort`'s `RunResult`.

**`internal/attractor/prompts.go`** — Add `feedbackTestError = "test_error"` constant. Add `"TEST FAILURE"` case to `feedbackHeader`.

**`internal/observability/container.go`** — Update `Run` method signature to match new `(RunResult, StopFunc, error)` return. Add `RunTest` method that delegates to inner and records a `container.run_test` span.

**`cmd/octog/main.go`** — Pass `parsedSpec.TestCommand` into `RunOptions.TestCommand`.

**`schemas/spec-format.md`** — Document the `Test-Command:` metadata field.

## Review Findings
- Errors: 0
- Warnings: 1
- Nits: 5
- Assessment: **NEEDS CHANGES**

The warning (case-sensitive metadata parsing) is the only actionable item. The feature is well-structured: clean separation between spec parsing, container exec, and attractor loop integration. The `Run()` return type change from bare `string` to `RunResult` is a good incremental improvement that aligns `Run` with `RunMultiPort`. Test coverage is thorough across all layers (spec parser, container, attractor, observability).
