### PR TITLE
feat(scenario): fix browser fill observation gap and add run verbosity levels

### DIFF
--- a/cmd/octog/main.go
+++ b/cmd/octog/main.go
@@ -147,6 +147,7 @@ func runCmd(ctx context.Context, logger *slog.Logger, args []string) error {
 	otelEndpoint := fs.String("otel-endpoint", "", "OTLP/HTTP endpoint for tracing (e.g. localhost:4318); disabled if empty")
 	skipPreflight := fs.Bool("skip-preflight", false, "skip the spec clarity preflight check")
 	preflightThreshold := fs.Float64("preflight-threshold", 0.8, "aggregate clarity score threshold for preflight (0.0–1.0)")
+	verbose := fs.Int("v", 0, "verbosity level: 0=quiet, 1=per-scenario summary after each iteration, 2=full step detail with reasoning")
 
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: octog run [flags]\n\nFlags:\n")
@@ -219,6 +220,7 @@ func runCmd(ctx context.Context, logger *slog.Logger, args []string) error {
 		Language:          langForOpts,
 		GenesGuide:        genesGuide,
 		GeneLanguage:      genesLanguage,
+		Verbosity:         *verbose,
 	})
 }
 
@@ -271,6 +273,7 @@ type runLoopParams struct {
 	Language          string
 	GenesGuide        string
 	GeneLanguage      string
+	Verbosity         int
 }
 
 func runAttractorLoop(ctx context.Context, logger *slog.Logger, llmClient llm.Client, p runLoopParams) error {
@@ -358,7 +361,7 @@ func runAttractorLoop(ctx context.Context, logger *slog.Logger, llmClient llm.Cl
 		BlockOnRegression: p.BlockOnRegression,
 		ContextBudget:     p.ContextBudget,
 		Language:          p.Language,
-		Progress:          progressFn(ctx, logger, st),
+		Progress:          progressFn(ctx, logger, st, os.Stderr, p.Verbosity),
 		Capabilities:      caps,
 		Genes:             p.GenesGuide,
 		GeneLanguage:      p.GeneLanguage,
@@ -408,16 +411,29 @@ func detectStepCaps(caps *attractor.ScenarioCapabilities, step scenario.Step) {
 	}
 }
 
-func progressFn(ctx context.Context, logger *slog.Logger, st *store.Store) func(attractor.IterationProgress) {
+func progressFn(ctx context.Context, logger *slog.Logger, st *store.Store, w io.Writer, verbosity int) func(attractor.IterationProgress) {
 	return func(p attractor.IterationProgress) {
 		if p.Outcome != attractor.OutcomeValidated {
-			fmt.Fprintf(os.Stderr, "iter %d/%d  %s  cost: $%.2f  [%s]\n", //nolint:gosec // G705 false positive: writing to stderr, not an HTTP response
+			_, _ = fmt.Fprintf(w, "iter %d/%d  %s  cost: $%.2f  [%s]\n", //nolint:gosec // G705 false positive: writing to injected io.Writer, not an HTTP response
 				p.Iteration, p.MaxIterations, p.Outcome,
 				p.TotalCostUSD, p.Elapsed.Truncate(time.Second))
 		} else {
-			fmt.Fprintf(os.Stderr, "iter %d/%d  satisfaction: %.1f/%.1f  cost: $%.2f  trend: %s  [%s]\n", //nolint:gosec // G705 false positive: writing to stderr, not an HTTP response
+			_, _ = fmt.Fprintf(w, "iter %d/%d  satisfaction: %.1f/%.1f  cost: $%.2f  trend: %s  [%s]\n", //nolint:gosec // G705 false positive: writing to injected io.Writer, not an HTTP response
 				p.Iteration, p.MaxIterations, p.Satisfaction, p.Threshold,
 				p.TotalCostUSD, p.Trend, p.Elapsed.Truncate(time.Second))
+		}
+
+		// p.Failures holds per-scenario feedback strings (both passing and failing scenarios);
+		// they are only populated after the validation phase, so we gate on OutcomeValidated.
+		if verbosity > 0 && p.Outcome == attractor.OutcomeValidated && len(p.Failures) > 0 {
+			for _, f := range p.Failures {
+				if verbosity >= 2 {
+					_, _ = fmt.Fprintf(w, "  %s\n", f) //nolint:gosec // G705 false positive: writing to injected io.Writer, not an HTTP response
+				} else {
+					line, _, _ := strings.Cut(f, "\n")
+					_, _ = fmt.Fprintf(w, "  %s\n", line) //nolint:gosec // G705 false positive: writing to injected io.Writer, not an HTTP response
+				}
+			}
 		}
 
 		it := store.Iteration{
@@ -483,6 +499,7 @@ func validateCmd(ctx context.Context, logger *slog.Logger, args []string) error 
 	judgeModel := fs.String("judge-model", "", "LLM model for satisfaction judging (default: provider-specific)")
 	threshold := fs.Float64("threshold", 0, "minimum satisfaction score (0-100); non-zero enables exit code 1 on failure")
 	format := fs.String("format", "text", "output format: text or json")
+	verbose := fs.Int("v", 0, "verbosity level: 0=standard, 1=per-scenario summary, 2=full step detail with judge reasoning")
 
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: octog validate [flags]\n\nFlags:\n")
@@ -538,18 +555,32 @@ func validateCmd(ctx context.Context, logger *slog.Logger, args []string) error 
 		return fmt.Errorf("validate: %w", err)
 	}
 
-	return outputValidation(agg, *target, *threshold, *format)
+	return outputValidation(agg, *target, *threshold, *format, *verbose, os.Stdout)
 }
 
-func outputValidation(agg scenario.AggregateResult, target string, threshold float64, format string) error {
+func outputValidation(agg scenario.AggregateResult, target string, threshold float64, format string, verbosity int, w io.Writer) error {
 	switch format {
 	case "json":
 		out := view.NewValidateOutput(agg, target, threshold, stepPassThreshold)
-		if err := view.WriteJSON(os.Stdout, out); err != nil {
+		if err := view.WriteJSON(w, out); err != nil {
 			return fmt.Errorf("write json: %w", err)
 		}
 	default:
-		fprintValidationResult(os.Stdout, agg)
+		fprintValidationResult(w, agg)
+		if verbosity >= 1 {
+			failures := buildDetailedFailures(agg)
+			if len(failures) > 0 {
+				_, _ = fmt.Fprintln(w, "\nStep detail:")
+				for _, f := range failures {
+					if verbosity >= 2 {
+						_, _ = fmt.Fprintf(w, "  %s\n", f) //nolint:gosec // G705 false positive: writing to injected io.Writer, not an HTTP response
+					} else {
+						line, _, _ := strings.Cut(f, "\n")
+						_, _ = fmt.Fprintf(w, "  %s\n", line) //nolint:gosec // G705 false positive: writing to injected io.Writer, not an HTTP response
+					}
+				}
+			}
+		}
 	}
 
 	if threshold > 0 && agg.Satisfaction < threshold {
@@ -1073,12 +1104,12 @@ func formatFailedScenario(s scenario.ScoredScenario) string {
 	b.WriteString(attractor.FormatScenarioFailureLine(s.ScenarioID, s.Score))
 	for _, step := range s.Steps {
 		if step.StepScore.Score >= stepPassThreshold {
-			fmt.Fprintf(&b, "\n%s %s (%d/100)", attractor.StepPassPrefix, step.StepResult.Description, step.StepScore.Score)
+			fmt.Fprintf(&b, "\n%s %s (%d/100)", attractor.StepPassPrefix, step.StepResult.Description, step.StepScore.Score) //nolint:gosec // G705 false positive: writing to strings.Builder, not an HTTP response
 			continue
 		}
-		fmt.Fprintf(&b, "\n%s %s (%d/100)", attractor.StepFailPrefix, step.StepResult.Description, step.StepScore.Score)
+		fmt.Fprintf(&b, "\n%s %s (%d/100)", attractor.StepFailPrefix, step.StepResult.Description, step.StepScore.Score) //nolint:gosec // G705 false positive: writing to strings.Builder, not an HTTP response
 		if step.StepScore.Reasoning != "" {
-			fmt.Fprintf(&b, "\n    Reasoning: %s", step.StepScore.Reasoning)
+			fmt.Fprintf(&b, "\n    Reasoning: %s", step.StepScore.Reasoning) //nolint:gosec // G705 false positive: writing to strings.Builder, not an HTTP response
 		}
 		if step.StepResult.Observed != "" {
 			obs := step.StepResult.Observed
@@ -1087,7 +1118,7 @@ func formatFailedScenario(s scenario.ScoredScenario) string {
 				obs = truncateObserved(obs, attractor.MaxObservedBytes)
 				label = fmt.Sprintf("Observed (%dB)", attractor.MaxObservedBytes)
 			}
-			fmt.Fprintf(&b, "\n    %s: %s", label, obs)
+			fmt.Fprintf(&b, "\n    %s: %s", label, obs) //nolint:gosec // G705 false positive: writing to strings.Builder, not an HTTP response
 		}
 	}
 	return b.String()

--- a/cmd/octog/main_test.go
+++ b/cmd/octog/main_test.go
@@ -14,11 +14,13 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/foundatron/octopusgarden/internal/attractor"
 	"github.com/foundatron/octopusgarden/internal/container"
 	"github.com/foundatron/octopusgarden/internal/llm"
 	"github.com/foundatron/octopusgarden/internal/scenario"
+	"github.com/foundatron/octopusgarden/internal/store"
 )
 
 // mockLLMClient implements llm.Client for testing.
@@ -1426,6 +1428,141 @@ func TestRunCmdInvalidThreshold(t *testing.T) {
 			err := runCmd(ctx, logger, tt.args)
 			if !errors.Is(err, errInvalidThreshold) {
 				t.Errorf("runCmd(%v) = %v, want %v", tt.args, err, errInvalidThreshold)
+			}
+		})
+	}
+}
+
+func TestProgressFnVerbosity(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+	st, err := store.NewStore(ctx, ":memory:")
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+
+	progress := attractor.IterationProgress{
+		RunID:         "test-run",
+		Iteration:     1,
+		MaxIterations: 5,
+		Outcome:       attractor.OutcomeValidated,
+		Satisfaction:  72.5,
+		Threshold:     95.0,
+		TotalCostUSD:  0.01,
+		Elapsed:       2 * time.Second,
+		Failures: []string{
+			"✗ scenario-a (45/100)\n  ✗ step one (40/100)\n    Reasoning: not working\n    Observed: got 404",
+			"✓ scenario-b (95/100)",
+		},
+	}
+
+	tests := []struct {
+		name      string
+		verbosity int
+		wantLines []string
+		noLines   []string
+	}{
+		{
+			name:      "v0 shows summary only",
+			verbosity: 0,
+			wantLines: []string{"iter 1/5  satisfaction: 72.5/95.0"},
+			noLines:   []string{"scenario-a", "scenario-b"},
+		},
+		{
+			name:      "v1 shows first line of each failure",
+			verbosity: 1,
+			wantLines: []string{"iter 1/5  satisfaction: 72.5/95.0", "✗ scenario-a (45/100)", "✓ scenario-b (95/100)"},
+			noLines:   []string{"Reasoning: not working"},
+		},
+		{
+			name:      "v2 shows full failure detail",
+			verbosity: 2,
+			wantLines: []string{"iter 1/5  satisfaction: 72.5/95.0", "✗ scenario-a (45/100)", "Reasoning: not working", "✓ scenario-b (95/100)"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			fn := progressFn(ctx, logger, st, &buf, tt.verbosity)
+			fn(progress)
+			out := buf.String()
+			for _, want := range tt.wantLines {
+				if !strings.Contains(out, want) {
+					t.Errorf("output missing %q\nfull output:\n%s", want, out)
+				}
+			}
+			for _, noWant := range tt.noLines {
+				if strings.Contains(out, noWant) {
+					t.Errorf("output should not contain %q\nfull output:\n%s", noWant, out)
+				}
+			}
+		})
+	}
+}
+
+func TestOutputValidationVerbosity(t *testing.T) {
+	agg := scenario.AggregateResult{
+		Satisfaction: 55.0,
+		TotalCostUSD: 0.001,
+		Scenarios: []scenario.ScoredScenario{
+			{
+				ScenarioID: "failing-scenario",
+				Score:      55,
+				Weight:     1.0,
+				Steps: []scenario.ScoredStep{
+					{
+						StepResult: scenario.StepResult{Description: "get items", Observed: "HTTP 404"},
+						StepScore:  scenario.StepScore{Score: 55, Reasoning: "expected 200 got 404"},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name      string
+		verbosity int
+		wantLines []string
+		noLines   []string
+	}{
+		{
+			name:      "v0 shows summary only",
+			verbosity: 0,
+			wantLines: []string{"failing-scenario", "Aggregate satisfaction: 55.0/100"},
+			noLines:   []string{"Step detail:", "expected 200 got 404"},
+		},
+		{
+			name:      "v1 shows per-scenario summary line",
+			verbosity: 1,
+			wantLines: []string{"Aggregate satisfaction: 55.0/100", "Step detail:", "failing-scenario"},
+			noLines:   []string{"expected 200 got 404"},
+		},
+		{
+			name:      "v2 shows full step detail with reasoning",
+			verbosity: 2,
+			wantLines: []string{"Aggregate satisfaction: 55.0/100", "Step detail:", "expected 200 got 404"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := outputValidation(agg, "http://localhost", 0, "text", tt.verbosity, &buf)
+			if err != nil {
+				t.Fatalf("outputValidation: %v", err)
+			}
+			out := buf.String()
+			for _, want := range tt.wantLines {
+				if !strings.Contains(out, want) {
+					t.Errorf("output missing %q\nfull output:\n%s", want, out)
+				}
+			}
+			for _, noWant := range tt.noLines {
+				if strings.Contains(out, noWant) {
+					t.Errorf("output should not contain %q\nfull output:\n%s", noWant, out)
+				}
 			}
 		})
 	}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -158,6 +158,7 @@ const (
 	BrowserSourceHTML     = "html"
 	BrowserSourceCount    = "count"
 	BrowserSourceLocation = "location"
+	BrowserSourceValue    = "value"
 )
 
 // GRPC capture source constants.

--- a/internal/scenario/browser.go
+++ b/internal/scenario/browser.go
@@ -50,7 +50,7 @@ func NewBrowserExecutor(ctx context.Context, baseURL string, logger *slog.Logger
 
 // ValidCaptureSources returns the valid capture source names for browser steps.
 func (e *BrowserExecutor) ValidCaptureSources() []string {
-	return []string{BrowserSourceText, BrowserSourceHTML, BrowserSourceCount, BrowserSourceLocation}
+	return []string{BrowserSourceText, BrowserSourceHTML, BrowserSourceCount, BrowserSourceLocation, BrowserSourceValue}
 }
 
 // Execute dispatches a browser action and returns the step output.
@@ -231,11 +231,12 @@ func (e *BrowserExecutor) doClick(ctx context.Context, req BrowserRequest) (Step
 }
 
 func (e *BrowserExecutor) doFill(ctx context.Context, req BrowserRequest) (StepOutput, error) {
-	var text, html, location string
+	var text, html, location, inputValue string
 	err := chromedp.Run(ctx,
 		chromedp.WaitVisible(req.Selector, chromedp.ByQuery),
 		chromedp.Clear(req.Selector, chromedp.ByQuery),
 		chromedp.SendKeys(req.Selector, req.Value, chromedp.ByQuery),
+		chromedp.Value(req.Selector, &inputValue, chromedp.ByQuery),
 		chromedp.InnerHTML("body", &html, chromedp.ByQuery),
 		chromedp.Text("body", &text, chromedp.ByQuery),
 		chromedp.Location(&location),
@@ -244,7 +245,19 @@ func (e *BrowserExecutor) doFill(ctx context.Context, req BrowserRequest) (StepO
 		return StepOutput{}, fmt.Errorf("browser: fill: %w", err)
 	}
 
-	return buildBrowserOutput(location, text, html, -1), nil
+	observed := fmt.Sprintf("URL: %s\nSelector: %s\nFilled value: %s\nPage content:\n%s",
+		location, req.Selector, inputValue, text)
+
+	return StepOutput{
+		Observed:    observed,
+		CaptureBody: text,
+		CaptureSources: map[string]string{
+			BrowserSourceText:     text,
+			BrowserSourceHTML:     html,
+			BrowserSourceLocation: location,
+			BrowserSourceValue:    inputValue,
+		},
+	}, nil
 }
 
 func (e *BrowserExecutor) doAssert(ctx context.Context, req BrowserRequest) (StepOutput, error) {

--- a/internal/scenario/browser_test.go
+++ b/internal/scenario/browser_test.go
@@ -94,7 +94,7 @@ func TestBrowserValidCaptureSources(t *testing.T) {
 	exec := &BrowserExecutor{}
 	sources := exec.ValidCaptureSources()
 	want := map[string]bool{
-		"text": true, "html": true, "count": true, "location": true,
+		"text": true, "html": true, "count": true, "location": true, "value": true,
 	}
 	if len(sources) != len(want) {
 		t.Fatalf("got %d sources, want %d", len(sources), len(want))

--- a/internal/scenario/types.go
+++ b/internal/scenario/types.go
@@ -23,6 +23,7 @@ const (
 	BrowserSourceHTML     = "html"
 	BrowserSourceCount    = "count"
 	BrowserSourceLocation = "location"
+	BrowserSourceValue    = "value"
 )
 
 // GRPC capture source constants.


### PR DESCRIPTION
Closes #129

## Changes
1. **`internal/scenario/types.go`** — Add `BrowserSourceValue = "value"` constant.

2. **`internal/scenario/browser.go`**
   - `ValidCaptureSources()`: add `BrowserSourceValue`.
   - `doFill()`: add `chromedp.Value(req.Selector, &inputValue, chromedp.ByQuery)` to the Run chain (after SendKeys). Build inline `StepOutput` with fill-specific `Observed` string and `BrowserSourceValue` in `CaptureSources`.

3. **`internal/llm/anthropic.go`** — `logUsage`: `Info` → `Debug`.

4. **`internal/llm/openai.go`** — `logUsage`: `Info` → `Debug`.

5. **`cmd/octog/main.go`**
   - `runCmd()`: add `-v` int flag, wire to `runLoopParams.Verbosity`.
   - `runLoopParams`: add `Verbosity int`.
   - `progressFn()`: add `verbosity int` to factory params. When `verbosity > 0` and outcome is validated, print per-scenario first lines from `p.Failures`. When `verbosity >= 2`, print full multi-line detail.
   - `runAttractorLoop()`: pass `p.Verbosity` to `progressFn`.
   - `validateCmd()`: add `-v` int flag. After `outputValidation`, if `*verbose >= 2`, print per-step detail from `agg.Scenarios`. (Note: `fprintValidationResult` already prints per-scenario summary lines, so `-v 1` is redundant for validate — only `-v 2` adds value by showing step-level detail.)

## Review Findings
- Errors: 0
- Warnings: 2
- Nits: 6
- Assessment: **NEEDS CHANGES**

The two warnings worth addressing: (1) `outputValidation` should accept an `io.Writer` for testability consistency, and (2) the validate `-v` flag should document or handle level 1 to avoid user confusion. The log level change from Info→Debug is worth a conscious decision against the "cost-aware by default" invariant in CLAUDE.md.
