### PR TITLE
feat(preflight): verbose mode with actionable per-dimension feedback

### DIFF
--- a/cmd/octog/main.go
+++ b/cmd/octog/main.go
@@ -863,6 +863,7 @@ func preflightCmd(ctx context.Context, logger *slog.Logger, args []string) error
 	provider := fs.String("provider", "", "LLM provider: anthropic or openai (auto-detected from env if omitted)")
 	judgeModel := fs.String("judge-model", "", "LLM model for clarity assessment (default: provider-specific)")
 	threshold := fs.Float64("threshold", 0.8, "aggregate clarity score threshold (0.0–1.0)")
+	verbose := fs.Bool("verbose", false, "show per-dimension strengths and gaps")
 
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: octog preflight [flags] <spec-path>\n\nAssess spec clarity before running the attractor loop.\n\nFlags:\n")
@@ -902,9 +903,15 @@ func preflightCmd(ctx context.Context, logger *slog.Logger, args []string) error
 	}
 
 	fmt.Printf("Preflight results for: %s\n", specPath)
-	fmt.Printf("  Goal clarity:       %.2f\n", result.GoalClarity)
-	fmt.Printf("  Constraint clarity: %.2f\n", result.ConstraintClarity)
-	fmt.Printf("  Success clarity:    %.2f\n", result.SuccessClarity)
+
+	if *verbose {
+		printPreflightVerbose(result)
+	} else {
+		fmt.Printf("  Goal clarity:       %.2f\n", result.GoalClarity)
+		fmt.Printf("  Constraint clarity: %.2f\n", result.ConstraintClarity)
+		fmt.Printf("  Success clarity:    %.2f\n", result.SuccessClarity)
+	}
+
 	fmt.Printf("  Aggregate score:    %.2f (threshold: %.2f)\n", result.AggregateScore, *threshold)
 
 	if result.Pass {
@@ -920,6 +927,34 @@ func preflightCmd(ctx context.Context, logger *slog.Logger, args []string) error
 		}
 	}
 	return errPreflightFailed
+}
+
+func printPreflightVerbose(result *preflight.Result) {
+	dims := []struct {
+		key   string
+		label string
+		score float64
+	}{
+		{"goal", "Goal clarity:", result.GoalClarity},
+		{"constraint", "Constraint clarity:", result.ConstraintClarity},
+		{"success", "Success clarity:", result.SuccessClarity},
+	}
+	for _, d := range dims {
+		fmt.Printf("  %-20s%.2f\n", d.label, d.score)
+		strengths := result.Strengths[d.key]
+		gaps := result.Gaps[d.key]
+		if len(strengths) == 0 && len(gaps) == 0 {
+			fmt.Printf("    (no details available)\n")
+		} else {
+			for _, s := range strengths {
+				fmt.Printf("    ✓ %s\n", s)
+			}
+			for _, g := range gaps {
+				fmt.Printf("    ~ %s\n", g)
+			}
+		}
+		fmt.Println()
+	}
 }
 
 func openStore(ctx context.Context) (*store.Store, error) {

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -20,6 +20,8 @@ type Result struct {
 	AggregateScore    float64
 	Pass              bool
 	Questions         []string
+	Strengths         map[string][]string
+	Gaps              map[string][]string
 }
 
 // preflightResponse is the expected JSON structure from the preflight LLM call.
@@ -28,6 +30,8 @@ type preflightResponse struct {
 	ConstraintClarity float64             `json:"constraint_clarity"`
 	SuccessClarity    float64             `json:"success_clarity"`
 	Questions         map[string][]string `json:"questions"`
+	Strengths         map[string][]string `json:"strengths"`
+	Gaps              map[string][]string `json:"gaps"`
 }
 
 // computeAggregate returns a weighted aggregate of the three clarity dimensions.
@@ -45,13 +49,27 @@ Evaluate the spec on three dimensions, each scored from 0.0 (completely unclear)
 - constraint_clarity: Does the spec clearly define HOW the software should work? Are technical constraints, interfaces, and non-functional requirements specified?
 - success_clarity: Does the spec clearly define how to verify success? Are acceptance criteria measurable and testable?
 
-For any dimension scoring below the caller's threshold, provide clarifying questions that, if answered, would raise that dimension's score.
+For each dimension, provide:
+- "strengths": 2–4 bullets describing what the spec does well for that dimension
+- "gaps": 0–4 bullets describing specific, actionable gaps that would raise the score if addressed
+
+For any dimension scoring below the caller's threshold, also provide clarifying questions in "questions".
 
 Respond ONLY with valid JSON matching this exact schema:
 {
   "goal_clarity": <float 0.0-1.0>,
   "constraint_clarity": <float 0.0-1.0>,
   "success_clarity": <float 0.0-1.0>,
+  "strengths": {
+    "goal": ["strength1", "strength2"],
+    "constraint": ["strength1"],
+    "success": ["strength1"]
+  },
+  "gaps": {
+    "goal": ["gap1"],
+    "constraint": ["gap1", "gap2"],
+    "success": []
+  },
   "questions": {
     "goal": ["question1", "question2"],
     "constraint": ["question1"],
@@ -64,6 +82,16 @@ Example response for a clear spec:
   "goal_clarity": 0.95,
   "constraint_clarity": 0.88,
   "success_clarity": 0.92,
+  "strengths": {
+    "goal": ["Core user flows are explicitly enumerated", "Problem statement is unambiguous"],
+    "constraint": ["API contract is fully specified", "Performance budget is defined"],
+    "success": ["Acceptance criteria are measurable", "Test scenarios are concrete"]
+  },
+  "gaps": {
+    "goal": [],
+    "constraint": ["Error handling behavior under load is unspecified"],
+    "success": []
+  },
   "questions": {}
 }
 
@@ -72,6 +100,16 @@ Example response for an unclear spec:
   "goal_clarity": 0.4,
   "constraint_clarity": 0.6,
   "success_clarity": 0.3,
+  "strengths": {
+    "goal": ["High-level purpose is stated"],
+    "constraint": ["Technology stack is named", "Deployment target is specified"],
+    "success": ["One passing criterion is given"]
+  },
+  "gaps": {
+    "goal": ["Primary user-facing features are not listed", "Edge cases are absent"],
+    "constraint": ["API request/response shapes are missing"],
+    "success": ["No measurable thresholds defined", "No negative test cases specified"]
+  },
   "questions": {
     "goal": ["What are the primary user-facing features?", "What problem does this software solve?"],
     "success": ["How will success be measured?", "What constitutes a passing test?"]
@@ -154,5 +192,7 @@ func Check(ctx context.Context, client llm.Client, model, specContent string, th
 		AggregateScore:    agg,
 		Pass:              agg >= threshold,
 		Questions:         questions,
+		Strengths:         parsed.Strengths,
+		Gaps:              parsed.Gaps,
 	}, nil
 }

--- a/internal/preflight/preflight_test.go
+++ b/internal/preflight/preflight_test.go
@@ -38,6 +38,13 @@ func makeJSONResponse(goal, constraint, success float64, questions string) strin
 		goal, constraint, success, questions)
 }
 
+func makeJSONResponseFull(goal, constraint, success float64, questions, strengths, gaps string) string {
+	return fmt.Sprintf(
+		`{"goal_clarity":%g,"constraint_clarity":%g,"success_clarity":%g,"questions":%s,"strengths":%s,"gaps":%s}`,
+		goal, constraint, success, questions, strengths, gaps,
+	)
+}
+
 func TestComputeAggregate(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -224,6 +231,73 @@ func TestCheckMalformedResponse(t *testing.T) {
 				t.Errorf("expected errMalformedResponse, got %v", err)
 			}
 		})
+	}
+}
+
+func TestParseResponseWithStrengthsGaps(t *testing.T) {
+	strengths := `{"goal":["Clear purpose"],"constraint":["API specified"],"success":["Measurable criteria"]}`
+	gaps := `{"goal":["Edge cases absent"],"constraint":[],"success":["No thresholds"]}`
+	input := makeJSONResponseFull(0.9, 0.8, 0.85, `{}`, strengths, gaps)
+
+	got, err := parseResponse(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.Strengths["goal"]) != 1 || got.Strengths["goal"][0] != "Clear purpose" {
+		t.Errorf("unexpected goal strengths: %v", got.Strengths["goal"])
+	}
+	if len(got.Strengths["constraint"]) != 1 || got.Strengths["constraint"][0] != "API specified" {
+		t.Errorf("unexpected constraint strengths: %v", got.Strengths["constraint"])
+	}
+	if len(got.Gaps["goal"]) != 1 || got.Gaps["goal"][0] != "Edge cases absent" {
+		t.Errorf("unexpected goal gaps: %v", got.Gaps["goal"])
+	}
+	if len(got.Gaps["constraint"]) != 0 {
+		t.Errorf("expected empty constraint gaps, got %v", got.Gaps["constraint"])
+	}
+	if len(got.Gaps["success"]) != 1 || got.Gaps["success"][0] != "No thresholds" {
+		t.Errorf("unexpected success gaps: %v", got.Gaps["success"])
+	}
+}
+
+func TestParseResponseWithoutStrengthsGaps(t *testing.T) {
+	input := makeJSONResponse(0.9, 0.8, 0.85, `{}`)
+
+	got, err := parseResponse(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Strengths != nil {
+		t.Errorf("expected nil Strengths, got %v", got.Strengths)
+	}
+	if got.Gaps != nil {
+		t.Errorf("expected nil Gaps, got %v", got.Gaps)
+	}
+}
+
+func TestCheckPropagatesStrengthsGaps(t *testing.T) {
+	strengths := `{"goal":["Purpose is clear"],"constraint":["Constraints listed"],"success":["Criteria given"]}`
+	gaps := `{"goal":[],"constraint":["Error handling missing"],"success":[]}`
+	mock := &mockClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{
+				Content: makeJSONResponseFull(0.9, 0.8, 0.85, `{}`, strengths, gaps),
+			}, nil
+		},
+	}
+
+	result, err := Check(context.Background(), mock, "test-model", "spec content", 0.8, testLogger())
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if len(result.Strengths["goal"]) != 1 || result.Strengths["goal"][0] != "Purpose is clear" {
+		t.Errorf("unexpected goal strengths: %v", result.Strengths["goal"])
+	}
+	if len(result.Gaps["constraint"]) != 1 || result.Gaps["constraint"][0] != "Error handling missing" {
+		t.Errorf("unexpected constraint gaps: %v", result.Gaps["constraint"])
+	}
+	if len(result.Gaps["goal"]) != 0 {
+		t.Errorf("expected empty goal gaps, got %v", result.Gaps["goal"])
 	}
 }
 


### PR DESCRIPTION
Closes #130

## Changes
**`internal/preflight/preflight.go`**
1. Add `Strengths map[string][]string` and `Gaps map[string][]string` fields to `preflightResponse` struct, with JSON tags `"strengths"` and `"gaps"`
2. Add `Strengths map[string][]string` and `Gaps map[string][]string` fields to `Result` struct
3. Extend `buildSystemPrompt()`: add instructions for per-dimension `"strengths"` (2–4 bullets) and `"gaps"` (0–4 bullets, specific and actionable). Update both example JSON blocks to include these fields keyed by `"goal"`, `"constraint"`, `"success"`
4. In `Check()`: propagate `parsed.Strengths` and `parsed.Gaps` into the returned `Result`

**`cmd/octog/main.go`**
1. Add a `--verbose` bool flag to the `preflightCmd` FlagSet: `verbose := fs.Bool("verbose", false, "show per-dimension strengths and gaps")`
2. Define a fixed dimension order slice: `dims := []string{"goal", "constraint", "success"}`
3. Replace the dimension output block with a conditional: if `*verbose`, iterate over `dims` printing score, then `✓` for each strength and `~` for each gap per dimension with a trailing blank line; else, print existing compact format unchanged
4. Aggregate/status/questions output unchanged

## Review Findings
- Errors: 0
- Warnings: 1
- Nits: 3
- Assessment: **NEEDS CHANGES** (the nil-map UX issue in finding #1 should be addressed — while it won't crash, verbose mode silently producing empty output when the LLM omits strengths/gaps is a poor user experience and a likely real-world scenario given backward compatibility)
