### PR TITLE
docs: add package-level doc.go files for internal packages

### DIFF
--- a/internal/attractor/doc.go
+++ b/internal/attractor/doc.go
@@ -1,0 +1,13 @@
+// Package attractor implements the convergence loop that iteratively generates
+// code from a specification until holdout scenarios are satisfied.
+//
+// The loop proceeds as: generate code via LLM → parse file blocks → build a
+// Docker image → run the container → validate against scenarios → repeat until
+// the aggregate satisfaction score meets the configured threshold. Failed
+// iterations produce steering feedback that is appended to the conversation
+// before the next generation attempt.
+//
+// The primary entry point is Attractor.Run, which accepts a ValidateFn
+// callback for external validation and returns a RunResult with final
+// satisfaction, cost, and output directory.
+package attractor

--- a/internal/container/doc.go
+++ b/internal/container/doc.go
@@ -1,0 +1,10 @@
+// Package container manages Docker image builds, container lifecycle, and
+// health checking for generated code execution.
+//
+// Manager wraps the Docker API to build images from a source directory
+// (assembled as an in-memory tarball), run containers with port bindings, and
+// poll HTTP or TCP endpoints until they are healthy. Long-lived exec sessions
+// are available via StartSession and Session.Exec for scenario steps that run
+// shell commands inside a running container. Close releases the underlying
+// Docker client connection.
+package container

--- a/internal/e2e/doc.go
+++ b/internal/e2e/doc.go
@@ -1,0 +1,6 @@
+// Package e2e contains end-to-end integration tests that exercise the full
+// attractor loop against real Docker and LLM backends.
+//
+// Tests are gated by the integration build tag and are not run as part of the
+// standard unit test suite.
+package e2e

--- a/internal/gene/doc.go
+++ b/internal/gene/doc.go
@@ -1,0 +1,9 @@
+// Package gene scans exemplar codebases to extract structural patterns via LLM
+// analysis.
+//
+// Scan walks a source directory, selects high-signal files within a 20K-token
+// budget, and returns a ScanResult with file contents grouped by language.
+// Analyze submits the scan to an LLM and returns a Gene containing a prose
+// coding guide that can be injected into the attractor's system prompt.
+// Genes are persisted as JSON files via Save and Load.
+package gene

--- a/internal/lint/doc.go
+++ b/internal/lint/doc.go
@@ -1,0 +1,9 @@
+// Package lint provides structural validation for spec markdown and scenario
+// YAML files.
+//
+// CheckSpec validates heading hierarchy and description content of a markdown
+// spec. CheckScenario and CheckScenarioDir validate YAML scenario files,
+// checking step structure, HTTP methods, JSON path syntax, variable references,
+// and duplicate scenario IDs. All findings are returned as Diagnostic values
+// with file path, line number, and severity level.
+package lint

--- a/internal/llm/doc.go
+++ b/internal/llm/doc.go
@@ -1,0 +1,10 @@
+// Package llm defines a model-agnostic client interface for LLM interactions
+// with Anthropic and OpenAI backend implementations.
+//
+// The Client interface exposes two methods: Generate for code generation and
+// Judge for satisfaction scoring. Both methods track token counts and estimated
+// cost per call. Generate supports prompt caching via CacheControl to reduce
+// cost on repeated spec content across attractor iterations. The Anthropic and
+// OpenAI implementations are interchangeable; provider selection is handled by
+// the calling layer.
+package llm

--- a/internal/observability/doc.go
+++ b/internal/observability/doc.go
@@ -1,0 +1,9 @@
+// Package observability provides OpenTelemetry tracing wrappers for LLM
+// clients, container managers, and scenario validation.
+//
+// InitTracer sets up a TracerProvider; it returns a noop provider when no OTLP
+// endpoint is configured, so callers do not need to special-case the disabled
+// case. TracingLLMClient wraps an llm.Client and records spans with attributes
+// for input tokens, output tokens, and estimated cost on each Generate and
+// Judge call.
+package observability

--- a/internal/preflight/doc.go
+++ b/internal/preflight/doc.go
@@ -1,0 +1,9 @@
+// Package preflight validates spec and scenario quality via LLM assessment
+// before running the attractor loop.
+//
+// Check evaluates a spec's goal clarity, constraint clarity, and success
+// criteria clarity, returning a Result with per-dimension scores, an aggregate,
+// and clarifying questions when the spec falls below the configured threshold.
+// CheckScenarios evaluates scenario coverage, feasibility, and isolation,
+// returning a ScenarioResult with issues grouped by dimension.
+package preflight

--- a/internal/scenario/doc.go
+++ b/internal/scenario/doc.go
@@ -1,0 +1,11 @@
+// Package scenario loads YAML scenario definitions and executes HTTP, gRPC,
+// exec, WebSocket, and browser steps against a running container.
+//
+// LoadDir, LoadFile, and Load parse YAML into Scenario values. Runner executes
+// steps sequentially: setup steps are fatal on failure, while scored steps
+// continue so that all expectations are evaluated. Variable capture records
+// values from step output via JSON path expressions, and substitution injects
+// them into subsequent steps. Judge scores each step's observed output against
+// its expectation via an LLM, and Aggregate computes the weighted satisfaction
+// score across all scenarios.
+package scenario

--- a/internal/spec/doc.go
+++ b/internal/spec/doc.go
@@ -1,0 +1,9 @@
+// Package spec parses markdown specification files into structured section
+// trees.
+//
+// Parse accepts an io.Reader and ParseFile accepts a file path; both return a
+// Spec with a title, description, and ordered slice of Section values.
+// Summarize generates an LLM summary for large specs to stay within context
+// budgets, and SelectContent returns either the full spec or a failure-focused
+// view based on available token budget.
+package spec

--- a/internal/store/doc.go
+++ b/internal/store/doc.go
@@ -1,0 +1,9 @@
+// Package store persists attractor run history and per-iteration results in
+// SQLite.
+//
+// NewStore opens or creates a SQLite database using the pure-Go modernc.org/sqlite
+// driver, requiring no CGO. The schema contains two tables: runs (metadata and
+// final status for each attractor invocation) and iterations (per-iteration
+// satisfaction scores, token counts, and costs). ErrRunNotFound is returned
+// when a requested run ID does not exist.
+package store

--- a/internal/testutil/doc.go
+++ b/internal/testutil/doc.go
@@ -1,0 +1,8 @@
+// Package testutil provides shared test helpers for the octopusgarden test
+// suite.
+//
+// RepoRoot walks up from the working directory until it finds a go.mod file and
+// returns the containing directory as the repository root. This is used by
+// integration tests that need to reference fixture files relative to the
+// repository root.
+package testutil

--- a/internal/view/doc.go
+++ b/internal/view/doc.go
@@ -1,0 +1,7 @@
+// Package view defines JSON-serializable output types for CLI commands.
+//
+// NewValidateOutput converts an AggregateResult and threshold configuration
+// into a ValidateOutput suitable for structured JSON output. WriteJSON encodes
+// any value as indented JSON to the provided writer. The types in this package
+// are the stable serialization format for the validate and status subcommands.
+package view


### PR DESCRIPTION
Closes #147

## Changes
Create 13 new `doc.go` files — one per internal package. No existing files modified.

1. **`internal/attractor/doc.go`** — Package attractor implements the convergence loop that iteratively generates code from a specification until holdout scenarios are satisfied. Describe the generation → validation → feedback cycle and external validation via scenario runner. *(Verify actual phase names in attractor.go before writing.)*

2. **`internal/container/doc.go`** — Package container manages Docker image builds, container lifecycle, and health checking for generated code execution. Mention tarball context building and session cleanup via Close.

3. **`internal/e2e/doc.go`** — Package e2e contains end-to-end integration tests that exercise the full attractor loop. Uses `package e2e` (valid alongside `package e2e_test` in test files).

4. **`internal/gene/doc.go`** — Package gene scans exemplar codebases to extract structural patterns via LLM analysis. Mention file selection, token budgeting, and JSON persistence.

5. **`internal/lint/doc.go`** — Package lint provides structural validation for spec markdown and scenario YAML files. Mention line-number-accurate diagnostics and variable reference checking.

6. **`internal/llm/doc.go`** — Package llm defines a model-agnostic client interface for LLM interactions with Anthropic and OpenAI backend implementations. Mention prompt caching, cost tracking, and judge/generate separation.

7. **`internal/observability/doc.go`** — Package observability provides OpenTelemetry tracing wrappers for LLM clients, container managers, and scenario validation. Mention span attributes for token counts and costs.

8. **`internal/preflight/doc.go`** — Package preflight validates spec and scenario quality via LLM assessment before running the attractor loop. Mention clarity and coverage dimensions.

9. **`internal/scenario/doc.go`** — Package scenario loads YAML scenario definitions and executes HTTP, gRPC, and browser steps against a running container. Mention variable capture, substitution, and LLM-as-judge scoring.

10. **`internal/spec/doc.go`** — Package spec parses markdown specification files into structured section trees. Mention io.Reader and file-based entry points.

11. **`internal/store/doc.go`** — Package store persists attractor run history and per-iteration results in SQLite. Mention pure-Go driver and run/iteration schema.

12. **`internal/testutil/doc.go`** — Package testutil provides shared test helpers. *(Verify actual exports before narrowing the description to just repo root location.)*

13. **`internal/view/doc.go`** — Package view defines JSON-serializable output types for CLI commands. Mention validate and status output formatting.

## Review Findings
- Errors: 0
- Warnings: 0
- Nits: 3
- Assessment: **PASS**

This is a clean, documentation-only change adding `doc.go` files to all internal packages. The comments are accurate, well-written, and reference the correct exported symbols and entry points. No logic, no error handling, no security surface. Ship it.
