### PR TITLE
refactor(llm): consolidate duplicate metrics, logging, and token constants

### DIFF
--- a/internal/llm/anthropic.go
+++ b/internal/llm/anthropic.go
@@ -36,53 +36,37 @@ func NewAnthropicClient(apiKey string, logger *slog.Logger, opts ...option.Reque
 	}
 }
 
-// anthropicMetrics holds extracted token counts and cost from an Anthropic API response.
-type anthropicMetrics struct {
-	regularInput  int
-	cacheCreation int
-	cacheRead     int
-	output        int
-	cost          float64
-}
+// logUsage extracts token counts, calculates cost, logs structured metrics,
+// and returns a usageMetrics for the Anthropic API call.
+// The prefix distinguishes call types (e.g. "anthropic generate", "anthropic judge").
+func (c *AnthropicClient) logUsage(prefix, model string, usage anthropic.Usage) usageMetrics {
+	inputTokens := int(usage.InputTokens)
+	cacheCreationTokens := int(usage.CacheCreationInputTokens)
+	cacheReadTokens := int(usage.CacheReadInputTokens)
+	outputTokens := int(usage.OutputTokens)
 
-// logUsage extracts token counts, calculates cost, and logs structured metrics
-// for an Anthropic API call. The prefix distinguishes call types (e.g. "anthropic generate",
-// "anthropic judge").
-func (c *AnthropicClient) logUsage(prefix, model string, usage anthropic.Usage) anthropicMetrics {
-	cacheCreation := int(usage.CacheCreationInputTokens)
-	cacheRead := int(usage.CacheReadInputTokens)
-	regularInput := int(usage.InputTokens)
-	output := int(usage.OutputTokens)
-
-	cost, usingFallback := CalculateCost(model, regularInput, cacheCreation, cacheRead, output)
+	cost, usingFallback := CalculateCost(model, inputTokens, cacheCreationTokens, cacheReadTokens, outputTokens)
 	if usingFallback {
 		c.logger.Warn("using fallback pricing for unknown model", "model", model)
 	}
 
-	c.logger.Info(prefix,
-		"model", model,
-		"input_tokens", regularInput,
-		"cache_creation_tokens", cacheCreation,
-		"cache_read_tokens", cacheRead,
-		"output_tokens", output,
-		"cost_usd", cost,
-		"cache_hit", cacheRead > 0,
-	)
-
-	return anthropicMetrics{
-		regularInput:  regularInput,
-		cacheCreation: cacheCreation,
-		cacheRead:     cacheRead,
-		output:        output,
-		cost:          cost,
+	m := usageMetrics{
+		model:               model,
+		inputTokens:         inputTokens,
+		cacheCreationTokens: cacheCreationTokens,
+		cacheReadTokens:     cacheReadTokens,
+		outputTokens:        outputTokens,
+		cost:                cost,
 	}
+	m.log(c.logger, prefix)
+	return m
 }
 
 // Generate calls the Anthropic Messages API to generate code.
 func (c *AnthropicClient) Generate(ctx context.Context, req GenerateRequest) (GenerateResponse, error) {
 	maxTokens := int64(req.MaxTokens)
 	if maxTokens == 0 {
-		maxTokens = 8192
+		maxTokens = defaultGenerateMaxTokens
 	}
 
 	// Build system prompt blocks.
@@ -138,9 +122,9 @@ func (c *AnthropicClient) Generate(ctx context.Context, req GenerateRequest) (Ge
 
 	return GenerateResponse{
 		Content:      content,
-		InputTokens:  m.regularInput + m.cacheCreation + m.cacheRead,
-		OutputTokens: m.output,
-		CacheHit:     m.cacheRead > 0,
+		InputTokens:  m.inputTokens + m.cacheCreationTokens + m.cacheReadTokens,
+		OutputTokens: m.outputTokens,
+		CacheHit:     m.cacheReadTokens > 0,
 		CostUSD:      m.cost,
 		FinishReason: string(resp.StopReason),
 	}, nil
@@ -192,7 +176,7 @@ func (c *AnthropicClient) Judge(ctx context.Context, req JudgeRequest) (JudgeRes
 
 	params := anthropic.MessageNewParams{
 		Model:     anthropic.Model(req.Model),
-		MaxTokens: 4096,
+		MaxTokens: defaultJudgeMaxTokens,
 		Messages:  messages,
 		System:    system,
 	}

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -2,6 +2,11 @@ package llm
 
 import "context"
 
+const (
+	defaultGenerateMaxTokens = 8192
+	defaultJudgeMaxTokens    = 4096
+)
+
 // Client is the model-agnostic LLM interface used by the attractor loop and judge.
 type Client interface {
 	Generate(ctx context.Context, req GenerateRequest) (GenerateResponse, error)

--- a/internal/llm/metrics.go
+++ b/internal/llm/metrics.go
@@ -1,0 +1,27 @@
+package llm
+
+import "log/slog"
+
+// usageMetrics holds token counts and cost for a single LLM API call.
+type usageMetrics struct {
+	model               string
+	inputTokens         int // Anthropic: regular input only; OpenAI: total prompt tokens
+	cacheCreationTokens int
+	cacheReadTokens     int
+	outputTokens        int
+	cost                float64
+}
+
+// log emits structured slog attributes for this metrics snapshot.
+// prefix distinguishes call types (e.g. "anthropic generate", "openai judge").
+func (m *usageMetrics) log(logger *slog.Logger, prefix string) {
+	logger.Info(prefix,
+		"model", m.model,
+		"input_tokens", m.inputTokens,
+		"cache_creation_tokens", m.cacheCreationTokens,
+		"cache_read_tokens", m.cacheReadTokens,
+		"output_tokens", m.outputTokens,
+		"cost_usd", m.cost,
+		"cache_hit", m.cacheReadTokens > 0,
+	)
+}

--- a/internal/llm/metrics_test.go
+++ b/internal/llm/metrics_test.go
@@ -1,0 +1,109 @@
+package llm
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+)
+
+// recordHandler captures slog records for inspection in tests.
+type recordHandler struct {
+	records []slog.Record
+}
+
+func (h *recordHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+
+func (h *recordHandler) Handle(_ context.Context, r slog.Record) error {
+	h.records = append(h.records, r)
+	return nil
+}
+
+func (h *recordHandler) WithAttrs(attrs []slog.Attr) slog.Handler { return h }
+func (h *recordHandler) WithGroup(name string) slog.Handler       { return h }
+
+func TestUsageMetricsLog(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		m      usageMetrics
+		prefix string
+		want   map[string]any
+	}{
+		{
+			name:   "all fields populated",
+			prefix: "openai generate",
+			m: usageMetrics{
+				model:               "gpt-4o",
+				inputTokens:         100,
+				cacheCreationTokens: 10,
+				cacheReadTokens:     50,
+				outputTokens:        200,
+				cost:                0.005,
+			},
+			want: map[string]any{
+				"model":                 "gpt-4o",
+				"input_tokens":          int64(100),
+				"cache_creation_tokens": int64(10),
+				"cache_read_tokens":     int64(50),
+				"output_tokens":         int64(200),
+				"cost_usd":              0.005,
+				"cache_hit":             true,
+			},
+		},
+		{
+			name:   "no cache hit",
+			prefix: "anthropic judge",
+			m: usageMetrics{
+				model:        "claude-3-5-haiku-latest",
+				inputTokens:  80,
+				outputTokens: 120,
+			},
+			want: map[string]any{
+				"model":                 "claude-3-5-haiku-latest",
+				"input_tokens":          int64(80),
+				"cache_creation_tokens": int64(0),
+				"cache_read_tokens":     int64(0),
+				"output_tokens":         int64(120),
+				"cost_usd":              0.0,
+				"cache_hit":             false,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := &recordHandler{}
+			logger := slog.New(h)
+
+			tc.m.log(logger, tc.prefix)
+
+			if len(h.records) != 1 {
+				t.Fatalf("expected 1 log record, got %d", len(h.records))
+			}
+			r := h.records[0]
+			if r.Message != tc.prefix {
+				t.Errorf("message = %q, want %q", r.Message, tc.prefix)
+			}
+
+			got := make(map[string]any)
+			r.Attrs(func(a slog.Attr) bool {
+				got[a.Key] = a.Value.Any()
+				return true
+			})
+
+			for key, wantVal := range tc.want {
+				gotVal, ok := got[key]
+				if !ok {
+					t.Errorf("missing log field %q", key)
+					continue
+				}
+				if gotVal != wantVal {
+					t.Errorf("field %q = %v (%T), want %v (%T)", key, gotVal, gotVal, wantVal, wantVal)
+				}
+			}
+		})
+	}
+}

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -39,56 +39,42 @@ func NewOpenAIClient(apiKey, baseURL string, zeroCost bool, logger *slog.Logger)
 	}
 }
 
-// openaiMetrics holds extracted token counts and cost from an OpenAI API response.
-type openaiMetrics struct {
-	inputTokens  int
-	outputTokens int
-	cachedTokens int
-	cost         float64
-}
-
-// logUsage extracts token counts, calculates cost, and logs structured metrics
-// for an OpenAI API call. The prefix distinguishes call types (e.g. "openai generate",
-// "openai judge").
-func (c *OpenAIClient) logUsage(prefix, model string, usage openai.CompletionUsage) openaiMetrics {
+// logUsage extracts token counts, calculates cost, logs structured metrics,
+// and returns a usageMetrics for the OpenAI API call.
+// The prefix distinguishes call types (e.g. "openai generate", "openai judge").
+func (c *OpenAIClient) logUsage(prefix, model string, usage openai.CompletionUsage) usageMetrics {
 	inputTokens := int(usage.PromptTokens)
 	outputTokens := int(usage.CompletionTokens)
-	cachedTokens := int(usage.PromptTokensDetails.CachedTokens)
+	cacheReadTokens := int(usage.PromptTokensDetails.CachedTokens)
 
 	var cost float64
 	if !c.zeroCost {
 		// OpenAI: regular input = total prompt minus cached, cache write = 0 (same price),
 		// cache read = cached tokens.
-		regularInput := inputTokens - cachedTokens
+		regularInput := inputTokens - cacheReadTokens
 		var usingFallback bool
-		cost, usingFallback = CalculateCost(model, regularInput, 0, cachedTokens, outputTokens)
+		cost, usingFallback = CalculateCost(model, regularInput, 0, cacheReadTokens, outputTokens)
 		if usingFallback {
 			c.logger.Warn("using fallback pricing for unknown model", "model", model)
 		}
 	}
 
-	c.logger.Info(prefix,
-		"model", model,
-		"input_tokens", inputTokens,
-		"cached_tokens", cachedTokens,
-		"output_tokens", outputTokens,
-		"cost_usd", cost,
-		"cache_hit", cachedTokens > 0,
-	)
-
-	return openaiMetrics{
-		inputTokens:  inputTokens,
-		outputTokens: outputTokens,
-		cachedTokens: cachedTokens,
-		cost:         cost,
+	m := usageMetrics{
+		model:           model,
+		inputTokens:     inputTokens,
+		cacheReadTokens: cacheReadTokens,
+		outputTokens:    outputTokens,
+		cost:            cost,
 	}
+	m.log(c.logger, prefix)
+	return m
 }
 
 // Generate calls the OpenAI Chat Completions API to generate code.
 func (c *OpenAIClient) Generate(ctx context.Context, req GenerateRequest) (GenerateResponse, error) {
 	maxTokens := req.MaxTokens
 	if maxTokens == 0 {
-		maxTokens = 8192
+		maxTokens = defaultGenerateMaxTokens
 	}
 
 	messages := make([]openai.ChatCompletionMessageParamUnion, 0, len(req.Messages)+1)
@@ -131,7 +117,7 @@ func (c *OpenAIClient) Generate(ctx context.Context, req GenerateRequest) (Gener
 		Content:      content,
 		InputTokens:  m.inputTokens,
 		OutputTokens: m.outputTokens,
-		CacheHit:     m.cachedTokens > 0,
+		CacheHit:     m.cacheReadTokens > 0,
 		CostUSD:      m.cost,
 		FinishReason: finishReason,
 	}, nil
@@ -150,7 +136,7 @@ func (c *OpenAIClient) Judge(ctx context.Context, req JudgeRequest) (JudgeRespon
 	resp, err := c.client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
 		Model:               req.Model,
 		Messages:            messages,
-		MaxCompletionTokens: openai.Int(4096),
+		MaxCompletionTokens: openai.Int(defaultJudgeMaxTokens),
 	})
 	if err != nil {
 		return JudgeResponse{}, fmt.Errorf("openai judge: %w", err)


### PR DESCRIPTION
Closes #140

## Changes
1. **Create `internal/llm/metrics.go`**
   - Define `usageMetrics` struct:
     ```go
     type usageMetrics struct {
         model              string
         inputTokens        int // Anthropic: regular input only; OpenAI: total prompt tokens
         cacheCreationTokens int
         cacheReadTokens    int
         outputTokens       int
         cost               float64
     }
     ```
   - Define method `(m usageMetrics) log(logger *slog.Logger, prefix string)` that logs all fields as structured slog attributes (`model`, `input_tokens`, `cache_creation_tokens`, `cache_read_tokens`, `output_tokens`, `cost_usd`, `cache_hit`)

2. **Modify `internal/llm/client.go`**
   - Add constants `defaultGenerateMaxTokens = 8192`, `defaultJudgeMaxTokens = 4096`

3. **Modify `internal/llm/anthropic.go`**
   - Remove `anthropicMetrics` struct
   - Refactor `logUsage` method: extract tokens, compute cost (keep fallback warning), construct `usageMetrics`, call `m.log(c.logger, prefix)`, return `usageMetrics`
   - Replace magic numbers with `defaultGenerateMaxTokens` / `defaultJudgeMaxTokens`
   - Update field references at call sites (lines 139–146, 221–229)

4. **Modify `internal/llm/openai.go`**
   - Remove `openaiMetrics` struct
   - Refactor `logUsage` method: same pattern, `cacheCreationTokens: 0`, zeroCost guard preserved
   - Replace magic numbers with `defaultGenerateMaxTokens` / `defaultJudgeMaxTokens`
   - Update field references at call sites (lines 130–137, 164)

## Review Findings
- Errors: 0
- Warnings: 1
- Nits: 3
- Assessment: **NEEDS CHANGES** (the log field rename in finding #1 should be explicitly acknowledged/documented; if it's intentional and operators are aware, downgrade to nit and PASS)
