### PR TITLE
chore: add compile-time interface checks for all implementations

### DIFF
--- a/cmd/octog/main.go
+++ b/cmd/octog/main.go
@@ -650,6 +650,11 @@ type modelLister interface {
 	ListModels(ctx context.Context) ([]llm.AvailableModel, error)
 }
 
+var (
+	_ modelLister = (*llm.AnthropicClient)(nil)
+	_ modelLister = (*llm.OpenAIClient)(nil)
+)
+
 func modelsCmd(ctx context.Context, logger *slog.Logger, args []string) error {
 	fs := flag.NewFlagSet("models", flag.ContinueOnError)
 	provider := fs.String("provider", "", "LLM provider: anthropic or openai (auto-detected from env if omitted)")

--- a/internal/attractor/attractor.go
+++ b/internal/attractor/attractor.go
@@ -26,6 +26,8 @@ var (
 	errEmptySpec            = errors.New("attractor: spec content is empty")
 	errUnsupportedLanguage  = errors.New("attractor: unsupported language")
 	errMinimalismNoMessages = errors.New("attractor: minimalism suffix: no messages to append to")
+
+	_ ContainerManager = (*container.Manager)(nil)
 )
 
 // summarizeModel is the cheap model used for spec summarization.

--- a/internal/scenario/browser.go
+++ b/internal/scenario/browser.go
@@ -16,6 +16,8 @@ import (
 const defaultBrowserTimeout = 10 * time.Second
 
 var (
+	_ StepExecutor = (*BrowserExecutor)(nil)
+
 	errInvalidBrowserAction = errors.New("invalid browser action")
 	errNavigateRequiresURL  = errors.New("navigate action requires url")
 	errClickRequiresSelect  = errors.New("click action requires selector")

--- a/internal/scenario/exec.go
+++ b/internal/scenario/exec.go
@@ -25,7 +25,12 @@ const (
 	defaultMaxOutputBytes = 10 << 20 // 10MB
 )
 
-var errWriteFileFailed = errors.New("write file failed")
+var (
+	errWriteFileFailed = errors.New("write file failed")
+
+	_ StepExecutor     = (*ExecExecutor)(nil)
+	_ containerSession = (*container.Session)(nil)
+)
 
 // containerSession provides command execution inside a running container.
 // Satisfied by *container.Session via structural typing.

--- a/internal/scenario/grpc.go
+++ b/internal/scenario/grpc.go
@@ -23,6 +23,8 @@ import (
 const defaultGRPCTimeout = 30 * time.Second
 
 var (
+	_ StepExecutor = (*GRPCExecutor)(nil)
+
 	errGRPCMissingService  = errors.New("grpc step missing required field: service")
 	errGRPCMissingMethod   = errors.New("grpc step missing required field: method")
 	errGRPCNotAService     = errors.New("resolved name is not a service")

--- a/internal/scenario/http.go
+++ b/internal/scenario/http.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 )
 
+var _ StepExecutor = (*HTTPExecutor)(nil)
+
 // HTTPExecutor executes HTTP request steps.
 type HTTPExecutor struct {
 	Client  *http.Client

--- a/internal/scenario/ws.go
+++ b/internal/scenario/ws.go
@@ -19,7 +19,11 @@ const (
 	wsMessageBufferCap      = 1000
 )
 
-var errWSConnNotFound = errors.New("ws connection not found for id")
+var (
+	errWSConnNotFound = errors.New("ws connection not found for id")
+
+	_ StepExecutor = (*WSExecutor)(nil)
+)
 
 // WSExecutor executes WebSocket steps.
 // Each WSExecutor instance is per-scenario (not shared across concurrent runs).


### PR DESCRIPTION
Closes #149

## Changes
**1. `internal/scenario/http.go`** — Add `var _ StepExecutor = (*HTTPExecutor)(nil)` after imports, before type definition.

**2. `internal/scenario/exec.go`** — Add `var _ StepExecutor = (*ExecExecutor)(nil)` and `var _ containerSession = (*container.Session)(nil)` after imports.

**3. `internal/scenario/browser.go`** — Add `var _ StepExecutor = (*BrowserExecutor)(nil)` after imports.

**4. `internal/scenario/grpc.go`** — Add `var _ StepExecutor = (*GRPCExecutor)(nil)` after imports.

**5. `internal/scenario/ws.go`** — Add `var _ StepExecutor = (*WSExecutor)(nil)` after imports.

**6. `internal/attractor/attractor.go`** — Add `var _ ContainerManager = (*container.Manager)(nil)` after imports.

**7. `cmd/octog/main.go`** — Add `var _ modelLister = (*llm.AnthropicClient)(nil)` and `var _ modelLister = (*llm.OpenAIClient)(nil)` near the `modelLister` interface definition.

## Review Findings
- Errors: 0
- Warnings: 0
- Nits: 2
- Assessment: PASS

Clean mechanical change. Compile-time interface satisfaction checks are idiomatic Go, catch interface drift at build time, and align with the project's existing `gochecknoglobals` exemption noted in CLAUDE.md. No logic, no runtime cost, no risk.
