### PR TITLE
feat(scenario): parallelize independent scenario execution during validation

### DIFF
--- a/cmd/octog/main.go
+++ b/cmd/octog/main.go
@@ -19,6 +19,8 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/foundatron/octopusgarden/internal/attractor"
 	"github.com/foundatron/octopusgarden/internal/container"
 	"github.com/foundatron/octopusgarden/internal/gene"
@@ -51,6 +53,7 @@ var (
 	errNoJudgeModelPricing        = errors.New("judge model has no pricing entry")
 	errInvalidFormat              = errors.New("--format must be \"text\" or \"json\"")
 	errInvalidProvider            = errors.New("--provider must be \"anthropic\" or \"openai\"")
+	errInvalidParallelScenarios   = errors.New("--parallel-scenarios must be >= 1")
 	errInvalidLanguage            = errors.New("--language must be one of: go, python, node, rust, auto")
 	errListModelsUnsupported      = errors.New("provider does not support listing models")
 	errPreflightFailed            = errors.New("preflight: spec clarity below threshold")
@@ -492,16 +495,17 @@ func applyModelDefaults(model, judgeModel *string, provider string) {
 
 // validateFlags holds parsed flags for the validate subcommand.
 type validateFlags struct {
-	scenarios     string
-	target        string
-	code          string
-	healthTimeout time.Duration
-	grpcTarget    string
-	provider      string
-	judgeModel    string
-	threshold     float64
-	format        string
-	verbose       int
+	scenarios         string
+	target            string
+	code              string
+	healthTimeout     time.Duration
+	grpcTarget        string
+	provider          string
+	judgeModel        string
+	threshold         float64
+	format            string
+	verbose           int
+	parallelScenarios int
 }
 
 func parseValidateFlags(args []string) (validateFlags, error) {
@@ -517,6 +521,7 @@ func parseValidateFlags(args []string) (validateFlags, error) {
 	fs.Float64Var(&vf.threshold, "threshold", 0, "minimum satisfaction score (0-100); non-zero enables exit code 1 on failure")
 	fs.StringVar(&vf.format, "format", "text", "output format: text or json")
 	fs.IntVar(&vf.verbose, "v", 0, "verbosity level: 0=standard, 1=per-scenario summary, 2=full step detail with judge reasoning")
+	fs.IntVar(&vf.parallelScenarios, "parallel-scenarios", 1, "number of scenarios to run concurrently (>1 disables container restart; scenarios share container state)")
 
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: octog validate [flags]\n\nFlags:\n")
@@ -529,6 +534,9 @@ func parseValidateFlags(args []string) (validateFlags, error) {
 
 	if vf.format != "text" && vf.format != "json" {
 		return validateFlags{}, errInvalidFormat
+	}
+	if vf.parallelScenarios < 1 {
+		return validateFlags{}, errInvalidParallelScenarios
 	}
 	if vf.code != "" && vf.target != "" {
 		return validateFlags{}, errCodeAndTargetConflict
@@ -594,7 +602,7 @@ func validateCmd(ctx context.Context, logger *slog.Logger, args []string) error 
 		needsBrowser:  caps.NeedsBrowser,
 		needsWS:       caps.NeedsWS,
 		grpcTarget:    vf.grpcTarget,
-	}, clients.client, vf.judgeModel, restartFn)
+	}, clients.client, vf.judgeModel, restartFn, vf.parallelScenarios)
 	if err != nil {
 		return fmt.Errorf("validate: %w", err)
 	}
@@ -1187,7 +1195,14 @@ func buildExecutors(opts executorOpts) (map[string]scenario.StepExecutor, func()
 	return executors, cleanup
 }
 
-func runAndScore(ctx context.Context, scenarios []scenario.Scenario, opts executorOpts, llmClient llm.Client, judgeModel string, restart attractor.RestartFunc) (scenario.AggregateResult, error) {
+func runAndScore(ctx context.Context, scenarios []scenario.Scenario, opts executorOpts, llmClient llm.Client, judgeModel string, restart attractor.RestartFunc, parallelism int) (scenario.AggregateResult, error) {
+	if parallelism <= 1 {
+		return runAndScoreSequential(ctx, scenarios, opts, llmClient, judgeModel, restart)
+	}
+	return runAndScoreParallel(ctx, scenarios, opts, llmClient, judgeModel, parallelism)
+}
+
+func runAndScoreSequential(ctx context.Context, scenarios []scenario.Scenario, opts executorOpts, llmClient llm.Client, judgeModel string, restart attractor.RestartFunc) (scenario.AggregateResult, error) {
 	scored := make([]scenario.ScoredScenario, 0, len(scenarios))
 
 	for i, sc := range scenarios {
@@ -1233,12 +1248,62 @@ func runAndScore(ctx context.Context, scenarios []scenario.Scenario, opts execut
 	return scenario.Aggregate(scored), nil
 }
 
+func runAndScoreParallel(ctx context.Context, scenarios []scenario.Scenario, opts executorOpts, llmClient llm.Client, judgeModel string, parallelism int) (scenario.AggregateResult, error) {
+	if opts.logger != nil {
+		opts.logger.Info("running scenarios in parallel", "count", len(scenarios), "parallelism", parallelism)
+	}
+
+	results := make([]scenario.ScoredScenario, len(scenarios))
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(parallelism)
+
+	for i, sc := range scenarios {
+		g.Go(func() error {
+			executors, cleanup := buildExecutors(opts)
+			runner := scenario.NewRunner(executors, opts.logger)
+			judge := scenario.NewJudge(llmClient, judgeModel, opts.logger)
+
+			result, runErr := runner.Run(gctx, sc)
+			cleanup()
+			if runErr != nil {
+				weight := 1.0
+				if sc.Weight != nil {
+					weight = *sc.Weight
+				}
+				if opts.logger != nil {
+					opts.logger.Warn("scenario setup failed", "scenario", sc.ID, "error", runErr)
+				}
+				results[i] = scenario.ScoredScenario{
+					ScenarioID: sc.ID,
+					Weight:     weight,
+					Score:      0,
+				}
+				return nil
+			}
+
+			ss, err := judge.ScoreScenario(gctx, sc, result)
+			if err != nil {
+				return fmt.Errorf("score scenario %s: %w", sc.ID, err)
+			}
+			results[i] = ss
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return scenario.AggregateResult{}, err
+	}
+
+	return scenario.Aggregate(results), nil
+}
+
 func buildValidateFn(scenarios []scenario.Scenario, llmClient llm.Client, judgeModel string, baseOpts executorOpts, grpcTargetGetter func() string) attractor.ValidateFn {
 	return func(ctx context.Context, url string, restart attractor.RestartFunc) (float64, []string, float64, error) {
 		opts := baseOpts
 		opts.targetURL = url
 		opts.grpcTarget = grpcTargetGetter()
-		agg, err := runAndScore(ctx, scenarios, opts, llmClient, judgeModel, restart)
+		agg, err := runAndScore(ctx, scenarios, opts, llmClient, judgeModel, restart, 1)
 		if err != nil {
 			return 0, nil, 0, err
 		}

--- a/cmd/octog/main_test.go
+++ b/cmd/octog/main_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -91,7 +92,7 @@ func TestRunAndScore(t *testing.T) {
 		targetURL:     srv.URL,
 		logger:        testLogger(),
 		sessionGetter: func() *container.Session { return nil },
-	}, mock, "claude-haiku-4-5-20251001", nil)
+	}, mock, "claude-haiku-4-5-20251001", nil, 1)
 	if err != nil {
 		t.Fatalf("runAndScore: %v", err)
 	}
@@ -143,7 +144,7 @@ func TestRunAndScoreSetupFailure(t *testing.T) {
 		targetURL:     "http://127.0.0.1:1",
 		logger:        testLogger(),
 		sessionGetter: func() *container.Session { return nil },
-	}, mock, "claude-haiku-4-5-20251001", nil)
+	}, mock, "claude-haiku-4-5-20251001", nil, 1)
 	if err != nil {
 		t.Fatalf("runAndScore: %v", err)
 	}
@@ -319,7 +320,7 @@ func TestValidateThreshold(t *testing.T) {
 				targetURL:     srv.URL,
 				logger:        testLogger(),
 				sessionGetter: func() *container.Session { return nil },
-			}, mock, "claude-haiku-4-5-20251001", nil)
+			}, mock, "claude-haiku-4-5-20251001", nil, 1)
 			if err != nil {
 				t.Fatalf("runAndScore: %v", err)
 			}
@@ -1636,7 +1637,7 @@ func TestRunAndScoreSequentialOrder(t *testing.T) {
 		targetURL:     srv.URL,
 		logger:        testLogger(),
 		sessionGetter: func() *container.Session { return nil },
-	}, mock, "claude-haiku-4-5-20251001", nil)
+	}, mock, "claude-haiku-4-5-20251001", nil, 1)
 	if err != nil {
 		t.Fatalf("runAndScore: %v", err)
 	}
@@ -1673,7 +1674,7 @@ func TestRunAndScoreRestartCalledBetweenScenarios(t *testing.T) {
 		targetURL:     srv.URL,
 		logger:        testLogger(),
 		sessionGetter: func() *container.Session { return nil },
-	}, mock, "claude-haiku-4-5-20251001", restart)
+	}, mock, "claude-haiku-4-5-20251001", restart, 1)
 	if err != nil {
 		t.Fatalf("runAndScore: %v", err)
 	}
@@ -1707,7 +1708,7 @@ func TestRunAndScoreRestartErrorPropagation(t *testing.T) {
 		targetURL:     srv.URL,
 		logger:        testLogger(),
 		sessionGetter: func() *container.Session { return nil },
-	}, mock, "claude-haiku-4-5-20251001", restart)
+	}, mock, "claude-haiku-4-5-20251001", restart, 1)
 	if err == nil {
 		t.Fatal("expected error from restart, got nil")
 	}
@@ -1732,11 +1733,238 @@ func TestRunAndScoreNilRestart(t *testing.T) {
 		targetURL:     srv.URL,
 		logger:        testLogger(),
 		sessionGetter: func() *container.Session { return nil },
-	}, mock, "claude-haiku-4-5-20251001", nil)
+	}, mock, "claude-haiku-4-5-20251001", nil, 1)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(agg.Scenarios) != 2 {
 		t.Fatalf("expected 2 scenarios, got %d", len(agg.Scenarios))
+	}
+}
+
+func TestParseValidateFlagsParallelScenarios(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	t.Run("valid flag parsed", func(t *testing.T) {
+		vf, err := parseValidateFlags([]string{
+			"--scenarios", "testdata/scenarios",
+			"--target", srv.URL,
+			"--parallel-scenarios", "4",
+		})
+		if err != nil {
+			// Flag parsing is tested here; missing testdata dir is OK as long as flag is accepted.
+			if strings.Contains(err.Error(), "flag provided but not defined") {
+				t.Fatalf("--parallel-scenarios flag not recognized: %v", err)
+			}
+		} else if vf.parallelScenarios != 4 {
+			t.Errorf("expected parallelScenarios=4, got %d", vf.parallelScenarios)
+		}
+	})
+
+	t.Run("zero returns errInvalidParallelScenarios", func(t *testing.T) {
+		_, err := parseValidateFlags([]string{
+			"--scenarios", "testdata/scenarios",
+			"--target", srv.URL,
+			"--parallel-scenarios", "0",
+		})
+		if !errors.Is(err, errInvalidParallelScenarios) {
+			t.Errorf("expected errInvalidParallelScenarios, got: %v", err)
+		}
+	})
+}
+
+func TestRunAndScoreParallelMatchesSequential(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	scenarios := []scenario.Scenario{
+		simpleScenario("s1"),
+		simpleScenario("s2"),
+		simpleScenario("s3"),
+	}
+
+	mock := &mockLLMClient{
+		judgeFn: func(_ context.Context, _ llm.JudgeRequest) (llm.JudgeResponse, error) {
+			return llm.JudgeResponse{Score: 75, CostUSD: 0.001}, nil
+		},
+	}
+	opts := executorOpts{
+		targetURL:     srv.URL,
+		logger:        testLogger(),
+		sessionGetter: func() *container.Session { return nil },
+	}
+	const judgeModel = "claude-haiku-4-5-20251001"
+
+	seqAgg, err := runAndScore(context.Background(), scenarios, opts, mock, judgeModel, nil, 1)
+	if err != nil {
+		t.Fatalf("sequential runAndScore: %v", err)
+	}
+
+	parAgg, err := runAndScore(context.Background(), scenarios, opts, mock, judgeModel, nil, 3)
+	if err != nil {
+		t.Fatalf("parallel runAndScore: %v", err)
+	}
+
+	if len(seqAgg.Scenarios) != len(parAgg.Scenarios) {
+		t.Fatalf("scenario count mismatch: seq=%d par=%d", len(seqAgg.Scenarios), len(parAgg.Scenarios))
+	}
+	for i := range seqAgg.Scenarios {
+		if seqAgg.Scenarios[i].ScenarioID != parAgg.Scenarios[i].ScenarioID {
+			t.Errorf("scenario[%d] ID: seq=%q par=%q", i, seqAgg.Scenarios[i].ScenarioID, parAgg.Scenarios[i].ScenarioID)
+		}
+		if seqAgg.Scenarios[i].Score != parAgg.Scenarios[i].Score {
+			t.Errorf("scenario[%d] score: seq=%.1f par=%.1f", i, seqAgg.Scenarios[i].Score, parAgg.Scenarios[i].Score)
+		}
+	}
+	if seqAgg.Satisfaction != parAgg.Satisfaction {
+		t.Errorf("satisfaction: seq=%.1f par=%.1f", seqAgg.Satisfaction, parAgg.Satisfaction)
+	}
+}
+
+func TestRunAndScoreParallelContextCancellation(t *testing.T) {
+	// blocking channel: all goroutines will block until context is canceled.
+	block := make(chan struct{})
+
+	var callCount atomic.Int32
+	mock := &mockLLMClient{
+		judgeFn: func(ctx context.Context, _ llm.JudgeRequest) (llm.JudgeResponse, error) {
+			callCount.Add(1)
+			select {
+			case <-block:
+				return llm.JudgeResponse{Score: 90}, nil
+			case <-ctx.Done():
+				return llm.JudgeResponse{}, ctx.Err()
+			}
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		// Cancel after judge calls have started.
+		for callCount.Load() == 0 {
+			time.Sleep(time.Millisecond)
+		}
+		cancel()
+	}()
+
+	scenarios := []scenario.Scenario{
+		simpleScenario("s1"),
+		simpleScenario("s2"),
+	}
+	_, err := runAndScore(ctx, scenarios, executorOpts{
+		targetURL:     srv.URL,
+		logger:        testLogger(),
+		sessionGetter: func() *container.Session { return nil },
+	}, mock, "claude-haiku-4-5-20251001", nil, 2)
+	if err == nil {
+		t.Fatal("expected error from context cancellation, got nil")
+	}
+}
+
+func TestRunAndScoreParallelConcurrencyBound(t *testing.T) {
+	// Use a blocking channel inside a mock executor to verify that at most
+	// parallelism goroutines run concurrently. The mock LLM client blocks
+	// inside Judge until we release it, so we can count concurrent calls.
+	const parallelism = 2
+	const numScenarios = 4
+
+	var concurrent atomic.Int32
+	var maxConcurrent atomic.Int32
+	release := make(chan struct{})
+
+	mock := &mockLLMClient{
+		judgeFn: func(_ context.Context, _ llm.JudgeRequest) (llm.JudgeResponse, error) {
+			cur := concurrent.Add(1)
+			defer concurrent.Add(-1)
+
+			for {
+				prev := maxConcurrent.Load()
+				if cur <= prev || maxConcurrent.CompareAndSwap(prev, cur) {
+					break
+				}
+			}
+
+			<-release
+			return llm.JudgeResponse{Score: 90}, nil
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	scenarios := make([]scenario.Scenario, numScenarios)
+	for i := range scenarios {
+		scenarios[i] = simpleScenario(fmt.Sprintf("s%d", i+1))
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = runAndScore(context.Background(), scenarios, executorOpts{
+			targetURL:     srv.URL,
+			logger:        testLogger(),
+			sessionGetter: func() *container.Session { return nil },
+		}, mock, "claude-haiku-4-5-20251001", nil, parallelism)
+	}()
+
+	// Wait until parallelism goroutines are blocked inside Judge.
+	deadline := time.Now().Add(5 * time.Second)
+	for concurrent.Load() < parallelism && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if concurrent.Load() > parallelism {
+		t.Errorf("concurrent goroutines exceeded parallelism: got %d, want <= %d", concurrent.Load(), parallelism)
+	}
+
+	// Unblock all goroutines.
+	close(release)
+	<-done
+
+	if got := maxConcurrent.Load(); got > parallelism {
+		t.Errorf("max concurrent goroutines=%d exceeded parallelism=%d", got, parallelism)
+	}
+}
+
+func TestRunAndScoreParallelRestartSkipped(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	var restartCalls atomic.Int32
+	restart := attractor.RestartFunc(func(_ context.Context) (string, error) {
+		restartCalls.Add(1)
+		return srv.URL, nil
+	})
+
+	scenarios := []scenario.Scenario{
+		simpleScenario("s1"),
+		simpleScenario("s2"),
+		simpleScenario("s3"),
+	}
+
+	mock := &mockLLMClient{}
+	_, err := runAndScore(context.Background(), scenarios, executorOpts{
+		targetURL:     srv.URL,
+		logger:        testLogger(),
+		sessionGetter: func() *container.Session { return nil },
+	}, mock, "claude-haiku-4-5-20251001", restart, 2)
+	if err != nil {
+		t.Fatalf("runAndScore: %v", err)
+	}
+	if got := restartCalls.Load(); got != 0 {
+		t.Errorf("expected restart not called when parallelism>1, got %d calls", got)
 	}
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -195,7 +195,8 @@ content and failure feedback as strings. The validator (scenario runner + judge)
 - **Status**: Implemented
 - **Files**: `scenario/runner.go`, `scenario/grpc.go`, step executors
 - **Method**: Sequential step execution with variable capture/substitution. Pluggable executors: HTTP, exec, browser (chromedp), gRPC (reflection), WebSocket. Setup steps fatal, judged steps non-fatal.
-- **Limitations**: Sequential execution only. No parallel step groups. No conditional branching. JSONPath is dot-notation only (no filters, array slicing, or recursive descent).
+- **Parallelism**: `validate --parallel-scenarios N` runs up to N scenarios concurrently using a semaphore-bounded goroutine pool. Each goroutine owns its own `Runner`, `Judge`, and executor instances. Container restart is disabled when `N > 1` (scenarios share container state); use `--parallel-scenarios 1` (the default) when clean state between scenarios is required.
+- **Limitations**: Sequential steps within a scenario only. No parallel step groups. No conditional branching. JSONPath is dot-notation only (no filters, array slicing, or recursive descent).
 
 ## Known Gaps & Improvement Opportunities
 
@@ -208,7 +209,6 @@ content and failure feedback as strings. The validator (scenario runner + judge)
 - **Incremental patching**: AST-level diff and merge instead of full-file regeneration to preserve working code and reduce token cost
 - **Spec-failure alignment**: Dynamically weight spec sections in the prompt based on which sections are causing current failures
 - **Multi-exemplar gene synthesis**: Combine patterns from multiple codebases; update gene guide based on generation outcomes
-- **Parallel scenario execution**: Run independent scenarios concurrently during validation for faster iteration cycles
 - **Automated spec repair**: Use preflight failures to suggest or auto-fix spec ambiguities before entering the attractor loop
 
 ## LLM Client Interface

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.40.0
 	go.opentelemetry.io/otel/sdk v1.40.0
 	go.opentelemetry.io/otel/trace v1.40.0
+	golang.org/x/sync v0.19.0
 	google.golang.org/grpc v1.79.1
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
@@ -62,7 +63,6 @@ require (
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 // indirect
 	golang.org/x/net v0.49.0 // indirect
-	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260128011058-8636f8732409 // indirect

--- a/internal/scenario/runner.go
+++ b/internal/scenario/runner.go
@@ -22,6 +22,8 @@ var (
 )
 
 // Runner executes scenario steps by dispatching to registered StepExecutors.
+// Each Runner instance is single-use and not safe for concurrent use; callers
+// running scenarios in parallel must create a separate Runner per goroutine.
 type Runner struct {
 	Executors map[string]StepExecutor
 	Logger    *slog.Logger


### PR DESCRIPTION
Closes #176

## Changes
1. **`cmd/octog/main.go`**
   - Add `parallelScenarios int` field to `validateFlags` struct (~line 494)
   - Add `fs.IntVar(&vf.parallelScenarios, "parallel-scenarios", 1, ...)` in `parseValidateFlags` (~line 519)
   - Add validation: `if vf.parallelScenarios < 1 { return ..., errInvalidParallelScenarios }`
   - Add sentinel `var errInvalidParallelScenarios = errors.New("--parallel-scenarios must be >= 1")`
   - Pass `vf.parallelScenarios` to `runAndScore` call in `validateCmd` (~line 590)
   - Add `parallelism int` parameter to `runAndScore` signature
   - In `runAndScore`: when `parallelism <= 1`, keep exact current sequential behavior. When `parallelism > 1`:
     - If `restart != nil`, log warning and set `restart = nil` (restart is incompatible with parallelism)
     - Pre-allocate `results := make([]scenarioResult, len(scenarios))`
     - Use `sync.WaitGroup` + buffered channel semaphore of size `parallelism`
     - Each goroutine: acquire semaphore, build own executors/runner/judge, run & score, store result by index, release semaphore
     - After `wg.Wait()`, collect results: return first error from judge failures, aggregate scored scenarios
   - Add unexported `type scenarioResult struct { scored scenario.ScoredScenario; err error }`
   - Update the `buildValidateFn` call site to pass `parallelism: 1` (attractor loop always sequential; future issue)

2. **`internal/scenario/runner.go`** -- Add concurrency safety comment on `Runner` struct

3. **`docs/architecture.md`** -- Remove "Parallel scenario execution" from Known Gaps; add note about `--parallel-scenarios` flag in the Scenario Runner section

## Review Findings
- Errors: 0
- Warnings: 4
- Nits: 4
- Assessment: **NEEDS CHANGES**

The most actionable fix is finding #3/#4: use a cancellable derived context in the parallel path so that when a judge error occurs, in-flight goroutines are cancelled promptly rather than continuing to make costly LLM calls. Finding #1 (nil logger panic) should also be addressed. The `scenarioResult` wrapper (#2) is minor but adds unnecessary indirection.
