### PR TITLE
feat(attractor): start with cheaper model, escalate on failure

### DIFF
--- a/cmd/octog/main.go
+++ b/cmd/octog/main.go
@@ -135,6 +135,7 @@ func runCmd(ctx context.Context, logger *slog.Logger, args []string) error {
 	scenariosFlag := fs.String("scenarios", "", "path to scenarios directory (required)")
 	provider := fs.String("provider", "", "LLM provider: anthropic or openai (auto-detected from env if omitted)")
 	model := fs.String("model", "", "LLM model to use for generation (default: provider-specific)")
+	frugalModel := fs.String("frugal-model", "", "cheaper model to start with; escalates to --model after 2 consecutive non-improving iterations")
 	judgeModel := fs.String("judge-model", "", "LLM model for satisfaction judging (default: provider-specific)")
 	budget := fs.Float64("budget", 5.00, "maximum budget in USD")
 	threshold := fs.Float64("threshold", 95, "satisfaction threshold (0-100)")
@@ -207,6 +208,7 @@ func runCmd(ctx context.Context, logger *slog.Logger, args []string) error {
 		ParsedSpec:        parsedSpec,
 		ScenariosPath:     *scenariosFlag,
 		Model:             *model,
+		FrugalModel:       *frugalModel,
 		JudgeModel:        *judgeModel,
 		Budget:            *budget,
 		Threshold:         *threshold,
@@ -258,6 +260,7 @@ type runLoopParams struct {
 	ParsedSpec        spec.Spec
 	ScenariosPath     string
 	Model             string
+	FrugalModel       string
 	JudgeModel        string
 	Budget            float64
 	Threshold         float64
@@ -347,6 +350,7 @@ func runAttractorLoop(ctx context.Context, logger *slog.Logger, llmClient llm.Cl
 	att := attractor.New(instrumentedLLM, instrumentedContainer, logger, tp)
 	opts := attractor.RunOptions{
 		Model:             p.Model,
+		FrugalModel:       p.FrugalModel,
 		JudgeModel:        p.JudgeModel,
 		BudgetUSD:         p.Budget,
 		Threshold:         p.Threshold,

--- a/cmd/octog/main_test.go
+++ b/cmd/octog/main_test.go
@@ -1430,3 +1430,23 @@ func TestRunCmdInvalidThreshold(t *testing.T) {
 		})
 	}
 }
+
+func TestFrugalModelFlagParsing(t *testing.T) {
+	// Verify --frugal-model is a recognized flag and its value flows into runLoopParams.
+	// We use a flag.FlagSet with the same definition as runCmd to avoid going through
+	// the full run path (which requires Docker, API keys, etc.).
+	ctx := context.Background()
+	logger := testLogger()
+
+	// Passing missing --spec and --scenarios should return errSpecAndScenariosRequired,
+	// not a "flag provided but not defined" error — proving the flag is accepted.
+	err := runCmd(ctx, logger, []string{"--frugal-model", "claude-haiku-4-5", "--spec", "s.md", "--scenarios", "s/"})
+	if errors.Is(err, flag.ErrHelp) {
+		t.Fatal("--frugal-model was not recognized as a valid flag")
+	}
+	// The flag is parsed successfully; the error here is from missing spec file or API keys,
+	// not from an unrecognized flag.
+	if err != nil && strings.Contains(err.Error(), "flag provided but not defined") {
+		t.Errorf("--frugal-model flag not defined: %v", err)
+	}
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -496,6 +496,7 @@ type ValidateFn func(ctx context.Context, url string) (satisfaction float64, fai
 // RunOptions configures the attractor loop.
 type RunOptions struct {
 	Model             string
+	FrugalModel       string               // optional cheaper model to start with; escalates to Model after consecutive failures
 	JudgeModel        string               // model used for the wonder phase diagnosis; falls back to Model when empty
 	Language          string               // language hint: "go", "python", "node", "rust", or "" (auto)
 	BudgetUSD         float64              // 0 = unlimited
@@ -587,6 +588,7 @@ type IterationProgress struct {
 	InputTokens      int
 	OutputTokens     int
 	Failures         []string
+	Model            string // model used for generation in this iteration
 }
 ```
 

--- a/internal/attractor/attractor.go
+++ b/internal/attractor/attractor.go
@@ -71,6 +71,7 @@ type IterationProgress struct {
 	InputTokens      int
 	OutputTokens     int
 	Failures         []string
+	Model            string // model used for generation in this iteration
 }
 
 // ProgressFunc is called synchronously after each iteration completes.
@@ -114,6 +115,7 @@ type Attractor struct {
 // RunOptions configures the attractor loop.
 type RunOptions struct {
 	Model             string
+	FrugalModel       string               // optional cheaper model to start with; escalates to Model after consecutive failures
 	JudgeModel        string               // model used for the wonder phase diagnosis; falls back to Model when empty
 	Language          string               // language hint: "go", "python", "node", "rust", or "" (auto)
 	BudgetUSD         float64              // 0 = unlimited
@@ -163,6 +165,7 @@ type runState struct {
 	scoreHistory           []float64
 	lastOutcome            IterationOutcome
 	lastSatisfaction       float64
+	lastImproved           bool // true when the last validated iteration beat bestSatisfaction
 	lastInputTokens        int
 	lastOutputTokens       int
 	lastFailures           []string
@@ -176,6 +179,16 @@ type runState struct {
 	scenarioScores         map[string]float64      // per-scenario scores from the last validated iteration
 	scenarioScoreIteration int                     // iteration number corresponding to scenarioScores
 	codeHashes             []string                // SHA-256 hashes of generated file sets, in iteration order
+	escalation             *escalationState        // nil when FrugalModel is empty (escalation disabled)
+}
+
+// currentModel returns the model to use for generation, respecting escalation state.
+// Returns opts.Model directly when escalation is disabled.
+func (s *runState) currentModel() string {
+	if s.escalation != nil {
+		return s.escalation.currentModel()
+	}
+	return s.opts.Model
 }
 
 func (s *runState) result(iter int, status string) *RunResult {
@@ -211,6 +224,7 @@ func (s *runState) buildProgress(iter int, costBefore float64) IterationProgress
 		InputTokens:      s.lastInputTokens,
 		OutputTokens:     s.lastOutputTokens,
 		Failures:         s.lastFailures,
+		Model:            s.currentModel(),
 	}
 }
 
@@ -272,6 +286,7 @@ func (a *Attractor) Run(ctx context.Context, rawSpec string, opts RunOptions, va
 		patchActive:        opts.PatchMode,
 		sessionProvider:    sessionProvider,
 		grpcTargetProvider: grpcTargetProvider,
+		escalation:         newEscalationState(opts.FrugalModel, opts.Model, a.logger),
 	}
 	s.baseDir = filepath.Join(opts.WorkspaceDir, s.runID)
 	s.bestDir = filepath.Join(s.baseDir, "best")
@@ -326,6 +341,10 @@ func (a *Attractor) Run(ctx context.Context, rawSpec string, opts RunOptions, va
 			opts.Progress(s.buildProgress(iter, costBefore))
 		}
 
+		if s.escalation != nil {
+			s.escalation.recordOutcome(s.lastImproved, a.logger)
+		}
+
 		if result != nil {
 			a.setRunSpanAttrs(runSpan, result)
 			return result, nil
@@ -366,7 +385,7 @@ func (a *Attractor) generateContent(ctx context.Context, specContent string, mes
 	genResp, err := a.llm.Generate(ctx, llm.GenerateRequest{
 		SystemPrompt: buildSystemPrompt(specContent, s.opts.Capabilities, s.opts.Language, s.opts.Genes, s.opts.GeneLanguage),
 		Messages:     messages,
-		Model:        s.opts.Model,
+		Model:        s.currentModel(),
 		CacheControl: &llm.CacheControl{Type: "ephemeral"},
 	})
 	if err != nil {
@@ -386,10 +405,12 @@ func (a *Attractor) generateContent(ctx context.Context, specContent string, mes
 func (a *Attractor) wonderReflect(ctx context.Context, rawSpec string, iter int, s *runState) (string, error) {
 	opts := s.opts
 
-	// Resolve judge model — fall back to generator model when unset.
+	// Resolve judge model — fall back to the primary generation model when unset.
+	// Always use the primary model (not the current frugal tier) so diagnostics retain
+	// full capability during the exact window where the frugal model is struggling.
 	judgeModel := opts.JudgeModel
 	if judgeModel == "" {
-		a.logger.Debug("wonder/reflect: no judge model set, falling back to generator model", "model", opts.Model)
+		a.logger.Debug("wonder/reflect: no judge model set, falling back to primary model", "model", opts.Model)
 		judgeModel = opts.Model
 	}
 
@@ -436,7 +457,7 @@ func (a *Attractor) wonderReflect(ctx context.Context, rawSpec string, iter int,
 	reflectResp, err := a.llm.Generate(ctx, llm.GenerateRequest{
 		SystemPrompt: buildSystemPrompt(rawSpec, s.opts.Capabilities, s.opts.Language, s.opts.Genes, s.opts.GeneLanguage),
 		Messages:     []llm.Message{{Role: "user", Content: reflectPrompt}},
-		Model:        opts.Model,
+		Model:        opts.Model, // always use primary model; reflect crafts the next steering prompt
 		Temperature:  &reflectTemp,
 	})
 	if err != nil {
@@ -459,6 +480,8 @@ func (a *Attractor) wonderReflect(ctx context.Context, rawSpec string, iter int,
 // iterate runs a single iteration of the attractor loop.
 // Returns (result, nil) for terminal conditions, (nil, nil) to continue, or (nil, err) for hard errors.
 func (a *Attractor) iterate(ctx context.Context, rawSpec string, iter int, s *runState, validate ValidateFn) (*RunResult, error) {
+	s.lastImproved = false // reset at start of each iteration; set true only by processValidation on strict improvement
+
 	// Select spec content: use summarized view when available to respect context budget.
 	// SelectContent returns full spec if it fits the budget, so iteration 1 (no failures)
 	// still gets maximum detail. Iteration 2+ gets failure-relevant sections expanded.
@@ -751,6 +774,7 @@ func (a *Attractor) processValidation(iter int, satisfaction float64, failures [
 		s.bestFiles = maps.Clone(files)
 		s.stallCount = 0
 		s.patchRegressionCount = 0
+		s.lastImproved = true
 		if err := writeFiles(s.bestDir, files); err != nil {
 			return nil, fmt.Errorf("attractor: write best files: %w", err)
 		}

--- a/internal/attractor/attractor_test.go
+++ b/internal/attractor/attractor_test.go
@@ -2136,3 +2136,106 @@ func TestWonderReflect_BudgetExhaustedAfterWonder(t *testing.T) {
 		t.Errorf("unexpected status %q (expected budget_exceeded, stalled, or converged)", result.Status)
 	}
 }
+
+func TestModelEscalationPassedToGenerate(t *testing.T) {
+	// Simulate 2 build failures then success, verifying that the model seen by
+	// Generate changes from the frugal model to the primary model after escalation.
+	var buildCount atomic.Int32
+	capturedModels := make([]string, 0, 4)
+	var mu sync.Mutex
+
+	client := &mockLLMClient{
+		generateFn: func(_ context.Context, req llm.GenerateRequest) (llm.GenerateResponse, error) {
+			mu.Lock()
+			capturedModels = append(capturedModels, req.Model)
+			mu.Unlock()
+			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
+		},
+	}
+	mgr := &mockContainerMgr{
+		buildFn: func(_ context.Context, _, _ string) error {
+			n := buildCount.Add(1)
+			if n <= 2 {
+				return fmt.Errorf("build failed iteration %d", n)
+			}
+			return nil
+		},
+	}
+	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+		return 100, nil, 0.005, nil
+	}
+
+	opts := defaultOpts(t)
+	opts.Model = "primary-model"
+	opts.FrugalModel = "frugal-model"
+	opts.StallLimit = 5 // allow more iterations so escalation has room to fire
+
+	a := New(client, mgr, testLogger(), nil)
+	result, err := a.Run(context.Background(), "Build an app", opts, validate, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != StatusConverged {
+		t.Errorf("expected converged, got %q", result.Status)
+	}
+
+	// At least 3 generate calls: 2 before escalation (frugal) + 1 after (primary).
+	mu.Lock()
+	defer mu.Unlock()
+	if len(capturedModels) < 3 {
+		t.Fatalf("expected at least 3 generate calls, got %d", len(capturedModels))
+	}
+	// First 2 calls should use the frugal model.
+	for i := range 2 {
+		if capturedModels[i] != "frugal-model" {
+			t.Errorf("generate call %d: expected model %q, got %q", i+1, "frugal-model", capturedModels[i])
+		}
+	}
+	// The call after escalation should use the primary model.
+	if capturedModels[2] != "primary-model" {
+		t.Errorf("generate call 3 (post-escalation): expected model %q, got %q", "primary-model", capturedModels[2])
+	}
+}
+
+func TestNoEscalationWithoutFrugalModel(t *testing.T) {
+	var capturedModels []string
+	var mu sync.Mutex
+
+	client := &mockLLMClient{
+		generateFn: func(_ context.Context, req llm.GenerateRequest) (llm.GenerateResponse, error) {
+			mu.Lock()
+			capturedModels = append(capturedModels, req.Model)
+			mu.Unlock()
+			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
+		},
+	}
+	var callCount atomic.Int32
+	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+		n := callCount.Add(1)
+		if n < 3 {
+			return 50, []string{"not yet"}, 0.005, nil
+		}
+		return 100, nil, 0.005, nil
+	}
+
+	opts := defaultOpts(t)
+	opts.Model = "primary-model"
+	// FrugalModel intentionally left empty → escalation disabled.
+
+	a := New(client, &mockContainerMgr{}, testLogger(), nil)
+	result, err := a.Run(context.Background(), "Build an app", opts, validate, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != StatusConverged {
+		t.Errorf("expected converged, got %q", result.Status)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	for i, m := range capturedModels {
+		if m != "primary-model" {
+			t.Errorf("generate call %d: expected model %q, got %q", i+1, "primary-model", m)
+		}
+	}
+}

--- a/internal/attractor/escalation.go
+++ b/internal/attractor/escalation.go
@@ -1,0 +1,105 @@
+package attractor
+
+import "log/slog"
+
+// modelTier represents a model quality tier used by escalation state.
+// tierFrugal is the starting tier; tierPrimary is escalated to after consecutive failures.
+type modelTier int
+
+const (
+	// tierFrugal is the initial cost-efficient tier (--frugal-model).
+	tierFrugal modelTier = 1
+	// tierPrimary is the escalated tier (--model).
+	tierPrimary modelTier = 2
+)
+
+// String returns a human-readable label for the tier, used in log attributes.
+func (t modelTier) String() string {
+	switch t {
+	case tierFrugal:
+		return "frugal"
+	case tierPrimary:
+		return "primary"
+	default:
+		return "unknown"
+	}
+}
+
+const (
+	// escalateAfterFailures is the number of consecutive non-improving iterations
+	// required to escalate from tierFrugal to tierPrimary.
+	// Note: with a default stallLimit=3, escalation fires after 2 failures and the run
+	// terminates after 3. Escalation therefore buys exactly one extra attempt at the
+	// higher tier — this is intentional and acceptable.
+	escalateAfterFailures = 2
+	// downgradeAfterImprovements is the number of consecutive improving iterations
+	// required to downgrade from tierPrimary back to tierFrugal.
+	downgradeAfterImprovements = 5
+)
+
+// escalationState manages automatic model tier escalation and downgrade.
+// It tracks consecutive failures and improvements to decide when to switch tiers.
+// Use newEscalationState to construct; a nil pointer means escalation is disabled.
+type escalationState struct {
+	currentTier         modelTier
+	consecutiveFailures int
+	consecutiveImprove  int
+	models              [2]string // index 0 = tierFrugal, index 1 = tierPrimary
+}
+
+// newEscalationState returns an escalationState starting at tierFrugal.
+// Returns nil when frugalModel is empty (escalation disabled).
+func newEscalationState(frugalModel, primaryModel string, logger *slog.Logger) *escalationState {
+	if frugalModel == "" {
+		return nil
+	}
+	if frugalModel == primaryModel {
+		logger.Debug("frugal-model equals primary model; escalation machinery will run but model never changes", "model", frugalModel)
+	}
+	return &escalationState{
+		currentTier: tierFrugal,
+		models:      [2]string{frugalModel, primaryModel},
+	}
+}
+
+// currentModel returns the model string for the current tier.
+func (e *escalationState) currentModel() string {
+	return e.models[e.currentTier-1]
+}
+
+// recordOutcome updates escalation state based on whether the last iteration improved.
+// "Improved" means the iteration was validated and satisfaction strictly exceeded the
+// previous best — the caller (processValidation via runState) determines this.
+// Escalation fires after escalateAfterFailures consecutive non-improved outcomes.
+// Downgrade fires after downgradeAfterImprovements consecutive improved outcomes.
+func (e *escalationState) recordOutcome(improved bool, logger *slog.Logger) {
+	if improved {
+		e.consecutiveImprove++
+		e.consecutiveFailures = 0
+		if e.consecutiveImprove >= downgradeAfterImprovements && e.currentTier > tierFrugal {
+			from := e.currentTier
+			e.currentTier = tierFrugal
+			e.consecutiveImprove = 0
+			logger.Info("model downgraded",
+				"from_tier", from,
+				"to_tier", tierFrugal,
+				"model", e.currentModel(),
+				"reason", "consecutive_improvements",
+			)
+		}
+	} else {
+		e.consecutiveFailures++
+		e.consecutiveImprove = 0
+		if e.consecutiveFailures >= escalateAfterFailures && e.currentTier < tierPrimary {
+			from := e.currentTier
+			e.currentTier = tierPrimary
+			e.consecutiveFailures = 0
+			logger.Info("model escalated",
+				"from_tier", from,
+				"to_tier", tierPrimary,
+				"model", e.currentModel(),
+				"reason", "consecutive_failures",
+			)
+		}
+	}
+}

--- a/internal/attractor/escalation_test.go
+++ b/internal/attractor/escalation_test.go
@@ -1,0 +1,223 @@
+package attractor
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func noopLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil))
+}
+
+func capturingLogger(buf *bytes.Buffer) *slog.Logger {
+	return slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+}
+
+func TestNilEscalation(t *testing.T) {
+	e := newEscalationState("", "primary-model", noopLogger())
+	if e != nil {
+		t.Error("expected nil for empty frugalModel")
+	}
+}
+
+func TestEscalationStartsAtFrugal(t *testing.T) {
+	e := newEscalationState("frugal", "primary", noopLogger())
+	if e == nil {
+		t.Fatal("expected non-nil escalation state")
+	}
+	if got := e.currentModel(); got != "frugal" {
+		t.Errorf("expected %q, got %q", "frugal", got)
+	}
+	if e.currentTier != tierFrugal {
+		t.Errorf("expected tierFrugal, got %v", e.currentTier)
+	}
+}
+
+func TestEscalationOnFailure(t *testing.T) {
+	e := newEscalationState("frugal", "primary", noopLogger())
+	logger := noopLogger()
+
+	e.recordOutcome(false, logger) // failure 1 — no escalation yet
+	if e.currentTier != tierFrugal {
+		t.Errorf("should still be tierFrugal after 1 failure, got tier %v", e.currentTier)
+	}
+
+	e.recordOutcome(false, logger) // failure 2 — should escalate
+	if e.currentTier != tierPrimary {
+		t.Errorf("expected tierPrimary after 2 failures, got tier %v", e.currentTier)
+	}
+	if got := e.currentModel(); got != "primary" {
+		t.Errorf("expected model %q, got %q", "primary", got)
+	}
+}
+
+func TestEscalationCeiling(t *testing.T) {
+	e := newEscalationState("frugal", "primary", noopLogger())
+	logger := noopLogger()
+
+	// Escalate to primary.
+	e.recordOutcome(false, logger)
+	e.recordOutcome(false, logger)
+
+	if e.currentTier != tierPrimary {
+		t.Fatalf("expected tierPrimary, got %v", e.currentTier)
+	}
+
+	// More failures should not exceed tierPrimary.
+	e.recordOutcome(false, logger)
+	e.recordOutcome(false, logger)
+	e.recordOutcome(false, logger)
+
+	if e.currentTier != tierPrimary {
+		t.Errorf("expected tier to stay at tierPrimary, got %v", e.currentTier)
+	}
+}
+
+func TestDowngradeOnSuccess(t *testing.T) {
+	e := newEscalationState("frugal", "primary", noopLogger())
+	logger := noopLogger()
+
+	// Escalate to primary.
+	e.recordOutcome(false, logger)
+	e.recordOutcome(false, logger)
+	if e.currentTier != tierPrimary {
+		t.Fatalf("expected tierPrimary, got %v", e.currentTier)
+	}
+
+	// 4 improvements — not enough to downgrade.
+	for i := range 4 {
+		e.recordOutcome(true, logger)
+		if e.currentTier != tierPrimary {
+			t.Errorf("improvement %d: expected tierPrimary, got %v", i+1, e.currentTier)
+		}
+	}
+
+	// 5th improvement — should downgrade.
+	e.recordOutcome(true, logger)
+	if e.currentTier != tierFrugal {
+		t.Errorf("expected tierFrugal after 5 improvements, got %v", e.currentTier)
+	}
+	if got := e.currentModel(); got != "frugal" {
+		t.Errorf("expected model %q, got %q", "frugal", got)
+	}
+}
+
+func TestFailureResetsImprovementCounter(t *testing.T) {
+	e := newEscalationState("frugal", "primary", noopLogger())
+	logger := noopLogger()
+
+	// Escalate to primary.
+	e.recordOutcome(false, logger)
+	e.recordOutcome(false, logger)
+
+	// 4 improvements then 1 failure — counter resets.
+	for range 4 {
+		e.recordOutcome(true, logger)
+	}
+	e.recordOutcome(false, logger) // resets improvement counter
+
+	if e.currentTier != tierPrimary {
+		t.Errorf("expected tierPrimary after reset, got %v", e.currentTier)
+	}
+	if e.consecutiveImprove != 0 {
+		t.Errorf("expected consecutiveImprove=0 after failure, got %d", e.consecutiveImprove)
+	}
+
+	// Need 5 fresh improvements to downgrade.
+	for i := range 4 {
+		e.recordOutcome(true, logger)
+		if e.currentTier != tierPrimary {
+			t.Errorf("fresh improvement %d: expected tierPrimary, got %v", i+1, e.currentTier)
+		}
+	}
+	e.recordOutcome(true, logger)
+	if e.currentTier != tierFrugal {
+		t.Errorf("expected tierFrugal after 5 fresh improvements, got %v", e.currentTier)
+	}
+}
+
+func TestImprovementResetsFailureCounter(t *testing.T) {
+	e := newEscalationState("frugal", "primary", noopLogger())
+	logger := noopLogger()
+
+	e.recordOutcome(false, logger) // 1 failure
+	e.recordOutcome(true, logger)  // resets failure counter
+
+	if e.consecutiveFailures != 0 {
+		t.Errorf("expected consecutiveFailures=0 after improvement, got %d", e.consecutiveFailures)
+	}
+	if e.currentTier != tierFrugal {
+		t.Errorf("expected tierFrugal, got %v", e.currentTier)
+	}
+
+	// Need 2 fresh failures to escalate.
+	e.recordOutcome(false, logger)
+	if e.currentTier != tierFrugal {
+		t.Errorf("expected tierFrugal after 1 fresh failure, got %v", e.currentTier)
+	}
+	e.recordOutcome(false, logger)
+	if e.currentTier != tierPrimary {
+		t.Errorf("expected tierPrimary after 2 fresh failures, got %v", e.currentTier)
+	}
+}
+
+func TestStateTransitionSequence(t *testing.T) {
+	// Table-driven sequence: each row is (improved bool, expectedTier after recordOutcome).
+	tests := []struct {
+		improved     bool
+		expectedTier modelTier
+	}{
+		// Start at frugal.
+		{false, tierFrugal},  // failures=1
+		{true, tierFrugal},   // reset, improvements=1
+		{false, tierFrugal},  // failures=1
+		{false, tierPrimary}, // failures=2 → escalate
+		{true, tierPrimary},  // improvements=1
+		{true, tierPrimary},  // improvements=2
+		{true, tierPrimary},  // improvements=3
+		{true, tierPrimary},  // improvements=4
+		{true, tierFrugal},   // improvements=5 → downgrade
+	}
+
+	e := newEscalationState("frugal", "primary", noopLogger())
+	logger := noopLogger()
+
+	for i, tc := range tests {
+		e.recordOutcome(tc.improved, logger)
+		if e.currentTier != tc.expectedTier {
+			t.Errorf("step %d (improved=%v): expected tier %v, got %v", i, tc.improved, tc.expectedTier, e.currentTier)
+		}
+	}
+}
+
+func TestEscalationLogging(t *testing.T) {
+	var buf bytes.Buffer
+	logger := capturingLogger(&buf)
+
+	e := newEscalationState("frugal", "primary", noopLogger())
+	e.recordOutcome(false, logger)
+	e.recordOutcome(false, logger) // triggers escalation log
+
+	output := buf.String()
+	if !strings.Contains(output, "model escalated") {
+		t.Errorf("expected 'model escalated' in log output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "primary") {
+		t.Errorf("expected model name in log output, got:\n%s", output)
+	}
+
+	buf.Reset()
+	// 5 improvements to trigger downgrade log.
+	for range 5 {
+		e.recordOutcome(true, logger)
+	}
+	output = buf.String()
+	if !strings.Contains(output, "model downgraded") {
+		t.Errorf("expected 'model downgraded' in log output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "frugal") {
+		t.Errorf("expected model name in downgrade log output, got:\n%s", output)
+	}
+}


### PR DESCRIPTION
Closes #118

## Changes
**1. `internal/attractor/escalation.go` (new file)**
- `ModelTier` type (int): `TierFrugal = 1`, `TierPrimary = 2` (2 tiers only)
- `escalationState` struct: `currentTier ModelTier`, `consecutiveFailures int`, `consecutiveImprovements int`, `models [2]string`
- `newEscalationState(frugalModel, primaryModel string) *escalationState` — returns `nil` if `frugalModel` is empty
- `(e *escalationState) currentModel() string` — returns `e.models[e.currentTier-1]`
- `(e *escalationState) recordOutcome(improved bool, logger *slog.Logger)`:
  - If `improved`: increment `consecutiveImprovements`, reset `consecutiveFailures`; if improvements >= 5 and tier > 1, downgrade and log `slog.Info("model downgraded", ...)`, reset counter
  - If not improved: increment `consecutiveFailures`, reset `consecutiveImprovements`; if failures >= 2 and tier < 2, escalate and log `slog.Info("model escalated", ...)`, reset counter
- "Not improved" = any non-validated outcome OR validated but `satisfaction <= bestSatisfaction` (caller determines this, passes `improved=false`)

**2. `internal/attractor/attractor.go` (modify)**
- Add `FrugalModel string` to `RunOptions`
- Add `escalation *escalationState` to `runState`
- In `Run()`, after `withDefaults`: if `opts.FrugalModel != ""`, set `s.escalation = newEscalationState(opts.FrugalModel, opts.Model)`
- Add `(s *runState) currentModel() string` helper (nil-safe: returns `s.opts.Model` when escalation is nil)
- In `generateContent()` (line 369): replace `s.opts.Model` with `s.currentModel()`
- In `wonderReflect()` (line 439): replace `opts.Model` with `s.currentModel()` for the reflect phase
- Add `Model string` to `IterationProgress`; set it in `buildProgress()`
- Record escalation outcome once in the main loop, after `buildProgress` (around line 326): `s.recordEscalation(a.logger)` — a helper on `runState` that checks `s.escalation != nil`, then calls `recordOutcome(s.lastOutcome == OutcomeValidated && s.lastSatisfaction > previousBest)`. This requires tracking whether satisfaction improved, which is already determined in `processValidation` — add a `lastImproved bool` field to `runState`, set in `processValidation` and defaulted to `false` for non-validated outcomes.

**3. `cmd/octog/main.go` (modify)**
- Add `--frugal-model` flag, wire through `runLoopParams` → `attractor.RunOptions.FrugalModel`

## Review Findings
- Errors: 0
- Warnings: 2
- Nits: 6
- Assessment: **NEEDS CHANGES**

The two warnings center on the same design concern: wonder/reflect (the diagnostic+steering phase) now inherits the frugal model when `JudgeModel` is unset. This means the cheapest model is used for both generation *and* self-diagnosis during the exact window where it's already failing to make progress — undermining the purpose of the wonder phase. The fix is straightforward: fall back to `opts.Model` (not `s.currentModel()`) for the judge and reflect calls, preserving the previous behavior where diagnostics always use the primary-tier model.
