### PR TITLE
feat(cli): scenario preflight — LLM-based scenario quality check against spec

### DIFF
--- a/cmd/octog/main.go
+++ b/cmd/octog/main.go
@@ -53,6 +53,7 @@ var (
 	errInvalidLanguage            = errors.New("--language must be one of: go, python, node, rust, auto")
 	errListModelsUnsupported      = errors.New("provider does not support listing models")
 	errPreflightFailed            = errors.New("preflight: spec clarity below threshold")
+	errScenarioPreflightFailed    = errors.New("preflight: scenario quality below threshold")
 	errInvalidPreflightThreshold  = errors.New("preflight threshold must be between 0.0 and 1.0")
 	errSourceDirRequired          = errors.New("--source-dir is required")
 	errSourceDirNotExist          = errors.New("--source-dir does not exist")
@@ -864,6 +865,7 @@ func preflightCmd(ctx context.Context, logger *slog.Logger, args []string) error
 	judgeModel := fs.String("judge-model", "", "LLM model for clarity assessment (default: provider-specific)")
 	threshold := fs.Float64("threshold", 0.8, "aggregate clarity score threshold (0.0–1.0)")
 	verbose := fs.Bool("verbose", false, "show per-dimension strengths and gaps")
+	scenarios := fs.String("scenarios", "", "directory of scenario YAML files to assess against the spec (both spec and scenario checks always run; use exit code to gate on either)")
 
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: octog preflight [flags] <spec-path>\n\nAssess spec clarity before running the attractor loop.\n\nFlags:\n")
@@ -903,22 +905,42 @@ func preflightCmd(ctx context.Context, logger *slog.Logger, args []string) error
 	}
 
 	fmt.Printf("Preflight results for: %s\n", specPath)
+	specErr := printSpecResult(result, *threshold, *verbose)
 
-	if *verbose {
+	if *scenarios == "" {
+		return specErr
+	}
+
+	fmt.Println()
+	scenarioResult, err := preflight.CheckScenarios(ctx, clients.client, *judgeModel, parsedSpec.RawContent, *scenarios, *threshold, logger)
+	if err != nil {
+		return err
+	}
+	printScenarioPreflight(scenarioResult, *threshold)
+
+	if specErr != nil {
+		return specErr
+	}
+	if !scenarioResult.Pass {
+		return errScenarioPreflightFailed
+	}
+	return nil
+}
+
+// printSpecResult prints spec preflight scores and returns errPreflightFailed if the spec did not pass.
+func printSpecResult(result *preflight.Result, threshold float64, verbose bool) error {
+	if verbose {
 		printPreflightVerbose(result)
 	} else {
 		fmt.Printf("  Goal clarity:       %.2f\n", result.GoalClarity)
 		fmt.Printf("  Constraint clarity: %.2f\n", result.ConstraintClarity)
 		fmt.Printf("  Success clarity:    %.2f\n", result.SuccessClarity)
 	}
-
-	fmt.Printf("  Aggregate score:    %.2f (threshold: %.2f)\n", result.AggregateScore, *threshold)
-
+	fmt.Printf("  Aggregate score:    %.2f (threshold: %.2f)\n", result.AggregateScore, threshold)
 	if result.Pass {
 		fmt.Printf("  Status: PASS\n")
 		return nil
 	}
-
 	fmt.Printf("  Status: WARN — spec clarity below threshold\n")
 	if len(result.Questions) > 0 {
 		fmt.Printf("\nSuggested clarifications:\n")
@@ -927,6 +949,26 @@ func preflightCmd(ctx context.Context, logger *slog.Logger, args []string) error
 		}
 	}
 	return errPreflightFailed
+}
+
+func printScenarioPreflight(result *preflight.ScenarioResult, threshold float64) {
+	fmt.Printf("Scenario preflight results:\n")
+	fmt.Printf("  Coverage:    %.2f\n", result.Coverage)
+	fmt.Printf("  Feasibility: %.2f\n", result.Feasibility)
+	fmt.Printf("  Isolation:   %.2f\n", result.Isolation)
+	fmt.Printf("  Chains:      %.2f\n", result.Chains)
+	fmt.Printf("  Aggregate score: %.2f (threshold: %.2f)\n", result.Aggregate, threshold)
+	if result.Pass {
+		fmt.Printf("  Status: PASS\n")
+	} else {
+		fmt.Printf("  Status: WARN — scenario quality below threshold\n")
+	}
+	if len(result.Issues) > 0 {
+		fmt.Printf("\nScenario issues:\n")
+		for _, issue := range result.Issues {
+			fmt.Printf("  [%s/%s] %s\n", issue.Scenario, issue.Dimension, issue.Detail)
+		}
+	}
 }
 
 func printPreflightVerbose(result *preflight.Result) {

--- a/internal/preflight/scenario.go
+++ b/internal/preflight/scenario.go
@@ -1,0 +1,214 @@
+package preflight
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/foundatron/octopusgarden/internal/llm"
+)
+
+// maxScenarioTotalBytes is the maximum combined size of all scenario files
+// accepted by CheckScenarios. Prevents context-window overruns and unexpected costs.
+const maxScenarioTotalBytes = 5 * 1024 * 1024 // 5 MB
+
+var errScenariosTooLarge = errors.New("preflight: total scenario file size exceeds 5 MB limit")
+
+var (
+	errMalformedScenarioResponse = errors.New("preflight: malformed scenario LLM response")
+	errNoScenarios               = errors.New("preflight: no YAML scenario files found in directory")
+)
+
+// ScenarioIssue describes a specific problem found in a scenario.
+type ScenarioIssue struct {
+	Scenario  string `json:"scenario"`
+	Dimension string `json:"dimension"`
+	Detail    string `json:"detail"`
+}
+
+// ScenarioResult holds the quality assessment for a set of scenarios.
+type ScenarioResult struct {
+	Coverage    float64
+	Feasibility float64
+	Isolation   float64
+	Chains      float64
+	Aggregate   float64
+	Pass        bool
+	Issues      []ScenarioIssue
+}
+
+// scenarioPreflightResponse is the expected JSON structure from the scenario preflight LLM call.
+type scenarioPreflightResponse struct {
+	Coverage    float64         `json:"coverage"`
+	Feasibility float64         `json:"feasibility"`
+	Isolation   float64         `json:"isolation"`
+	Chains      float64         `json:"chains"`
+	Issues      []ScenarioIssue `json:"issues"`
+}
+
+func buildScenarioSystemPrompt() string {
+	return `You are a scenario quality analyst. Your job is to assess how well a set of test scenarios covers and exercises a software specification.
+
+Evaluate the scenarios on four dimensions, each scored from 0.0 (completely inadequate) to 1.0 (excellent):
+
+- coverage: Do the scenarios collectively exercise all behaviors described in the spec? Are happy paths, edge cases, and failure modes represented?
+- feasibility: Are the scenarios executable as written? Do steps reference valid endpoints, actions, and data that an implementation could satisfy?
+- isolation: Does each scenario test one coherent behavior? Are scenarios free from hidden dependencies on each other's side effects?
+- chains: For multi-step scenarios, do step sequences form coherent chains? Are captures and variable substitutions used correctly?
+
+For any issues found, report them with the scenario name, affected dimension, and a concise actionable description.
+
+Respond ONLY with valid JSON matching this exact schema:
+{
+  "coverage": <float 0.0-1.0>,
+  "feasibility": <float 0.0-1.0>,
+  "isolation": <float 0.0-1.0>,
+  "chains": <float 0.0-1.0>,
+  "issues": [
+    {"scenario": "<name>", "dimension": "<coverage|feasibility|isolation|chains>", "detail": "<actionable description>"}
+  ]
+}
+
+If there are no issues, set "issues" to an empty array [].`
+}
+
+func buildScenarioUserPrompt(specContent string, scenarioYAMLs map[string]string) string {
+	var sb strings.Builder
+	sb.WriteString("Assess the following scenarios against the spec.\n\n")
+	sb.WriteString("## Spec\n\n")
+	sb.WriteString(specContent)
+	sb.WriteString("\n\n## Scenarios\n\n")
+
+	names := make([]string, 0, len(scenarioYAMLs))
+	for name := range scenarioYAMLs {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+
+	for _, name := range names {
+		fmt.Fprintf(&sb, "### %s\n\n", name)
+		sb.WriteString("```yaml\n")
+		sb.WriteString(scenarioYAMLs[name])
+		sb.WriteString("\n```\n\n")
+	}
+
+	return sb.String()
+}
+
+func parseScenarioResponse(raw string) (*scenarioPreflightResponse, error) {
+	extracted := llm.ExtractJSON(raw)
+	var r scenarioPreflightResponse
+	if err := json.Unmarshal([]byte(extracted), &r); err != nil {
+		return nil, fmt.Errorf("%w: %w", errMalformedScenarioResponse, err)
+	}
+	if r.Coverage < 0 || r.Coverage > 1 ||
+		r.Feasibility < 0 || r.Feasibility > 1 ||
+		r.Isolation < 0 || r.Isolation > 1 ||
+		r.Chains < 0 || r.Chains > 1 {
+		return nil, fmt.Errorf("%w: scores must be in [0, 1]", errMalformedScenarioResponse)
+	}
+	validDimensions := map[string]bool{
+		"coverage": true, "feasibility": true, "isolation": true, "chains": true,
+	}
+	for _, issue := range r.Issues {
+		if issue.Dimension != "" && !validDimensions[issue.Dimension] {
+			return nil, fmt.Errorf("%w: unknown dimension %q", errMalformedScenarioResponse, issue.Dimension)
+		}
+	}
+	if r.Issues == nil {
+		r.Issues = []ScenarioIssue{}
+	}
+	return &r, nil
+}
+
+// computeScenarioAggregate returns the unweighted average of the four scenario quality dimensions.
+func computeScenarioAggregate(coverage, feasibility, isolation, chains float64) float64 {
+	return (coverage + feasibility + isolation + chains) / 4.0
+}
+
+// CheckScenarios calls the LLM to assess scenario quality against the spec and returns a ScenarioResult.
+// threshold is the aggregate score (0.0–1.0) below which Pass is false.
+func CheckScenarios(ctx context.Context, client llm.Client, model, specContent, scenarioDir string, threshold float64, logger *slog.Logger) (*ScenarioResult, error) {
+	entries, err := os.ReadDir(scenarioDir)
+	if err != nil {
+		return nil, fmt.Errorf("read scenario dir: %w", err)
+	}
+
+	scenarioYAMLs := make(map[string]string)
+	var totalBytes int64
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		// Skip symlinks to prevent reading files outside the scenario directory.
+		if entry.Type()&os.ModeSymlink != 0 {
+			continue
+		}
+		name := entry.Name()
+		if strings.HasPrefix(name, ".") {
+			continue
+		}
+		ext := strings.ToLower(filepath.Ext(name))
+		if ext != ".yaml" && ext != ".yml" {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(scenarioDir, name))
+		if err != nil {
+			return nil, fmt.Errorf("read scenario file %s: %w", name, err)
+		}
+		totalBytes += int64(len(data))
+		if totalBytes > maxScenarioTotalBytes {
+			return nil, fmt.Errorf("%w", errScenariosTooLarge)
+		}
+		scenarioYAMLs[name] = string(data)
+	}
+
+	if len(scenarioYAMLs) == 0 {
+		return nil, errNoScenarios
+	}
+
+	req := llm.GenerateRequest{
+		Model:     model,
+		MaxTokens: 2048,
+		Messages: []llm.Message{
+			{Role: "user", Content: buildScenarioUserPrompt(specContent, scenarioYAMLs)},
+		},
+		SystemPrompt: buildScenarioSystemPrompt(),
+		CacheControl: &llm.CacheControl{Type: "ephemeral"},
+	}
+
+	resp, err := client.Generate(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("scenario preflight: generate: %w", err)
+	}
+
+	logger.Info("scenario preflight LLM call complete",
+		"input_tokens", resp.InputTokens,
+		"output_tokens", resp.OutputTokens,
+		"cost_usd", resp.CostUSD,
+		"cache_hit", resp.CacheHit,
+	)
+
+	parsed, err := parseScenarioResponse(resp.Content)
+	if err != nil {
+		return nil, err
+	}
+
+	agg := computeScenarioAggregate(parsed.Coverage, parsed.Feasibility, parsed.Isolation, parsed.Chains)
+
+	return &ScenarioResult{
+		Coverage:    parsed.Coverage,
+		Feasibility: parsed.Feasibility,
+		Isolation:   parsed.Isolation,
+		Chains:      parsed.Chains,
+		Aggregate:   agg,
+		Pass:        agg >= threshold,
+		Issues:      parsed.Issues,
+	}, nil
+}

--- a/internal/preflight/scenario_test.go
+++ b/internal/preflight/scenario_test.go
@@ -1,0 +1,258 @@
+package preflight
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/foundatron/octopusgarden/internal/llm"
+)
+
+func makeScenarioJSONResponse(coverage, feasibility, isolation, chains float64, issues string) string {
+	return fmt.Sprintf(`{"coverage":%g,"feasibility":%g,"isolation":%g,"chains":%g,"issues":%s}`,
+		coverage, feasibility, isolation, chains, issues)
+}
+
+func TestComputeScenarioAggregate(t *testing.T) {
+	tests := []struct {
+		name        string
+		coverage    float64
+		feasibility float64
+		isolation   float64
+		chains      float64
+		want        float64
+	}{
+		{"all ones", 1.0, 1.0, 1.0, 1.0, 1.0},
+		{"all zeros", 0.0, 0.0, 0.0, 0.0, 0.0},
+		{"mixed", 0.8, 0.6, 0.4, 0.2, (0.8 + 0.6 + 0.4 + 0.2) / 4.0},
+	}
+	const eps = 1e-12
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := computeScenarioAggregate(tc.coverage, tc.feasibility, tc.isolation, tc.chains)
+			if math.Abs(got-tc.want) > eps {
+				t.Errorf("computeScenarioAggregate(%g,%g,%g,%g) = %g, want %g",
+					tc.coverage, tc.feasibility, tc.isolation, tc.chains, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseScenarioResponse(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{
+			name:  "valid JSON",
+			input: makeScenarioJSONResponse(0.9, 0.8, 0.85, 0.7, `[]`),
+		},
+		{
+			name:  "JSON in code fences",
+			input: "```json\n" + makeScenarioJSONResponse(0.9, 0.8, 0.85, 0.7, `[]`) + "\n```",
+		},
+		{
+			name:    "non-JSON",
+			input:   "not json at all",
+			wantErr: true,
+		},
+		{
+			name:    "score out of range high",
+			input:   makeScenarioJSONResponse(1.5, 0.8, 0.85, 0.7, `[]`),
+			wantErr: true,
+		},
+		{
+			name:    "score out of range low",
+			input:   makeScenarioJSONResponse(-0.1, 0.8, 0.85, 0.7, `[]`),
+			wantErr: true,
+		},
+		{
+			name:    "invalid dimension name",
+			input:   `{"coverage":0.9,"feasibility":0.8,"isolation":0.85,"chains":0.7,"issues":[{"scenario":"foo","dimension":"badname","detail":"x"}]}`,
+			wantErr: true,
+		},
+		{
+			name:  "missing issues treated as empty",
+			input: `{"coverage":0.9,"feasibility":0.8,"isolation":0.85,"chains":0.7}`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseScenarioResponse(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !errors.Is(err, errMalformedScenarioResponse) {
+					t.Errorf("expected errMalformedScenarioResponse, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got == nil {
+				t.Fatal("expected non-nil result")
+			}
+		})
+	}
+}
+
+func TestBuildScenarioSystemPrompt(t *testing.T) {
+	prompt := buildScenarioSystemPrompt()
+	for _, keyword := range []string{"coverage", "feasibility", "isolation", "chains", "JSON"} {
+		if !strings.Contains(prompt, keyword) {
+			t.Errorf("system prompt missing keyword: %q", keyword)
+		}
+	}
+}
+
+func TestBuildScenarioUserPrompt(t *testing.T) {
+	specContent := "# My Spec\nDoes things."
+	scenarios := map[string]string{
+		"zebra.yaml": "name: zebra\n",
+		"alpha.yaml": "name: alpha\n",
+	}
+	prompt := buildScenarioUserPrompt(specContent, scenarios)
+	if !strings.Contains(prompt, specContent) {
+		t.Error("prompt does not contain spec content")
+	}
+	alphaIdx := strings.Index(prompt, "alpha.yaml")
+	zebraIdx := strings.Index(prompt, "zebra.yaml")
+	if alphaIdx == -1 || zebraIdx == -1 {
+		t.Fatal("prompt missing scenario headings")
+	}
+	if alphaIdx > zebraIdx {
+		t.Error("scenarios not in sorted order: alpha should appear before zebra")
+	}
+	if !strings.Contains(prompt, "```yaml") {
+		t.Error("prompt missing yaml code fences")
+	}
+}
+
+func TestCheckScenariosPassFail(t *testing.T) {
+	tests := []struct {
+		name      string
+		scores    [4]float64
+		threshold float64
+		wantPass  bool
+	}{
+		{"pass above threshold", [4]float64{0.9, 0.9, 0.9, 0.9}, 0.8, true},
+		{"pass at threshold exactly", [4]float64{0.8, 0.8, 0.8, 0.8}, 0.8, true},
+		{"fail below threshold", [4]float64{0.5, 0.5, 0.5, 0.5}, 0.8, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := &mockClient{
+				generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+					return llm.GenerateResponse{
+						Content: makeScenarioJSONResponse(tc.scores[0], tc.scores[1], tc.scores[2], tc.scores[3], `[]`),
+					}, nil
+				},
+			}
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, "test.yaml"), []byte("name: test\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			result, err := CheckScenarios(context.Background(), mock, "test-model", "spec content", dir, tc.threshold, testLogger())
+			if err != nil {
+				t.Fatalf("CheckScenarios: %v", err)
+			}
+			if result.Pass != tc.wantPass {
+				t.Errorf("Pass=%v, want %v (aggregate=%.4f)", result.Pass, tc.wantPass, result.Aggregate)
+			}
+		})
+	}
+}
+
+func TestCheckScenariosTransportError(t *testing.T) {
+	wantErr := errors.New("network failure")
+	mock := &mockClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{}, wantErr
+		},
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "test.yaml"), []byte("name: test\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := CheckScenarios(context.Background(), mock, "test-model", "spec", dir, 0.8, testLogger())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Errorf("expected transport error to be wrapped, got %v", err)
+	}
+}
+
+func TestCheckScenariosMalformedResponse(t *testing.T) {
+	mock := &mockClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{Content: "garbage response"}, nil
+		},
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "test.yaml"), []byte("name: test\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := CheckScenarios(context.Background(), mock, "test-model", "spec", dir, 0.8, testLogger())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, errMalformedScenarioResponse) {
+		t.Errorf("expected errMalformedScenarioResponse, got %v", err)
+	}
+}
+
+func TestCheckScenariosEmptyDir(t *testing.T) {
+	mock := &mockClient{}
+	dir := t.TempDir()
+	_, err := CheckScenarios(context.Background(), mock, "test-model", "spec", dir, 0.8, testLogger())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, errNoScenarios) {
+		t.Errorf("expected errNoScenarios, got %v", err)
+	}
+}
+
+func TestCheckScenariosSkipsNonYAML(t *testing.T) {
+	var capturedContent string
+	mock := &mockClient{
+		generateFn: func(_ context.Context, req llm.GenerateRequest) (llm.GenerateResponse, error) {
+			capturedContent = req.Messages[0].Content
+			return llm.GenerateResponse{
+				Content: makeScenarioJSONResponse(0.9, 0.9, 0.9, 0.9, `[]`),
+			}, nil
+		},
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "scenario.yaml"), []byte("name: scenario\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "shorthand.yml"), []byte("name: shorthand\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "README.txt"), []byte("do not include this"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := CheckScenarios(context.Background(), mock, "test-model", "spec", dir, 0.8, testLogger())
+	if err != nil {
+		t.Fatalf("CheckScenarios: %v", err)
+	}
+	if strings.Contains(capturedContent, "do not include this") {
+		t.Error("non-YAML file content was included in the prompt")
+	}
+	if !strings.Contains(capturedContent, "scenario.yaml") {
+		t.Error(".yaml file was not included in the prompt")
+	}
+	if !strings.Contains(capturedContent, "shorthand.yml") {
+		t.Error(".yml file was not included in the prompt")
+	}
+}


### PR DESCRIPTION
Closes #126

## Changes
**1. `internal/preflight/scenario.go` (NEW)**

- **Types**: `scenarioPreflightResponse` (unexported), `scenarioIssue` (unexported), `ScenarioResult` (exported), `ScenarioIssue` (exported).
- **Sentinel errors**: `errMalformedScenarioResponse`, `errNoScenarios`.
- **`buildScenarioSystemPrompt()`**: System prompt with 4 dimensions, JSON-only output format.
- **`buildScenarioUserPrompt(specContent string, scenarioYAMLs map[string]string)`**: Spec + sorted scenario YAML blocks in code fences.
- **`parseScenarioResponse(raw string)`**: `llm.ExtractJSON()` → unmarshal → validate scores in `[0,1]` → validate dimension names.
- **`computeScenarioAggregate(coverage, feasibility, isolation, chains float64) float64`**: `(c+f+i+ch) / 4.0`.
- **`CheckScenarios(ctx, client, model, specContent, scenarioDir, threshold, logger) (*ScenarioResult, error)`**:
  1. `os.ReadDir` → filter `.yaml`/`.yml` only → `os.ReadFile` each into `map[string]string`.
  2. If map is empty, return `errNoScenarios`.
  3. Build prompts, call `client.Generate()` with `MaxTokens: 2048`, `CacheControl: ephemeral`.
  4. Log tokens/cost/cache hit.
  5. Parse, compute aggregate, set `Pass = agg >= threshold`.
  6. Return `*ScenarioResult`.

**2. `cmd/octog/main.go` — `preflightCmd` modification**

- Add `--scenarios` flag (string, default `""`).
- If `--scenarios` is set and no spec path provided, return an error (scenarios are checked *against* the spec).
- After spec preflight completes, if `--scenarios != ""`: call `preflight.CheckScenarios()` using the same `specContent`, `client`, `*judgeModel`, and `*threshold`.
- Add `printScenarioPreflight(result *preflight.ScenarioResult)` — dimension scores, aggregate, PASS/WARN, issues list.
- Add `errScenarioPreflightFailed` sentinel.
- Exit code: fail if either spec or scenario preflight fails threshold.

## Review Findings
- Errors: 0
- Warnings: 4
- Nits: 6
- Assessment: **NEEDS CHANGES** (warnings 3, 5, 8, 11 should be addressed)
