### PR TITLE
refactor(scenario): consolidate response body size limit constants

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -159,6 +159,8 @@ package scenario
 import (
 	"context"
 	"errors"
+
+	"github.com/foundatron/octopusgarden/internal/limits"
 )
 
 var (
@@ -187,6 +189,10 @@ const (
 	GRPCSourceStatus  = "status"
 	GRPCSourceHeaders = "headers"
 )
+
+// MaxResponseBytes is the maximum bytes captured from response bodies and command output.
+// Re-exported from internal/limits for use within the scenario package.
+const MaxResponseBytes = limits.MaxResponseBytes
 
 // StepExecutor executes a single scenario step and returns its output.
 type StepExecutor interface {

--- a/internal/container/docker.go
+++ b/internal/container/docker.go
@@ -25,6 +25,8 @@ import (
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/go-connections/nat"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/foundatron/octopusgarden/internal/limits"
 )
 
 // DefaultGRPCPort is the standard container port for gRPC services.
@@ -457,9 +459,8 @@ type Session struct {
 	logger      *slog.Logger
 }
 
-// defaultMaxOutputBytes is the maximum bytes captured from exec output.
-// Keep in sync with the constant of the same name in internal/scenario/exec.go.
-const defaultMaxOutputBytes = 10 << 20 // 10MB
+// defaultMaxOutputBytes is the fallback for ExecOptions.MaxOutputBytes when not set.
+const defaultMaxOutputBytes = limits.MaxResponseBytes
 
 // Exec runs a command inside the container via docker exec.
 func (s *Session) Exec(ctx context.Context, command string, opts ExecOptions) (ExecResult, error) {

--- a/internal/limits/doc.go
+++ b/internal/limits/doc.go
@@ -1,0 +1,5 @@
+// Package limits defines shared size constraints used across packages.
+//
+// It exists as a leaf package (no internal imports) so that both container
+// and scenario can import it without creating a circular dependency.
+package limits

--- a/internal/limits/limits.go
+++ b/internal/limits/limits.go
@@ -1,0 +1,5 @@
+package limits
+
+// MaxResponseBytes is the maximum bytes captured from response bodies and command output (10 MB).
+// Typed int64 to match io.LimitReader and related APIs directly.
+const MaxResponseBytes int64 = 10 << 20

--- a/internal/scenario/exec.go
+++ b/internal/scenario/exec.go
@@ -20,9 +20,6 @@ import (
 
 const (
 	defaultExecTimeout = 30 * time.Second
-	// defaultMaxOutputBytes is the maximum bytes captured from command output.
-	// Keep in sync with the constant of the same name in internal/container/docker.go.
-	defaultMaxOutputBytes = 10 << 20 // 10MB
 )
 
 var (
@@ -99,7 +96,7 @@ func (e *ExecExecutor) writeFileContainer(ctx context.Context, filePath, dir, co
 	result, err := e.Session.Exec(ctx, cmd, container.ExecOptions{
 		Stdin:          content,
 		Timeout:        defaultExecTimeout,
-		MaxOutputBytes: defaultMaxOutputBytes,
+		MaxOutputBytes: MaxResponseBytes,
 	})
 	if err != nil {
 		return fmt.Errorf("write file %q: %w", filePath, err)
@@ -136,7 +133,7 @@ func (e *ExecExecutor) runContainer(ctx context.Context, command, stdin string, 
 		Stdin:          stdin,
 		Env:            env,
 		Timeout:        timeout,
-		MaxOutputBytes: defaultMaxOutputBytes,
+		MaxOutputBytes: MaxResponseBytes,
 	})
 	if err != nil {
 		return StepOutput{}, fmt.Errorf("exec: container exec: %w", err)
@@ -151,8 +148,8 @@ func (e *ExecExecutor) runLocal(ctx context.Context, command, stdin string, env 
 	cmd := exec.CommandContext(ctx, "sh", "-c", command) //nolint:gosec // command is from scenario YAML, not user input
 	cmd.WaitDelay = 3 * time.Second                      // don't block if child processes keep pipes open after kill
 	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &limitedWriter{w: &stdout, remaining: defaultMaxOutputBytes}
-	cmd.Stderr = &limitedWriter{w: &stderr, remaining: defaultMaxOutputBytes}
+	cmd.Stdout = &limitedWriter{w: &stdout, remaining: MaxResponseBytes}
+	cmd.Stderr = &limitedWriter{w: &stderr, remaining: MaxResponseBytes}
 
 	if stdin != "" {
 		cmd.Stdin = strings.NewReader(stdin)

--- a/internal/scenario/http.go
+++ b/internal/scenario/http.go
@@ -57,7 +57,7 @@ func (e *HTTPExecutor) Execute(ctx context.Context, step Step, vars map[string]s
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20)) // cap at 10MB
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, MaxResponseBytes))
 	if err != nil {
 		return StepOutput{}, fmt.Errorf("read response body: %w", err)
 	}

--- a/internal/scenario/types.go
+++ b/internal/scenario/types.go
@@ -3,6 +3,8 @@ package scenario
 import (
 	"context"
 	"errors"
+
+	"github.com/foundatron/octopusgarden/internal/limits"
 )
 
 var (
@@ -31,6 +33,10 @@ const (
 	GRPCSourceStatus  = "status"
 	GRPCSourceHeaders = "headers"
 )
+
+// MaxResponseBytes is the maximum bytes captured from response bodies and command output.
+// Re-exported from internal/limits for use within the scenario package.
+const MaxResponseBytes = limits.MaxResponseBytes
 
 // StepExecutor executes a single scenario step and returns its output.
 type StepExecutor interface {

--- a/internal/scenario/ws.go
+++ b/internal/scenario/ws.go
@@ -131,7 +131,7 @@ func (e *WSExecutor) connect(ctx context.Context, connID, wsURL string) error {
 	if err != nil {
 		return fmt.Errorf("dial %s: %w", wsURL, err)
 	}
-	conn.SetReadLimit(10 * 1024 * 1024) // 10 MB
+	conn.SetReadLimit(MaxResponseBytes)
 
 	bgCtx, cancel := context.WithCancel(context.Background()) //nolint:containedctx // background reader needs a long-lived context
 	c := &wsConn{


### PR DESCRIPTION
Closes #141

## Changes
1. **`internal/scenario/types.go`** — Add exported constant after the `GRPCSourceHeaders` const block:
   ```go
   // MaxResponseBytes is the maximum bytes captured from response bodies and command output.
   const MaxResponseBytes = 10 << 20 // 10 MB
   ```

2. **`internal/scenario/exec.go`** — Remove `defaultMaxOutputBytes` and its comment from the const block (keep `defaultExecTimeout`). Replace 4 references at lines 102, 139, 154, 155 with `MaxResponseBytes`.

3. **`internal/scenario/http.go`** — Line 60: replace `io.LimitReader(resp.Body, 10<<20)` with `io.LimitReader(resp.Body, MaxResponseBytes)`, remove trailing comment.

4. **`internal/scenario/ws.go`** — Line 134: replace `conn.SetReadLimit(10 * 1024 * 1024)` with `conn.SetReadLimit(MaxResponseBytes)`, remove trailing comment.

5. **`internal/container/docker.go`** — Lines 460–461: update comment to reference `scenario.MaxResponseBytes` and note the circular import reason. Keep the constant and its value unchanged.

## Review Findings
- Errors: 0
- Warnings: 1
- Nits: 3
- Assessment: **NEEDS CHANGES**

The one warning (duplicated constant across packages with no enforcement they stay in sync) is the core issue. The original "keep in sync" comment was replaced with a slightly better comment, but the fundamental fragility remains. A tiny shared package or a cross-package test assertion would resolve it cleanly.
