### PR TITLE
feat(cmd): add spec ambiguity preflight check

### DIFF
--- a/cmd/octog/main.go
+++ b/cmd/octog/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/foundatron/octopusgarden/internal/lint"
 	"github.com/foundatron/octopusgarden/internal/llm"
 	"github.com/foundatron/octopusgarden/internal/observability"
+	"github.com/foundatron/octopusgarden/internal/preflight"
 	"github.com/foundatron/octopusgarden/internal/scenario"
 	"github.com/foundatron/octopusgarden/internal/spec"
 	"github.com/foundatron/octopusgarden/internal/store"
@@ -55,6 +56,8 @@ var (
 	errInvalidProvider            = errors.New("--provider must be \"anthropic\" or \"openai\"")
 	errInvalidLanguage            = errors.New("--language must be one of: go, python, node, rust, auto")
 	errListModelsUnsupported      = errors.New("provider does not support listing models")
+	errPreflightFailed            = errors.New("preflight: spec clarity below threshold")
+	errInvalidPreflightThreshold  = errors.New("preflight threshold must be between 0.0 and 1.0")
 	errSourceDirRequired          = errors.New("--source-dir is required")
 	errSourceDirNotExist          = errors.New("--source-dir does not exist")
 	errSourceDirNotDir            = errors.New("--source-dir is not a directory")
@@ -90,6 +93,8 @@ func main() {
 		err = modelsCmd(ctx, logger, os.Args[2:])
 	case "extract":
 		err = extractCmd(ctx, logger, os.Args[2:])
+	case "preflight":
+		err = preflightCmd(ctx, logger, os.Args[2:])
 	case "configure":
 		err = configureCmd(ctx, logger, os.Args[2:])
 	default:
@@ -113,6 +118,7 @@ func printUsage() {
 Commands:
   run        Run the attractor loop to generate software from a spec
   validate   Validate a running service against scenarios
+  preflight  Assess spec clarity before running the attractor loop
   status     Show recent runs, scores, and costs
   lint       Check spec and scenario files for errors
   extract    Extract coding patterns from a source directory into a gene file
@@ -138,6 +144,8 @@ func runCmd(ctx context.Context, logger *slog.Logger, args []string) error {
 	blockOnRegression := fs.Bool("block-on-regression", false, "block convergence when any scenario regresses below threshold in the current iteration")
 	contextBudget := fs.Int("context-budget", 0, "max estimated tokens for spec in system prompt; 0 = unlimited")
 	otelEndpoint := fs.String("otel-endpoint", "", "OTLP/HTTP endpoint for tracing (e.g. localhost:4318); disabled if empty")
+	skipPreflight := fs.Bool("skip-preflight", false, "skip the spec clarity preflight check")
+	preflightThreshold := fs.Float64("preflight-threshold", 0.8, "aggregate clarity score threshold for preflight (0.0–1.0)")
 
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: octog run [flags]\n\nFlags:\n")
@@ -157,7 +165,6 @@ func runCmd(ctx context.Context, logger *slog.Logger, args []string) error {
 	if *threshold < 0 || *threshold > 100 {
 		return errInvalidThreshold
 	}
-
 	// Validate language flag.
 	langForOpts := *language
 	if langForOpts == "auto" {
@@ -183,6 +190,12 @@ func runCmd(ctx context.Context, logger *slog.Logger, args []string) error {
 		return err
 	}
 
+	// Parse spec and run preflight check (validates threshold, parses, and checks clarity).
+	parsedSpec, err := parseAndCheckPreflight(ctx, logger, clients.client, *specFlag, *judgeModel, *preflightThreshold, *skipPreflight)
+	if err != nil {
+		return err
+	}
+
 	// Resolve OTEL endpoint: flag → env → empty (disabled).
 	endpoint := *otelEndpoint
 	if endpoint == "" {
@@ -191,6 +204,7 @@ func runCmd(ctx context.Context, logger *slog.Logger, args []string) error {
 
 	return runAttractorLoop(ctx, logger, clients.client, runLoopParams{
 		SpecPath:          *specFlag,
+		ParsedSpec:        parsedSpec,
 		ScenariosPath:     *scenariosFlag,
 		Model:             *model,
 		JudgeModel:        *judgeModel,
@@ -241,6 +255,7 @@ func isFlagSet(fs *flag.FlagSet, name string) bool {
 // runLoopParams bundles the parameters for runAttractorLoop.
 type runLoopParams struct {
 	SpecPath          string
+	ParsedSpec        spec.Spec
 	ScenariosPath     string
 	Model             string
 	JudgeModel        string
@@ -266,10 +281,7 @@ func runAttractorLoop(ctx context.Context, logger *slog.Logger, llmClient llm.Cl
 		_ = shutdown(shutdownCtx)
 	}()
 
-	parsedSpec, err := spec.ParseFile(p.SpecPath)
-	if err != nil {
-		return fmt.Errorf("parse spec: %w", err)
-	}
+	parsedSpec := p.ParsedSpec
 
 	scenarios, err := scenario.LoadDir(p.ScenariosPath)
 	if err != nil {
@@ -780,6 +792,110 @@ func extractCmd(ctx context.Context, logger *slog.Logger, args []string) error {
 	}
 
 	return gene.Save(*output, g)
+}
+
+// parseAndCheckPreflight parses the spec file and optionally runs a preflight clarity check.
+// It validates the preflight threshold, parses the spec, and (if !skip) checks clarity.
+// Returns the parsed spec for use by the attractor loop.
+func parseAndCheckPreflight(ctx context.Context, logger *slog.Logger, client llm.Client, specPath, judgeModel string, threshold float64, skip bool) (spec.Spec, error) {
+	if threshold < 0 || threshold > 1 {
+		return spec.Spec{}, errInvalidPreflightThreshold
+	}
+	parsedSpec, err := spec.ParseFile(specPath)
+	if err != nil {
+		return spec.Spec{}, fmt.Errorf("parse spec: %w", err)
+	}
+	if !skip {
+		if err := runPreflightCheck(ctx, logger, client, parsedSpec.RawContent, judgeModel, threshold); err != nil {
+			return spec.Spec{}, err
+		}
+	}
+	return parsedSpec, nil
+}
+
+// runPreflightCheck runs a preflight clarity assessment on the given spec content.
+// Returns an error (wrapping errPreflightFailed) if the spec does not pass.
+func runPreflightCheck(ctx context.Context, logger *slog.Logger, client llm.Client, specContent, model string, threshold float64) error {
+	result, err := preflight.Check(ctx, client, model, specContent, threshold, logger)
+	if err != nil {
+		return fmt.Errorf("preflight check: %w", err)
+	}
+	if !result.Pass {
+		fmt.Fprintf(os.Stderr, "Preflight: spec clarity below threshold (%.2f < %.2f)\n", //nolint:gosec // G705 false positive: writing to stderr
+			result.AggregateScore, threshold)
+		for _, q := range result.Questions {
+			fmt.Fprintf(os.Stderr, "  ? %s\n", q) //nolint:gosec // G705 false positive: writing to stderr
+		}
+		return fmt.Errorf("%w (%.2f < %.2f)", errPreflightFailed, result.AggregateScore, threshold)
+	}
+	logger.Info("preflight passed", "score", result.AggregateScore)
+	return nil
+}
+
+var errPreflightSpecRequired = errors.New("spec path argument is required")
+
+func preflightCmd(ctx context.Context, logger *slog.Logger, args []string) error {
+	fs := flag.NewFlagSet("preflight", flag.ContinueOnError)
+	provider := fs.String("provider", "", "LLM provider: anthropic or openai (auto-detected from env if omitted)")
+	judgeModel := fs.String("judge-model", "", "LLM model for clarity assessment (default: provider-specific)")
+	threshold := fs.Float64("threshold", 0.8, "aggregate clarity score threshold (0.0–1.0)")
+
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: octog preflight [flags] <spec-path>\n\nAssess spec clarity before running the attractor loop.\n\nFlags:\n")
+		fs.PrintDefaults()
+	}
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if fs.NArg() < 1 {
+		fs.Usage()
+		return errPreflightSpecRequired
+	}
+	specPath := fs.Arg(0)
+
+	if *threshold < 0 || *threshold > 1 {
+		return errInvalidPreflightThreshold
+	}
+
+	parsedSpec, err := spec.ParseFile(specPath)
+	if err != nil {
+		return fmt.Errorf("parse spec: %w", err)
+	}
+
+	clients, err := newLLMClient(*provider, logger)
+	if err != nil {
+		return err
+	}
+	if *judgeModel == "" {
+		*judgeModel = defaultJudgeModel(clients.provider)
+	}
+
+	result, err := preflight.Check(ctx, clients.client, *judgeModel, parsedSpec.RawContent, *threshold, logger)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Preflight results for: %s\n", specPath)
+	fmt.Printf("  Goal clarity:       %.2f\n", result.GoalClarity)
+	fmt.Printf("  Constraint clarity: %.2f\n", result.ConstraintClarity)
+	fmt.Printf("  Success clarity:    %.2f\n", result.SuccessClarity)
+	fmt.Printf("  Aggregate score:    %.2f (threshold: %.2f)\n", result.AggregateScore, *threshold)
+
+	if result.Pass {
+		fmt.Printf("  Status: PASS\n")
+		return nil
+	}
+
+	fmt.Printf("  Status: WARN — spec clarity below threshold\n")
+	if len(result.Questions) > 0 {
+		fmt.Printf("\nSuggested clarifications:\n")
+		for _, q := range result.Questions {
+			fmt.Printf("  ? %s\n", q)
+		}
+	}
+	return errPreflightFailed
 }
 
 func openStore(ctx context.Context) (*store.Store, error) {

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -1,0 +1,158 @@
+package preflight
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/foundatron/octopusgarden/internal/llm"
+)
+
+var errMalformedResponse = errors.New("preflight: malformed LLM response")
+
+// Result holds the clarity assessment for a spec.
+type Result struct {
+	GoalClarity       float64
+	ConstraintClarity float64
+	SuccessClarity    float64
+	AggregateScore    float64
+	Pass              bool
+	Questions         []string
+}
+
+// preflightResponse is the expected JSON structure from the preflight LLM call.
+type preflightResponse struct {
+	GoalClarity       float64             `json:"goal_clarity"`
+	ConstraintClarity float64             `json:"constraint_clarity"`
+	SuccessClarity    float64             `json:"success_clarity"`
+	Questions         map[string][]string `json:"questions"`
+}
+
+// computeAggregate returns a weighted aggregate of the three clarity dimensions.
+// Weights: goal 0.4, constraint 0.3, success 0.3.
+func computeAggregate(goal, constraint, success float64) float64 {
+	return goal*0.4 + constraint*0.3 + success*0.3
+}
+
+func buildSystemPrompt() string {
+	return `You are a specification clarity analyst. Your job is to assess how well a software specification communicates its requirements to an automated code generator.
+
+Evaluate the spec on three dimensions, each scored from 0.0 (completely unclear) to 1.0 (perfectly clear):
+
+- goal_clarity: Does the spec clearly define WHAT the software should do? Are the core behaviors and purpose unambiguous?
+- constraint_clarity: Does the spec clearly define HOW the software should work? Are technical constraints, interfaces, and non-functional requirements specified?
+- success_clarity: Does the spec clearly define how to verify success? Are acceptance criteria measurable and testable?
+
+For any dimension scoring below the caller's threshold, provide clarifying questions that, if answered, would raise that dimension's score.
+
+Respond ONLY with valid JSON matching this exact schema:
+{
+  "goal_clarity": <float 0.0-1.0>,
+  "constraint_clarity": <float 0.0-1.0>,
+  "success_clarity": <float 0.0-1.0>,
+  "questions": {
+    "goal": ["question1", "question2"],
+    "constraint": ["question1"],
+    "success": ["question1"]
+  }
+}
+
+Example response for a clear spec:
+{
+  "goal_clarity": 0.95,
+  "constraint_clarity": 0.88,
+  "success_clarity": 0.92,
+  "questions": {}
+}
+
+Example response for an unclear spec:
+{
+  "goal_clarity": 0.4,
+  "constraint_clarity": 0.6,
+  "success_clarity": 0.3,
+  "questions": {
+    "goal": ["What are the primary user-facing features?", "What problem does this software solve?"],
+    "success": ["How will success be measured?", "What constitutes a passing test?"]
+  }
+}`
+}
+
+func buildUserPrompt(specContent string) string {
+	return fmt.Sprintf("Assess the following spec for clarity:\n\n%s", specContent)
+}
+
+func parseResponse(raw string) (*preflightResponse, error) {
+	extracted := llm.ExtractJSON(raw)
+	var r preflightResponse
+	if err := json.Unmarshal([]byte(extracted), &r); err != nil {
+		return nil, fmt.Errorf("%w: %w", errMalformedResponse, err)
+	}
+	if r.GoalClarity < 0 || r.GoalClarity > 1 ||
+		r.ConstraintClarity < 0 || r.ConstraintClarity > 1 ||
+		r.SuccessClarity < 0 || r.SuccessClarity > 1 {
+		return nil, fmt.Errorf("%w: scores must be in [0, 1]", errMalformedResponse)
+	}
+	return &r, nil
+}
+
+// Check calls the LLM to assess spec clarity and returns a Result.
+// threshold is the aggregate score (0.0–1.0) below which Pass is false and
+// questions are surfaced for dimensions scoring below threshold.
+func Check(ctx context.Context, client llm.Client, model, specContent string, threshold float64, logger *slog.Logger) (*Result, error) {
+	req := llm.GenerateRequest{
+		Model:     model,
+		MaxTokens: 2048,
+		Messages: []llm.Message{
+			{Role: "user", Content: buildUserPrompt(specContent)},
+		},
+		SystemPrompt: buildSystemPrompt(),
+		CacheControl: &llm.CacheControl{Type: "ephemeral"},
+	}
+
+	resp, err := client.Generate(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("preflight: generate: %w", err)
+	}
+
+	logger.Info("preflight LLM call complete",
+		"input_tokens", resp.InputTokens,
+		"output_tokens", resp.OutputTokens,
+		"cost_usd", resp.CostUSD,
+		"cache_hit", resp.CacheHit,
+	)
+
+	parsed, err := parseResponse(resp.Content)
+	if err != nil {
+		return nil, err
+	}
+
+	agg := computeAggregate(parsed.GoalClarity, parsed.ConstraintClarity, parsed.SuccessClarity)
+
+	// Flatten questions from dimensions scoring below threshold.
+	var questions []string
+	for _, d := range []struct {
+		key   string
+		score float64
+	}{
+		{"goal", parsed.GoalClarity},
+		{"constraint", parsed.ConstraintClarity},
+		{"success", parsed.SuccessClarity},
+	} {
+		if d.score < threshold {
+			for _, q := range parsed.Questions[d.key] {
+				questions = append(questions, fmt.Sprintf("[%s] %s", d.key, q))
+			}
+		}
+	}
+
+	return &Result{
+		GoalClarity:       parsed.GoalClarity,
+		ConstraintClarity: parsed.ConstraintClarity,
+		SuccessClarity:    parsed.SuccessClarity,
+		AggregateScore:    agg,
+		Pass:              agg >= threshold,
+		Questions:         questions,
+	}, nil
+}

--- a/internal/preflight/preflight_test.go
+++ b/internal/preflight/preflight_test.go
@@ -1,0 +1,289 @@
+package preflight
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/foundatron/octopusgarden/internal/llm"
+)
+
+// mockClient is a minimal llm.Client for testing.
+type mockClient struct {
+	generateFn func(ctx context.Context, req llm.GenerateRequest) (llm.GenerateResponse, error)
+	callCount  int
+}
+
+func (m *mockClient) Generate(ctx context.Context, req llm.GenerateRequest) (llm.GenerateResponse, error) {
+	m.callCount++
+	if m.generateFn != nil {
+		return m.generateFn(ctx, req)
+	}
+	return llm.GenerateResponse{}, nil
+}
+
+func (m *mockClient) Judge(_ context.Context, _ llm.JudgeRequest) (llm.JudgeResponse, error) {
+	return llm.JudgeResponse{}, nil
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+func makeJSONResponse(goal, constraint, success float64, questions string) string {
+	return fmt.Sprintf(`{"goal_clarity":%g,"constraint_clarity":%g,"success_clarity":%g,"questions":%s}`,
+		goal, constraint, success, questions)
+}
+
+func TestComputeAggregate(t *testing.T) {
+	tests := []struct {
+		name       string
+		goal       float64
+		constraint float64
+		success    float64
+		want       float64
+	}{
+		{"all ones", 1.0, 1.0, 1.0, 1.0},
+		{"all zeros", 0.0, 0.0, 0.0, 0.0},
+		{"mixed", 0.8, 0.6, 0.4, 0.8*0.4 + 0.6*0.3 + 0.4*0.3},
+		{"goal heavy", 1.0, 0.0, 0.0, 0.4},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := computeAggregate(tc.goal, tc.constraint, tc.success)
+			if got != tc.want {
+				t.Errorf("computeAggregate(%g, %g, %g) = %g, want %g",
+					tc.goal, tc.constraint, tc.success, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseResponse(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{
+			name:  "valid JSON",
+			input: makeJSONResponse(0.9, 0.8, 0.85, `{}`),
+		},
+		{
+			name:  "JSON in code fences",
+			input: "```json\n" + makeJSONResponse(0.9, 0.8, 0.85, `{}`) + "\n```",
+		},
+		{
+			name:    "non-JSON",
+			input:   "not json at all",
+			wantErr: true,
+		},
+		{
+			name:    "out-of-range score high",
+			input:   makeJSONResponse(1.5, 0.8, 0.85, `{}`),
+			wantErr: true,
+		},
+		{
+			name:    "out-of-range score low",
+			input:   makeJSONResponse(-0.1, 0.8, 0.85, `{}`),
+			wantErr: true,
+		},
+		{
+			name:  "missing questions field treated as empty",
+			input: `{"goal_clarity":0.9,"constraint_clarity":0.8,"success_clarity":0.85}`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseResponse(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !errors.Is(err, errMalformedResponse) {
+					t.Errorf("expected errMalformedResponse, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got == nil {
+				t.Fatal("expected non-nil result")
+			}
+		})
+	}
+}
+
+func TestCheckPass(t *testing.T) {
+	mock := &mockClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{
+				Content: makeJSONResponse(0.95, 0.92, 0.90, `{}`),
+			}, nil
+		},
+	}
+
+	result, err := Check(context.Background(), mock, "test-model", "spec content", 0.8, testLogger())
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if !result.Pass {
+		t.Errorf("expected Pass=true, got false (aggregate=%.4f)", result.AggregateScore)
+	}
+	if len(result.Questions) != 0 {
+		t.Errorf("expected no questions, got %v", result.Questions)
+	}
+}
+
+func TestCheckWarn(t *testing.T) {
+	questions := `{"goal":["What is the purpose?"],"constraint":["What is the API?"],"success":["How to verify?"]}`
+	mock := &mockClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{
+				Content: makeJSONResponse(0.3, 0.4, 0.2, questions),
+			}, nil
+		},
+	}
+
+	result, err := Check(context.Background(), mock, "test-model", "vague spec", 0.8, testLogger())
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if result.Pass {
+		t.Errorf("expected Pass=false, got true (aggregate=%.4f)", result.AggregateScore)
+	}
+	if len(result.Questions) == 0 {
+		t.Error("expected questions to be populated")
+	}
+}
+
+func TestCheckQuestionsOnlyForLowDimensions(t *testing.T) {
+	// goal is high (above threshold), constraint and success are low.
+	questions := `{"goal":["Ignore me"],"constraint":["Constraint Q?"],"success":["Success Q?"]}`
+	mock := &mockClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{
+				Content: makeJSONResponse(0.95, 0.3, 0.4, questions),
+			}, nil
+		},
+	}
+
+	result, err := Check(context.Background(), mock, "test-model", "spec", 0.8, testLogger())
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+
+	for _, q := range result.Questions {
+		if q == "[goal] Ignore me" {
+			t.Error("questions for high-scoring dimension should not appear")
+		}
+	}
+
+	foundConstraint := false
+	foundSuccess := false
+	for _, q := range result.Questions {
+		if q == "[constraint] Constraint Q?" {
+			foundConstraint = true
+		}
+		if q == "[success] Success Q?" {
+			foundSuccess = true
+		}
+	}
+	if !foundConstraint {
+		t.Error("expected constraint question to appear")
+	}
+	if !foundSuccess {
+		t.Error("expected success question to appear")
+	}
+}
+
+func TestCheckMalformedResponse(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{"non-JSON", "this is not json"},
+		{"out-of-range score", makeJSONResponse(1.5, 0.8, 0.85, `{}`)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := &mockClient{
+				generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+					return llm.GenerateResponse{Content: tc.content}, nil
+				},
+			}
+			_, err := Check(context.Background(), mock, "test-model", "spec", 0.8, testLogger())
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !errors.Is(err, errMalformedResponse) {
+				t.Errorf("expected errMalformedResponse, got %v", err)
+			}
+		})
+	}
+}
+
+func TestCheckTransportError(t *testing.T) {
+	wantErr := errors.New("network failure")
+	mock := &mockClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{}, wantErr
+		},
+	}
+	_, err := Check(context.Background(), mock, "test-model", "spec", 0.8, testLogger())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Errorf("expected transport error to be wrapped, got %v", err)
+	}
+}
+
+func TestCheckSingleLLMCall(t *testing.T) {
+	mock := &mockClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{
+				Content: makeJSONResponse(0.9, 0.9, 0.9, `{}`),
+			}, nil
+		},
+	}
+
+	_, err := Check(context.Background(), mock, "test-model", "spec", 0.8, testLogger())
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if mock.callCount != 1 {
+		t.Errorf("expected exactly 1 Generate call, got %d", mock.callCount)
+	}
+}
+
+func TestCheckCustomThreshold(t *testing.T) {
+	// Score that passes 0.5 but fails 0.8.
+	mock := &mockClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{
+				Content: makeJSONResponse(0.6, 0.6, 0.6, `{}`),
+			}, nil
+		},
+	}
+
+	resultLow, err := Check(context.Background(), mock, "test-model", "spec", 0.5, testLogger())
+	if err != nil {
+		t.Fatalf("Check (low threshold): %v", err)
+	}
+	if !resultLow.Pass {
+		t.Errorf("expected Pass=true with threshold=0.5, aggregate=%.4f", resultLow.AggregateScore)
+	}
+
+	resultHigh, err := Check(context.Background(), mock, "test-model", "spec", 0.8, testLogger())
+	if err != nil {
+		t.Fatalf("Check (high threshold): %v", err)
+	}
+	if resultHigh.Pass {
+		t.Errorf("expected Pass=false with threshold=0.8, aggregate=%.4f", resultHigh.AggregateScore)
+	}
+}


### PR DESCRIPTION
Closes #117

## Changes
**1. `internal/llm/json.go` (modify)**
- Export `extractJSON` → `ExtractJSON` (rename only, update internal callers)

**2. `internal/preflight/preflight.go` (new)**
- `Result` struct: `GoalClarity`, `ConstraintClarity`, `SuccessClarity` (float64), `AggregateScore` float64, `Pass` bool, `Questions []string`
- Sentinel: `var errMalformedResponse = errors.New("preflight: malformed LLM response")`
- `computeAggregate(goal, constraint, success float64) float64` — weighted 0.4/0.3/0.3
- `Check(ctx context.Context, client llm.Client, model, specContent string, threshold float64) (*Result, error)`:
  - Build system + user prompts (inline helper functions, not separate file)
  - Call `client.Generate()` with `MaxTokens: 2048`
  - Parse response via `llm.ExtractJSON` → `json.Unmarshal` into internal `preflightResponse`
  - Validate scores in [0,1], return `errMalformedResponse` on parse/validation failure
  - Compute aggregate, set `Pass = aggregate >= threshold`
  - Flatten questions from low-scoring dimensions (< threshold) into `[]string`
  - Log token usage + cost from `GenerateResponse`
  - Return `*Result`
- `preflightResponse` struct (unexported): `GoalClarity float64`, `ConstraintClarity float64`, `SuccessClarity float64`, `Questions map[string][]string`
- `parseResponse(raw string) (*preflightResponse, error)` — extract JSON, unmarshal, validate ranges

**3. `cmd/octog/main.go` (modify)**
- Add `case "preflight"` → `preflightCmd(ctx, logger, args)`
- `preflightCmd`: flags `--provider`, `--judge-model`, `--threshold` (default 0.8); positional spec path; parse spec, create client, call `preflight.Check`, print results, `os.Exit(1)` on warn
- Update `printUsage()` with `preflight` subcommand
- Add `--skip-preflight` flag to `runCmd`'s FlagSet
- In `runCmd`, after spec parsing and client creation but before `runAttractorLoop`: if `!skipPreflight`, call `preflight.Check()`. On `!result.Pass`, print questions and return error.

## Review Findings
- Errors: 1
- Warnings: 4
- Nits: 4
- Assessment: **NEEDS CHANGES**

The `os.Exit(1)` in `preflightCmd` is the hard blocker — it's a correctness issue that breaks the command pattern used by every other subcommand and prevents testing. The swallowed-error asymmetry between standalone and integrated preflight is the most concerning design issue. The core `internal/preflight` package is clean, well-tested, and follows project conventions.
