### PR TITLE
fix(scenario): isolate parallel scenarios to prevent shared-state pollution

### DIFF
--- a/cmd/octog/main.go
+++ b/cmd/octog/main.go
@@ -15,13 +15,9 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"slices"
 	"strings"
-	"sync"
 	"time"
 	"unicode/utf8"
-
-	"golang.org/x/sync/errgroup"
 
 	"github.com/foundatron/octopusgarden/internal/attractor"
 	"github.com/foundatron/octopusgarden/internal/container"
@@ -310,33 +306,23 @@ func runAttractorLoop(ctx context.Context, logger *slog.Logger, llmClient llm.Cl
 
 	// Session provider pattern: the attractor sets the current session before
 	// calling validate, and the validate closure reads it to create ExecExecutors.
-	// Mutex protects against future refactoring that might run the attractor and
-	// validation concurrently (runAndScore fans out to 10 goroutines).
-	var sessionMu sync.Mutex
+	// Both calls are sequential (attractor loop never overlaps with validate), so
+	// no synchronization is needed.
 	var currentSession *container.Session
 	sessionProvider := attractor.SessionProviderFn(func(session *container.Session) {
-		sessionMu.Lock()
 		currentSession = session
-		sessionMu.Unlock()
 	})
 	sessionGetter := func() *container.Session {
-		sessionMu.Lock()
-		defer sessionMu.Unlock()
 		return currentSession
 	}
 
 	// gRPC target provider pattern: same as session provider — attractor sets it,
 	// validate closure reads it.
-	var grpcTargetMu sync.Mutex
 	var currentGRPCTarget string
 	grpcTargetProvider := attractor.GRPCTargetProviderFn(func(target string) {
-		grpcTargetMu.Lock()
 		currentGRPCTarget = target
-		grpcTargetMu.Unlock()
 	})
 	grpcTargetGetter := func() string {
-		grpcTargetMu.Lock()
-		defer grpcTargetMu.Unlock()
 		return currentGRPCTarget
 	}
 
@@ -543,6 +529,9 @@ func validateCmd(ctx context.Context, logger *slog.Logger, args []string) error 
 	if caps.NeedsGRPC && *grpcTarget == "" {
 		logger.Warn("scenarios contain gRPC steps but --grpc-target is not set; gRPC steps will fail")
 	}
+	if len(scenarios) > 1 {
+		logger.Warn("validating multiple scenarios against --target without container restart; state may accumulate between scenarios")
+	}
 	agg, err := runAndScore(ctx, scenarios, executorOpts{
 		targetURL:     *target,
 		logger:        logger,
@@ -550,7 +539,7 @@ func validateCmd(ctx context.Context, logger *slog.Logger, args []string) error 
 		needsBrowser:  caps.NeedsBrowser,
 		needsWS:       caps.NeedsWS,
 		grpcTarget:    *grpcTarget,
-	}, clients.client, *judgeModel)
+	}, clients.client, *judgeModel, nil)
 	if err != nil {
 		return fmt.Errorf("validate: %w", err)
 	}
@@ -994,82 +983,58 @@ func buildExecutors(opts executorOpts) (map[string]scenario.StepExecutor, func()
 	return executors, cleanup
 }
 
-func runAndScore(ctx context.Context, scenarios []scenario.Scenario, opts executorOpts, llmClient llm.Client, judgeModel string) (scenario.AggregateResult, error) {
-	type indexedResult struct {
-		index int
-		ss    scenario.ScoredScenario
-	}
-
-	var (
-		mu      sync.Mutex
-		results = make([]indexedResult, 0, len(scenarios))
-	)
-
-	g, gctx := errgroup.WithContext(ctx)
-	g.SetLimit(10)
+func runAndScore(ctx context.Context, scenarios []scenario.Scenario, opts executorOpts, llmClient llm.Client, judgeModel string, restart attractor.RestartFunc) (scenario.AggregateResult, error) {
+	scored := make([]scenario.ScoredScenario, 0, len(scenarios))
 
 	for i, sc := range scenarios {
-		g.Go(func() error {
-			// Each goroutine gets its own Runner (independent variable capture state) and Judge.
-			executors, cleanup := buildExecutors(opts)
-			defer cleanup()
-			runner := scenario.NewRunner(executors, opts.logger)
-			judge := scenario.NewJudge(llmClient, judgeModel, opts.logger)
-
-			result, err := runner.Run(gctx, sc)
+		if ctx.Err() != nil {
+			return scenario.AggregateResult{}, ctx.Err()
+		}
+		if i > 0 && restart != nil {
+			newURL, err := restart(ctx)
 			if err != nil {
-				// If the group context was canceled (another goroutine failed),
-				// propagate the cancellation rather than recording a phantom zero.
-				if gctx.Err() != nil {
-					return gctx.Err()
-				}
-				weight := 1.0
-				if sc.Weight != nil {
-					weight = *sc.Weight
-				}
-				opts.logger.Warn("scenario setup failed", "scenario", sc.ID, "error", err)
-				mu.Lock()
-				results = append(results, indexedResult{index: i, ss: scenario.ScoredScenario{
-					ScenarioID: sc.ID,
-					Weight:     weight,
-					Score:      0,
-				}})
-				mu.Unlock()
-				return nil
+				return scenario.AggregateResult{}, fmt.Errorf("restart container: %w", err)
 			}
+			opts.targetURL = newURL
+		}
 
-			ss, err := judge.ScoreScenario(gctx, sc, result)
-			if err != nil {
-				return fmt.Errorf("score scenario %s: %w", sc.ID, err)
+		executors, cleanup := buildExecutors(opts)
+		runner := scenario.NewRunner(executors, opts.logger)
+		judge := scenario.NewJudge(llmClient, judgeModel, opts.logger)
+
+		result, runErr := runner.Run(ctx, sc)
+		cleanup()
+		if runErr != nil {
+			weight := 1.0
+			if sc.Weight != nil {
+				weight = *sc.Weight
 			}
+			opts.logger.Warn("scenario setup failed", "scenario", sc.ID, "error", runErr)
+			scored = append(scored, scenario.ScoredScenario{
+				ScenarioID: sc.ID,
+				Weight:     weight,
+				Score:      0,
+			})
+			continue
+		}
 
-			mu.Lock()
-			results = append(results, indexedResult{index: i, ss: ss})
-			mu.Unlock()
-			return nil
-		})
-	}
+		ss, err := judge.ScoreScenario(ctx, sc, result)
+		if err != nil {
+			return scenario.AggregateResult{}, fmt.Errorf("score scenario %s: %w", sc.ID, err)
+		}
 
-	if err := g.Wait(); err != nil {
-		return scenario.AggregateResult{}, err
-	}
-
-	// Sort by original index for deterministic output.
-	slices.SortFunc(results, func(a, b indexedResult) int { return a.index - b.index })
-	scored := make([]scenario.ScoredScenario, len(results))
-	for i, r := range results {
-		scored[i] = r.ss
+		scored = append(scored, ss)
 	}
 
 	return scenario.Aggregate(scored), nil
 }
 
 func buildValidateFn(scenarios []scenario.Scenario, llmClient llm.Client, judgeModel string, baseOpts executorOpts, grpcTargetGetter func() string) attractor.ValidateFn {
-	return func(ctx context.Context, url string) (float64, []string, float64, error) {
+	return func(ctx context.Context, url string, restart attractor.RestartFunc) (float64, []string, float64, error) {
 		opts := baseOpts
 		opts.targetURL = url
 		opts.grpcTarget = grpcTargetGetter()
-		agg, err := runAndScore(ctx, scenarios, opts, llmClient, judgeModel)
+		agg, err := runAndScore(ctx, scenarios, opts, llmClient, judgeModel, restart)
 		if err != nil {
 			return 0, nil, 0, err
 		}

--- a/cmd/octog/main_test.go
+++ b/cmd/octog/main_test.go
@@ -91,7 +91,7 @@ func TestRunAndScore(t *testing.T) {
 		targetURL:     srv.URL,
 		logger:        testLogger(),
 		sessionGetter: func() *container.Session { return nil },
-	}, mock, "claude-haiku-4-5-20251001")
+	}, mock, "claude-haiku-4-5-20251001", nil)
 	if err != nil {
 		t.Fatalf("runAndScore: %v", err)
 	}
@@ -143,7 +143,7 @@ func TestRunAndScoreSetupFailure(t *testing.T) {
 		targetURL:     "http://127.0.0.1:1",
 		logger:        testLogger(),
 		sessionGetter: func() *container.Session { return nil },
-	}, mock, "claude-haiku-4-5-20251001")
+	}, mock, "claude-haiku-4-5-20251001", nil)
 	if err != nil {
 		t.Fatalf("runAndScore: %v", err)
 	}
@@ -319,7 +319,7 @@ func TestValidateThreshold(t *testing.T) {
 				targetURL:     srv.URL,
 				logger:        testLogger(),
 				sessionGetter: func() *container.Session { return nil },
-			}, mock, "claude-haiku-4-5-20251001")
+			}, mock, "claude-haiku-4-5-20251001", nil)
 			if err != nil {
 				t.Fatalf("runAndScore: %v", err)
 			}
@@ -1585,5 +1585,137 @@ func TestFrugalModelFlagParsing(t *testing.T) {
 	// not from an unrecognized flag.
 	if err != nil && strings.Contains(err.Error(), "flag provided but not defined") {
 		t.Errorf("--frugal-model flag not defined: %v", err)
+	}
+}
+
+// simpleScenario returns a Scenario with a single GET request step.
+func simpleScenario(id string) scenario.Scenario {
+	return scenario.Scenario{
+		ID: id,
+		Steps: []scenario.Step{
+			{Request: &scenario.Request{Method: "GET", Path: "/"}},
+		},
+	}
+}
+
+func TestRunAndScoreSequentialOrder(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	scenarios := []scenario.Scenario{
+		simpleScenario("s1"),
+		simpleScenario("s2"),
+		simpleScenario("s3"),
+	}
+
+	mock := &mockLLMClient{}
+	agg, err := runAndScore(context.Background(), scenarios, executorOpts{
+		targetURL:     srv.URL,
+		logger:        testLogger(),
+		sessionGetter: func() *container.Session { return nil },
+	}, mock, "claude-haiku-4-5-20251001", nil)
+	if err != nil {
+		t.Fatalf("runAndScore: %v", err)
+	}
+
+	if len(agg.Scenarios) != 3 {
+		t.Fatalf("expected 3 scenarios, got %d", len(agg.Scenarios))
+	}
+	for i, want := range []string{"s1", "s2", "s3"} {
+		if agg.Scenarios[i].ScenarioID != want {
+			t.Errorf("scenario[%d]: got %q, want %q", i, agg.Scenarios[i].ScenarioID, want)
+		}
+	}
+}
+
+func TestRunAndScoreRestartCalledBetweenScenarios(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	scenarios := []scenario.Scenario{
+		simpleScenario("s1"),
+		simpleScenario("s2"),
+	}
+
+	restartCount := 0
+	restart := attractor.RestartFunc(func(_ context.Context) (string, error) {
+		restartCount++
+		return srv.URL, nil
+	})
+
+	mock := &mockLLMClient{}
+	agg, err := runAndScore(context.Background(), scenarios, executorOpts{
+		targetURL:     srv.URL,
+		logger:        testLogger(),
+		sessionGetter: func() *container.Session { return nil },
+	}, mock, "claude-haiku-4-5-20251001", restart)
+	if err != nil {
+		t.Fatalf("runAndScore: %v", err)
+	}
+
+	if len(agg.Scenarios) != 2 {
+		t.Fatalf("expected 2 scenarios, got %d", len(agg.Scenarios))
+	}
+	if restartCount != 1 {
+		t.Errorf("expected restart called 1 time, got %d", restartCount)
+	}
+}
+
+func TestRunAndScoreRestartErrorPropagation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	scenarios := []scenario.Scenario{
+		simpleScenario("s1"),
+		simpleScenario("s2"),
+	}
+
+	errRestart := errors.New("container restart failed")
+	restart := attractor.RestartFunc(func(_ context.Context) (string, error) {
+		return "", errRestart
+	})
+
+	mock := &mockLLMClient{}
+	_, err := runAndScore(context.Background(), scenarios, executorOpts{
+		targetURL:     srv.URL,
+		logger:        testLogger(),
+		sessionGetter: func() *container.Session { return nil },
+	}, mock, "claude-haiku-4-5-20251001", restart)
+	if err == nil {
+		t.Fatal("expected error from restart, got nil")
+	}
+	if !strings.Contains(err.Error(), "restart container") {
+		t.Errorf("expected error to contain 'restart container', got: %v", err)
+	}
+}
+
+func TestRunAndScoreNilRestart(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	scenarios := []scenario.Scenario{
+		simpleScenario("s1"),
+		simpleScenario("s2"),
+	}
+
+	mock := &mockLLMClient{}
+	agg, err := runAndScore(context.Background(), scenarios, executorOpts{
+		targetURL:     srv.URL,
+		logger:        testLogger(),
+		sessionGetter: func() *container.Session { return nil },
+	}, mock, "claude-haiku-4-5-20251001", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(agg.Scenarios) != 2 {
+		t.Fatalf("expected 2 scenarios, got %d", len(agg.Scenarios))
 	}
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -489,7 +489,9 @@ type ContainerManager interface {
 ```go
 // ValidateFn runs holdout scenarios against a running container and returns results.
 // The attractor never imports internal/scenario — the CLI provides this closure.
-type ValidateFn func(ctx context.Context, url string) (satisfaction float64, failures []string, cost float64, err error)
+// restart may be called to stop the current container and start a fresh one between scenarios.
+// restart is nil for gRPC and exec-only paths that do not support container restart.
+type ValidateFn func(ctx context.Context, url string, restart RestartFunc) (satisfaction float64, failures []string, cost float64, err error)
 ```
 
 [embedmd]:# (../internal/attractor/attractor.go go /^\/\/ RunOptions configures/ /^}/)

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.40.0
 	go.opentelemetry.io/otel/sdk v1.40.0
 	go.opentelemetry.io/otel/trace v1.40.0
-	golang.org/x/sync v0.19.0
 	google.golang.org/grpc v1.79.1
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
@@ -63,6 +62,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 // indirect
 	golang.org/x/net v0.49.0 // indirect
+	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260128011058-8636f8732409 // indirect

--- a/internal/attractor/attractor.go
+++ b/internal/attractor/attractor.go
@@ -100,9 +100,15 @@ type ContainerManager interface {
 	StartSession(ctx context.Context, tag string) (session *container.Session, stop container.StopFunc, err error)
 }
 
+// RestartFunc stops the current container, starts a fresh one, and returns the new URL.
+// It is provided to ValidateFn so that a scenario can trigger a clean restart between runs.
+type RestartFunc func(ctx context.Context) (newURL string, err error)
+
 // ValidateFn runs holdout scenarios against a running container and returns results.
 // The attractor never imports internal/scenario — the CLI provides this closure.
-type ValidateFn func(ctx context.Context, url string) (satisfaction float64, failures []string, cost float64, err error)
+// restart may be called to stop the current container and start a fresh one between scenarios.
+// restart is nil for gRPC and exec-only paths that do not support container restart.
+type ValidateFn func(ctx context.Context, url string, restart RestartFunc) (satisfaction float64, failures []string, cost float64, err error)
 
 // Attractor orchestrates the convergence loop: generate code → build → validate → iterate.
 type Attractor struct {
@@ -585,6 +591,7 @@ func (a *Attractor) buildRunValidate(ctx context.Context, iter int, iterDir stri
 		defer s.sessionProvider(nil) // clear session after validation
 	}
 
+	var restartFn RestartFunc
 	switch {
 	case caps.NeedsGRPC:
 		res, err := a.startGRPCContainer(ctx, iter, tag, caps, s)
@@ -601,25 +608,17 @@ func (a *Attractor) buildRunValidate(ctx context.Context, iter int, iterDir stri
 		defer s.grpcTargetProvider("") // clear after validation
 	case caps.NeedsHTTP || caps.NeedsBrowser || !caps.NeedsExec:
 		// If only HTTP needed, or no capabilities detected (legacy), use Run + WaitHealthy.
-		runRes, stop, err := a.containerMgr.Run(ctx, tag)
+		res, err := a.startHTTPContainer(ctx, iter, tag, s.opts.HealthTimeout, s)
 		if err != nil {
-			a.logger.Warn("container run failed", "iteration", iter, "error", err)
-			s.lastOutcome = OutcomeRunFail
-			s.lastSatisfaction = 0
-			s.recordStall(iter, feedbackRunError, fmt.Sprintf("Container failed to start: %s", err))
-			return a.checkStalled(iter, s), nil
+			return nil, err
 		}
-		defer stop()
-		url = runRes.URL
-		containerID = runRes.ContainerID
-
-		if err := a.containerMgr.WaitHealthy(ctx, url, s.opts.HealthTimeout); err != nil {
-			a.logger.Warn("health check failed", "iteration", iter, "error", err)
-			s.lastOutcome = OutcomeHealthFail
-			s.lastSatisfaction = 0
-			s.recordStall(iter, feedbackHealthError, fmt.Sprintf("Health check failed: %s", err))
-			return a.checkStalled(iter, s), nil
+		if res.stop == nil {
+			return res.stalled, nil
 		}
+		defer res.stop()
+		url = res.url
+		containerID = res.containerID
+		restartFn = res.restart
 	}
 
 	// Run test command before validation when configured and an HTTP container is available.
@@ -627,7 +626,7 @@ func (a *Attractor) buildRunValidate(ctx context.Context, iter int, iterDir stri
 		return stall, err
 	}
 
-	satisfaction, failures, valCost, err := validate(ctx, url)
+	satisfaction, failures, valCost, err := validate(ctx, url, restartFn)
 	if err != nil {
 		return nil, fmt.Errorf("attractor: validate iteration %d: %w", iter, err)
 	}
@@ -668,6 +667,64 @@ func (a *Attractor) runTestCommand(ctx context.Context, iter int, containerID st
 		return true, a.checkStalled(iter, s), nil
 	}
 	return false, nil, nil
+}
+
+// httpContainerResult holds the outputs of startHTTPContainer.
+type httpContainerResult struct {
+	url         string
+	stop        func() // non-nil on success; nil when startup failed (safe to use as failure sentinel)
+	restart     RestartFunc
+	containerID string
+	stalled     *RunResult // non-nil when startup failed and stall limit is reached
+}
+
+// startHTTPContainer launches a container, waits for HTTP health, and builds a RestartFunc.
+// When startup fails, result.stop is nil and the container has already been stopped.
+// The caller must defer result.stop() only when result.stop is non-nil.
+// The stop function and restart function share a mutable reference so that restarting
+// updates the cleanup target without changing the deferred call site.
+func (a *Attractor) startHTTPContainer(ctx context.Context, iter int, tag string, healthTimeout time.Duration, s *runState) (httpContainerResult, error) {
+	runRes, stop, err := a.containerMgr.Run(ctx, tag)
+	if err != nil {
+		a.logger.Warn("container run failed", "iteration", iter, "error", err)
+		s.lastOutcome = OutcomeRunFail
+		s.lastSatisfaction = 0
+		s.recordStall(iter, feedbackRunError, fmt.Sprintf("Container failed to start: %s", err))
+		return httpContainerResult{stalled: a.checkStalled(iter, s)}, nil
+	}
+
+	if err := a.containerMgr.WaitHealthy(ctx, runRes.URL, healthTimeout); err != nil {
+		stop()
+		a.logger.Warn("health check failed", "iteration", iter, "error", err)
+		s.lastOutcome = OutcomeHealthFail
+		s.lastSatisfaction = 0
+		s.recordStall(iter, feedbackHealthError, fmt.Sprintf("Health check failed: %s", err))
+		return httpContainerResult{stalled: a.checkStalled(iter, s)}, nil
+	}
+
+	currentStop := stop
+	restartFn := func(restartCtx context.Context) (string, error) {
+		currentStop()
+		currentStop = func() {} // prevent double-stop if Run fails
+		newRes, newStop, runErr := a.containerMgr.Run(restartCtx, tag)
+		if runErr != nil {
+			return "", fmt.Errorf("attractor: restart container: %w", runErr)
+		}
+		currentStop = newStop
+		if hErr := a.containerMgr.WaitHealthy(restartCtx, newRes.URL, healthTimeout); hErr != nil {
+			newStop()
+			currentStop = func() {}
+			return "", fmt.Errorf("attractor: restart health check: %w", hErr)
+		}
+		return newRes.URL, nil
+	}
+
+	return httpContainerResult{
+		url:         runRes.URL,
+		containerID: runRes.ContainerID,
+		stop:        func() { currentStop() },
+		restart:     restartFn,
+	}, nil
 }
 
 // grpcContainerResult holds the outputs of startGRPCContainer.

--- a/internal/attractor/attractor_test.go
+++ b/internal/attractor/attractor_test.go
@@ -123,7 +123,7 @@ func TestConvergesImmediately(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -147,7 +147,7 @@ func TestConvergesOnIteration2(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		n := callCount.Add(1)
 		if n == 1 {
 			return 60, []string{"missing endpoint"}, 0.005, nil
@@ -174,7 +174,7 @@ func TestStalls(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		return 50, []string{"not good enough"}, 0.005, nil
 	}
 
@@ -203,7 +203,7 @@ func TestStallResetsOnImprovement(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		n := callCount.Add(1)
 		idx := int(n) - 1
 		if idx >= len(scores) {
@@ -236,7 +236,7 @@ func TestBudgetExceeded(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.04}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		return 50, []string{"not done"}, 0.02, nil
 	}
 
@@ -273,7 +273,7 @@ func TestBuildFailureFeedback(t *testing.T) {
 			return nil
 		},
 	}
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -306,7 +306,7 @@ func TestHealthCheckFailure(t *testing.T) {
 			return nil
 		},
 	}
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -326,7 +326,7 @@ func TestMaxIterations(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		return 80, []string{"close but no cigar"}, 0.005, nil
 	}
 
@@ -418,7 +418,7 @@ func TestCacheControlSet(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -443,7 +443,7 @@ func TestCheckpointWritten(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		n := callCount.Add(1)
 		return scores[int(n)-1], nil, 0.005, nil
 	}
@@ -481,7 +481,7 @@ func TestContainerRunFailure(t *testing.T) {
 			return container.RunResult{URL: "http://127.0.0.1:9999", ContainerID: "mock-container-id"}, func() {}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -512,7 +512,7 @@ func TestNeedsBrowserTriggersHTTPContainer(t *testing.T) {
 			return nil
 		},
 	}
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -543,7 +543,7 @@ func TestProgressCallback(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		n := callCount.Add(1)
 		return scores[int(n)-1], []string{"needs work"}, 0.005, nil
 	}
@@ -620,7 +620,7 @@ func TestProgressCallbackBuildFailure(t *testing.T) {
 			return nil
 		},
 	}
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -680,7 +680,7 @@ func TestPatchModeUsedOnIteration2(t *testing.T) {
 		},
 	}
 	var callCount atomic.Int32
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		n := callCount.Add(1)
 		if n == 1 {
 			return 60, []string{"missing endpoint"}, 0.005, nil
@@ -728,7 +728,7 @@ func TestPatchModeFallbackOnRegressions(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		n := callCount.Add(1)
 		idx := int(n) - 1
 		if idx >= len(scores) {
@@ -776,7 +776,7 @@ func TestPatchModeRegressionResets(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		n := callCount.Add(1)
 		idx := int(n) - 1
 		if idx >= len(scores) {
@@ -816,7 +816,7 @@ func TestPatchModeDisabledByDefault(t *testing.T) {
 		},
 	}
 	var callCount atomic.Int32
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		n := callCount.Add(1)
 		if n == 1 {
 			return 60, []string{"needs work"}, 0.005, nil
@@ -860,7 +860,7 @@ func TestPatchModeNotActiveWithoutBestFiles(t *testing.T) {
 			return nil
 		},
 	}
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -919,7 +919,7 @@ func main() { serveFixed() }
 	}
 
 	var valCount atomic.Int32
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		n := valCount.Add(1)
 		if n == 1 {
 			return 60, []string{"needs fix"}, 0.005, nil
@@ -961,7 +961,7 @@ func TestValidateError(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		return 0, nil, 0, fmt.Errorf("judge unavailable")
 	}
 
@@ -987,7 +987,7 @@ func TestContextBudgetZeroPreservesBehavior(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -1033,7 +1033,7 @@ Brief abstract of the spec.`,
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		n := callCount.Add(1)
 		if n == 1 {
 			return 60, []string{"missing endpoint"}, 0.005, nil
@@ -1084,7 +1084,7 @@ func TestContextBudgetSummarizeFailureNonFatal(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -1116,7 +1116,7 @@ func TestAttractorRunWithGenes(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -1150,7 +1150,7 @@ func TestAttractorRunGenesInSystemPrompt(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -1185,7 +1185,7 @@ func TestAttractorRunGenesPersistAcrossIterations(t *testing.T) {
 		},
 	}
 	var callCount atomic.Int32
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		n := callCount.Add(1)
 		if n < 3 {
 			return 60, []string{"needs work"}, 0.005, nil
@@ -1224,7 +1224,7 @@ func TestAttractorCrossLanguagePrompt(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -1291,7 +1291,7 @@ func TestStallNoticeAppearsInGenerateByIteration3(t *testing.T) {
 	}
 
 	// ValidateFn always returns the same failing scenario in the format parsed by parseFailedScenarios.
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		return 45, []string{"✗ stall-scenario (45/100)"}, 0.005, nil
 	}
 
@@ -1368,7 +1368,7 @@ func TestMinimalismPromptAppearsAbove80(t *testing.T) {
 			}
 			failures := []string{FormatScenarioFailureLine("test-scenario", 50)}
 			var validateCount atomic.Int32
-			validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+			validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 				n := validateCount.Add(1)
 				if n == 1 {
 					return tt.score, failures, 0, nil
@@ -1410,7 +1410,7 @@ func TestMinimalismPromptIncludesFailingScenarios(t *testing.T) {
 		FormatScenarioFailureLine("list-items", 55),
 	}
 	var validateCount atomic.Int32
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		n := validateCount.Add(1)
 		if n == 1 {
 			return 85, failures, 0, nil
@@ -1455,7 +1455,7 @@ func TestMinimalismPromptProgression(t *testing.T) {
 		},
 	}
 	var validateCount atomic.Int32
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		n := int(validateCount.Add(1)) - 1
 		if n < len(scores) {
 			return scores[n], scenarioFailures[n], 0, nil
@@ -1512,7 +1512,7 @@ func TestRegressionFeedbackInjected(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		n := validateCount.Add(1)
 		switch n {
 		case 1:
@@ -1596,7 +1596,7 @@ CMD ["./server"]
 	}
 
 	// Validation always fails — drives stall without converging.
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		return 30, []string{"not good enough"}, 0.005, nil
 	}
 
@@ -1656,7 +1656,7 @@ func TestBlockOnRegressionPreventsConvergence(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		n := validateCount.Add(1)
 		switch n {
 		case 1:
@@ -1701,7 +1701,7 @@ func TestTestCommandEmpty_SkipsMechanicalTest(t *testing.T) {
 			return container.ExecResult{ExitCode: 0}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -1734,7 +1734,7 @@ func TestTestCommandExitZero_ProceedsToJudge(t *testing.T) {
 			return container.ExecResult{ExitCode: 0, Stdout: "ok\n"}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		validateCalled = true
 		return 100, nil, 0.005, nil
 	}
@@ -1772,7 +1772,7 @@ func TestTestCommandExitNonZero_SkipsJudge(t *testing.T) {
 			return container.ExecResult{ExitCode: 1, Stderr: "FAIL: test_foo\n"}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		validateCalled = true
 		return 100, nil, 0.005, nil
 	}
@@ -1819,7 +1819,7 @@ func TestTestCommandOutput_IncludedInFeedback(t *testing.T) {
 			return container.ExecResult{ExitCode: 1, Stdout: testOutput, Stderr: ""}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -1846,7 +1846,7 @@ func validDiagnosisJSON() string {
 // Failure format matches FormatScenarioFailureLine so buildSteeringText can detect the stall.
 func stallingValidateFn(n int) (ValidateFn, *atomic.Int32) {
 	var count atomic.Int32
-	fn := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	fn := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		c := int(count.Add(1))
 		if c <= n {
 			return 50, []string{FormatScenarioFailureLine("auth", 50)}, 0.005, nil
@@ -2051,7 +2051,7 @@ func TestWonderReflect_OnlyOnStall(t *testing.T) {
 	}
 
 	// Always succeeds — no stall, no wonder/reflect.
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -2161,7 +2161,7 @@ func TestModelEscalationPassedToGenerate(t *testing.T) {
 			return nil
 		},
 	}
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -2210,7 +2210,7 @@ func TestNoEscalationWithoutFrugalModel(t *testing.T) {
 		},
 	}
 	var callCount atomic.Int32
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		n := callCount.Add(1)
 		if n < 3 {
 			return 50, []string{"not yet"}, 0.005, nil

--- a/internal/attractor/isolation_test.go
+++ b/internal/attractor/isolation_test.go
@@ -46,7 +46,7 @@ func TestSystemPromptContainsOnlySpec(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -93,7 +93,7 @@ func TestScenarioContentNeverInSystemPrompt(t *testing.T) {
 		},
 	}
 
-	validate := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
 		n := callCount.Add(1)
 		// Return failures containing sentinels — these should appear in user
 		// messages (feedback channel) but never in system prompts.

--- a/internal/e2e/e2e_integration_test.go
+++ b/internal/e2e/e2e_integration_test.go
@@ -230,7 +230,7 @@ func checkDockerAvailable(ctx context.Context, t *testing.T) {
 // makeValidateFn builds an attractor.ValidateFn that runs all scenarios sequentially
 // and returns the aggregate satisfaction score.
 func makeValidateFn(t *testing.T, scenarios []scenario.Scenario, llmClient llm.Client, logger *slog.Logger) attractor.ValidateFn {
-	return func(ctx context.Context, baseURL string) (float64, []string, float64, error) {
+	return func(ctx context.Context, baseURL string, _ attractor.RestartFunc) (float64, []string, float64, error) {
 		httpCli := &http.Client{Timeout: 30 * time.Second}
 		executors := map[string]scenario.StepExecutor{
 			"request": &scenario.HTTPExecutor{Client: httpCli, BaseURL: baseURL},

--- a/internal/observability/validate.go
+++ b/internal/observability/validate.go
@@ -13,13 +13,13 @@ import (
 // WrapValidateFn wraps a ValidateFn with a scenario.validate span.
 func WrapValidateFn(fn attractor.ValidateFn, tp trace.TracerProvider) attractor.ValidateFn {
 	tracer := tp.Tracer("octog/scenario")
-	return func(ctx context.Context, url string) (float64, []string, float64, error) {
+	return func(ctx context.Context, url string, restart attractor.RestartFunc) (float64, []string, float64, error) {
 		ctx, span := tracer.Start(ctx, "scenario.validate", trace.WithAttributes(
 			attribute.String("scenario.target_url", url),
 		))
 		defer span.End()
 
-		satisfaction, failures, cost, err := fn(ctx, url)
+		satisfaction, failures, cost, err := fn(ctx, url, restart)
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())

--- a/internal/observability/validate_test.go
+++ b/internal/observability/validate_test.go
@@ -5,18 +5,20 @@ import (
 	"testing"
 
 	"go.opentelemetry.io/otel/codes"
+
+	"github.com/foundatron/octopusgarden/internal/attractor"
 )
 
 func TestWrapValidateFnSuccess(t *testing.T) {
 	exp, tp := newTestTP()
 	defer func() { _ = tp.Shutdown(context.Background()) }()
 
-	inner := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	inner := func(_ context.Context, _ string, _ attractor.RestartFunc) (float64, []string, float64, error) {
 		return 85.0, []string{"minor issue"}, 0.005, nil
 	}
 
 	wrapped := WrapValidateFn(inner, tp)
-	sat, failures, cost, err := wrapped(context.Background(), "http://localhost:8080")
+	sat, failures, cost, err := wrapped(context.Background(), "http://localhost:8080", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -49,12 +51,12 @@ func TestWrapValidateFnError(t *testing.T) {
 	exp, tp := newTestTP()
 	defer func() { _ = tp.Shutdown(context.Background()) }()
 
-	inner := func(_ context.Context, _ string) (float64, []string, float64, error) {
+	inner := func(_ context.Context, _ string, _ attractor.RestartFunc) (float64, []string, float64, error) {
 		return 0, nil, 0, errMock
 	}
 
 	wrapped := WrapValidateFn(inner, tp)
-	_, _, _, err := wrapped(context.Background(), "http://localhost:8080")
+	_, _, _, err := wrapped(context.Background(), "http://localhost:8080", nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}


### PR DESCRIPTION
Closes #128

## Changes
**1. `internal/attractor/attractor.go`**
- Add `RestartFunc` type: `type RestartFunc func(ctx context.Context) (newURL string, err error)`
- Update `ValidateFn` signature to: `func(ctx context.Context, url string, restart RestartFunc) (...)`
- In `buildRunValidate` HTTP/browser branch:
  - Declare `currentStop := stop`
  - Replace `defer stop()` with `defer func() { currentStop() }()`
  - Build `restartFn` closure that calls `currentStop()` → `Run()` → `WaitHealthy()`, reassigns `currentStop`
- Update `validate(ctx, url)` call to `validate(ctx, url, restartFn)`
- For gRPC and exec-only paths: declare `var restartFn RestartFunc` (nil) at top of switch, pass through

**2. `cmd/octog/main.go`**
- Add `restart attractor.RestartFunc` parameter to `runAndScore`
- Replace `errgroup` parallel loop with sequential `for` loop
- Between scenarios (`i > 0 && restart != nil`): call `restart(ctx)`, update local `opts.targetURL` with returned URL
- Remove `indexedResult` type, `sync.Mutex`, `slices.SortFunc` — append directly
- Update `buildValidateFn` closure to accept and pass through `RestartFunc`
- In `validateCmd` (line 546): pass `nil` restart; add `slog.Warn` when `len(scenarios) > 1`
- Update comment on line 314 ("fans out to 10 goroutines" → sequential)
- Remove `"golang.org/x/sync/errgroup"` and `"slices"` imports

**3. `internal/observability/validate.go`**
- Update `WrapValidateFn` inner closure to accept and pass through `RestartFunc`

**4. `internal/observability/validate_test.go`**
- Update both mock `ValidateFn` closures and `wrapped(...)` call sites for new signature

**5. `internal/attractor/attractor_test.go`**
- Update `stallingValidateFn` and all ~45 inline `ValidateFn` closures to accept `RestartFunc` (ignore it)

**6. `cmd/octog/main_test.go`**
- Update 3 existing `runAndScore(...)` calls to pass `nil` restart
- Add new tests (see below)

**7. `internal/e2e/e2e_integration_test.go`** *(missing from original plan)*
- Update `makeValidateFn` return closure signature to accept `RestartFunc` (ignore it — e2e tests don't use restart)

**8. `go.mod` / `go.sum`**
- Run `go mod tidy` to remove `golang.org/x/sync`

## Review Findings
- Errors: 1
- Warnings: 2
- Nits: 2
- Assessment: **NEEDS CHANGES**

The double-stop bug (finding 1) is a real defect that can cause panics or undefined behavior depending on the `StopFunc` implementation. The missing context cancellation check (finding 2) is a behavioral regression from the errgroup version.
