### PR TITLE
fix(container): clean up Docker images built by validate --code

### DIFF
--- a/cmd/octog/main.go
+++ b/cmd/octog/main.go
@@ -624,12 +624,18 @@ func setupValidateContainer(ctx context.Context, logger *slog.Logger, codeDir st
 
 	runRes, stop, err := mgr.Run(ctx, tag)
 	if err != nil {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		mgr.RemoveImage(cleanupCtx, tag)
 		_ = mgr.Close()
 		return validateContainerState{}, fmt.Errorf("validate: run container: %w", err)
 	}
 
 	if err := mgr.WaitHealthy(ctx, runRes.URL, healthTimeout); err != nil {
 		stop()
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		mgr.RemoveImage(cleanupCtx, tag)
 		_ = mgr.Close()
 		return validateContainerState{}, fmt.Errorf("validate: health check: %w", err)
 	}
@@ -656,6 +662,9 @@ func setupValidateContainer(ctx context.Context, logger *slog.Logger, codeDir st
 		restart: restartFn,
 		cleanup: func() {
 			currentStop()
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			mgr.RemoveImage(cleanupCtx, tag)
 			_ = mgr.Close()
 		},
 	}, nil

--- a/internal/container/docker.go
+++ b/internal/container/docker.go
@@ -20,6 +20,7 @@ import (
 	dockertypes "github.com/docker/docker/api/types"
 	dockerbuild "github.com/docker/docker/api/types/build"
 	dockercontainer "github.com/docker/docker/api/types/container"
+	dockerimage "github.com/docker/docker/api/types/image"
 	dockernetwork "github.com/docker/docker/api/types/network"
 	dockerclient "github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
@@ -53,6 +54,7 @@ type dockerAPI interface {
 	ContainerExecCreate(ctx context.Context, containerID string, config dockercontainer.ExecOptions) (dockercontainer.ExecCreateResponse, error)
 	ContainerExecAttach(ctx context.Context, execID string, config dockercontainer.ExecAttachOptions) (dockertypes.HijackedResponse, error)
 	ContainerExecInspect(ctx context.Context, execID string) (dockercontainer.ExecInspect, error)
+	ImageRemove(ctx context.Context, imageID string, options dockerimage.RemoveOptions) ([]dockerimage.DeleteResponse, error)
 }
 
 // Compile-time check: *dockerclient.Client must implement dockerAPI.
@@ -209,6 +211,15 @@ func (m *Manager) Run(ctx context.Context, tag string) (RunResult, StopFunc, err
 	}
 	m.logger.Info("container started", "id", shortID, "url", containerURL)
 	return RunResult{URL: containerURL, ContainerID: containerID}, stopFn, nil
+}
+
+// RemoveImage removes a Docker image by tag. Errors are logged as warnings and not returned;
+// this is a best-effort cleanup operation.
+func (m *Manager) RemoveImage(ctx context.Context, tag string) {
+	_, err := m.docker.ImageRemove(ctx, tag, dockerimage.RemoveOptions{Force: false, PruneChildren: true})
+	if err != nil {
+		m.logger.Warn("container: remove image", "tag", tag, "error", err)
+	}
 }
 
 // stopAndRemove stops and forcibly removes a running container.

--- a/internal/container/docker_test.go
+++ b/internal/container/docker_test.go
@@ -20,6 +20,7 @@ import (
 	dockertypes "github.com/docker/docker/api/types"
 	dockerbuild "github.com/docker/docker/api/types/build"
 	dockercontainer "github.com/docker/docker/api/types/container"
+	dockerimage "github.com/docker/docker/api/types/image"
 	dockernetwork "github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/go-connections/nat"
@@ -37,6 +38,7 @@ type mockDockerAPI struct {
 	containerExecCreateFunc  func(ctx context.Context, containerID string, config dockercontainer.ExecOptions) (dockercontainer.ExecCreateResponse, error)
 	containerExecAttachFunc  func(ctx context.Context, execID string, config dockercontainer.ExecAttachOptions) (dockertypes.HijackedResponse, error)
 	containerExecInspectFunc func(ctx context.Context, execID string) (dockercontainer.ExecInspect, error)
+	imageRemoveFunc          func(ctx context.Context, imageID string, options dockerimage.RemoveOptions) ([]dockerimage.DeleteResponse, error)
 }
 
 func (m *mockDockerAPI) ImageBuild(ctx context.Context, buildContext io.Reader, options dockerbuild.ImageBuildOptions) (dockerbuild.ImageBuildResponse, error) {
@@ -82,6 +84,13 @@ func (m *mockDockerAPI) ContainerExecInspect(ctx context.Context, execID string)
 		return m.containerExecInspectFunc(ctx, execID)
 	}
 	return dockercontainer.ExecInspect{}, nil
+}
+
+func (m *mockDockerAPI) ImageRemove(ctx context.Context, imageID string, options dockerimage.RemoveOptions) ([]dockerimage.DeleteResponse, error) {
+	if m.imageRemoveFunc != nil {
+		return m.imageRemoveFunc(ctx, imageID, options)
+	}
+	return nil, nil
 }
 
 // roundTripFunc adapts a function to http.RoundTripper.
@@ -827,4 +836,45 @@ func TestSessionExecPassesEnv(t *testing.T) {
 	if !foundEnv {
 		t.Errorf("expected FOO=bar in exec env, got %v", gotConfig.Env)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// RemoveImage tests
+// ---------------------------------------------------------------------------
+
+func TestRemoveImage(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		var gotImageID string
+		var gotOptions dockerimage.RemoveOptions
+		mock := &mockDockerAPI{
+			imageRemoveFunc: func(_ context.Context, imageID string, options dockerimage.RemoveOptions) ([]dockerimage.DeleteResponse, error) {
+				gotImageID = imageID
+				gotOptions = options
+				return nil, nil
+			},
+		}
+		m := newManager(mock, nil, newTestLogger())
+		m.RemoveImage(context.Background(), "test:latest")
+
+		if gotImageID != "test:latest" {
+			t.Errorf("ImageRemove called with %q, want %q", gotImageID, "test:latest")
+		}
+		if gotOptions.Force {
+			t.Error("expected Force=false")
+		}
+		if !gotOptions.PruneChildren {
+			t.Error("expected PruneChildren=true")
+		}
+	})
+
+	t.Run("error_does_not_propagate", func(t *testing.T) {
+		mock := &mockDockerAPI{
+			imageRemoveFunc: func(_ context.Context, _ string, _ dockerimage.RemoveOptions) ([]dockerimage.DeleteResponse, error) {
+				return nil, errors.New("image not found")
+			},
+		}
+		m := newManager(mock, nil, newTestLogger())
+		// Must not panic or propagate the error.
+		m.RemoveImage(context.Background(), "test:latest")
+	})
 }


### PR DESCRIPTION
Closes #162

## Changes
1. **`internal/container/docker.go`**
   - Add `dockerimage "github.com/docker/docker/api/types/image"` to imports
   - Add `ImageRemove(ctx context.Context, imageID string, options dockerimage.RemoveOptions) ([]dockerimage.DeleteResponse, error)` to the `dockerAPI` interface
   - Add `RemoveImage(ctx context.Context, tag string)` method on `*Manager` — calls `m.docker.ImageRemove` with `Force: false, PruneChildren: true`. On error, logs `slog.Warn` with the tag and error. No return value (best-effort).

2. **`internal/container/docker_test.go`**
   - Add `imageRemoveFunc func(ctx context.Context, imageID string, options dockerimage.RemoveOptions) ([]dockerimage.DeleteResponse, error)` field to `mockDockerAPI`
   - Add `ImageRemove` method on `*mockDockerAPI` — delegates to `imageRemoveFunc` if set, otherwise returns `nil, nil`
   - Add `TestRemoveImage` with two subtests (see Tests below)

3. **`cmd/octog/main.go`**
   - In `setupValidateContainer`, modify the final cleanup closure (line 657-659) to call `mgr.RemoveImage` before `mgr.Close()`, using a `context.WithTimeout(context.Background(), 10*time.Second)`:
     ```go
     cleanup: func() {
         currentStop()
         cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
         defer cancel()
         mgr.RemoveImage(cleanupCtx, tag)
         _ = mgr.Close()
     },
     ```
   - In the `Run` error path (line 627): add `mgr.RemoveImage` with 10s background-context timeout before `mgr.Close()`
   - In the `WaitHealthy` error path (line 632): add `mgr.RemoveImage` with 10s background-context timeout before `mgr.Close()` (after `stop()` which already cleans up the container)

## Review Findings
- Errors: 0
- Warnings: 0
- Nits: 2
- Assessment: **PASS**

The change is clean. Cleanup ordering is correct in all three paths (stop container → remove image → close manager). The best-effort `RemoveImage` design (log-and-discard errors) is appropriate for cleanup. `Force: false` is the right choice since containers are always stopped before image removal. Context handling with `context.Background()` + timeout for cleanup is proper (avoids inheriting a possibly-canceled parent context). Tests cover both the happy path (verifying arguments) and the error-swallowing behavior.
