### PR TITLE
chore: add per-package coverage reporting to make coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,10 @@ test-browser: ## Run browser integration tests (requires Chrome)
 
 coverage: ## Run tests with coverage and check threshold
 	go test -coverprofile=coverage.out ./...
-	go tool cover -func=coverage.out
-	@go tool cover -func=coverage.out | awk '/^total:/ { pct = $$3+0; if (pct < 50) { print "Coverage " $$3 " below 50% threshold"; exit 1 } }'
+	@echo "--- Per-function coverage ---"
+	@go tool cover -func=coverage.out | grep -v '^total:' | awk '{print $$NF, $$1}' | sort -n | column -t
+	@echo "--- Total ---"
+	@go tool cover -func=coverage.out | awk '/^total:/ { print "Coverage: " $$3; pct = $$3+0; if (pct < 50) { print "Coverage " $$3 " below 50% threshold"; exit 1 } }'
 
 lint: ## Run golangci-lint (full module)
 	golangci-lint run ./...


### PR DESCRIPTION
Closes #148

## Changes
1. **`Makefile`** (modify lines 25–28) — Replace the `coverage` target:
   - Keep `go test -coverprofile=coverage.out ./...`
   - Add `--- Per-package coverage ---` banner, then pipe `go tool cover -func=coverage.out` through `grep -v '^total:'` (exclude total line), then `awk '{print $$NF, $$1}'`, `sort -n`, `column -t`
   - Add `--- Total ---` banner, extract total percentage, compare against threshold (50), exit 1 if below

   Use `grep -v '^total:'` instead of `grep -E '^[a-z]'` to filter the total line — it's explicit about intent and doesn't rely on assumptions about line content.

## Review Findings
- Errors: 0
- Warnings: 0
- Nits: 3
- Assessment: **PASS**
