### PR TITLE
docs: add interface-to-implementation index to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,19 @@ Minimize — stdlib first. Allowed exceptions:
   (repeated per attractor iteration — ~90% cost reduction on cache reads)
 - Linting: `make lint`; config in `.golangci.yaml`; gochecknoglobals disabled (pricing tables OK)
 
+## Interfaces
+
+Cross-package and multi-implementation interfaces:
+
+| Interface        | Package   | Implementations                                                       |
+| ---------------- | --------- | --------------------------------------------------------------------- |
+| Client           | llm       | AnthropicClient, OpenAIClient, observability.TracingLLMClient         |
+| StepExecutor     | scenario  | HTTPExecutor, ExecExecutor, BrowserExecutor, GRPCExecutor, WSExecutor |
+| ContainerManager | attractor | container.Manager, observability.TracingContainerManager              |
+| containerSession | scenario  | `*container.Session`                                                  |
+| dockerAPI        | container | dockerclient.Client                                                   |
+| modelLister      | cmd/octog | llm.AnthropicClient, llm.OpenAIClient                                 |
+
 ## Configuration
 
 API keys go in `~/.octopusgarden/config` (preferred) or environment variables. Config file uses


### PR DESCRIPTION
Closes #146

## Changes
1. **`CLAUDE.md`** — Add `## Interfaces` section after `## Coding Standards`, before `## Configuration`. Content:

   ```markdown
   ## Interfaces

   Cross-package and multi-implementation interfaces:

   | Interface | Package | Implementations |
   |-----------|---------|-----------------|
   | Client | llm | AnthropicClient, OpenAIClient, observability.TracingLLMClient |
   | StepExecutor | scenario | HTTPExecutor, ExecExecutor, BrowserExecutor, GRPCExecutor, WSExecutor |
   | ContainerManager | attractor | container.Manager, observability.TracingContainerManager |
   | containerSession | scenario | *container.Session |
   | dockerAPI | container | dockerclient.Client |
   | modelLister | cmd/octog | llm.AnthropicClient, llm.OpenAIClient |
   ```

   That's it. One file, one section.

## Review Findings
- Errors: 0
- Warnings: 0
- Nits: 1
- Assessment: PASS

This is a documentation-only change adding an interface reference table to CLAUDE.md. No code, no logic, no security surface. The table is accurate based on the project structure documented in memory. Clean pass.
