### PR TITLE
feat(attractor): define and implement agent file tools

### DIFF
--- a/internal/attractor/tools.go
+++ b/internal/attractor/tools.go
@@ -1,0 +1,181 @@
+package attractor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/foundatron/octopusgarden/internal/llm"
+)
+
+var errUnknownTool = errors.New("attractor: unknown tool")
+
+// agentToolHandler dispatches agent tool calls for file operations within an iteration directory.
+type agentToolHandler struct {
+	iterDir string
+	logger  *slog.Logger
+}
+
+// newAgentToolHandler creates a handler rooted at iterDir.
+// iterDir is resolved to an absolute path.
+func newAgentToolHandler(iterDir string, logger *slog.Logger) (*agentToolHandler, error) {
+	abs, err := filepath.Abs(iterDir)
+	if err != nil {
+		return nil, fmt.Errorf("attractor: resolve iterDir: %w", err)
+	}
+	return &agentToolHandler{
+		iterDir: abs,
+		logger:  logger,
+	}, nil
+}
+
+type writeFileInput struct {
+	Path    string `json:"path"`
+	Content string `json:"content"`
+}
+
+type readFileInput struct {
+	Path string `json:"path"`
+}
+
+type listFilesInput struct {
+	Directory string `json:"directory"`
+}
+
+// Handle dispatches a tool call to the appropriate handler.
+func (h *agentToolHandler) Handle(_ context.Context, call llm.ToolCall) (string, error) {
+	switch call.Name {
+	case "write_file":
+		return h.handleWriteFile(call.Input)
+	case "read_file":
+		return h.handleReadFile(call.Input)
+	case "list_files":
+		return h.handleListFiles(call.Input)
+	default:
+		return "", errUnknownTool
+	}
+}
+
+func (h *agentToolHandler) handleWriteFile(raw json.RawMessage) (string, error) {
+	var input writeFileInput
+	if err := json.Unmarshal(raw, &input); err != nil {
+		return "", fmt.Errorf("attractor: unmarshal write_file input: %w", err)
+	}
+	if err := validatePath(input.Path); err != nil {
+		return "", err
+	}
+	if err := writeOneFile(h.iterDir, input.Path, input.Content); err != nil {
+		return "", err
+	}
+	if h.logger != nil {
+		h.logger.Debug("agent wrote file", "path", input.Path)
+	}
+	return "ok", nil
+}
+
+// resolveContained joins rel to h.iterDir, resolves the absolute path, and verifies it remains
+// within the sandbox. It mirrors the containment check in writeOneFile for consistency.
+// Note: this does not resolve symlinks; a symlink to a file outside iterDir would pass.
+// However, writeOneFile cannot create symlinks, so pre-existing symlinks are required to exploit.
+func (h *agentToolHandler) resolveContained(rel string) (string, error) {
+	abs, err := filepath.Abs(filepath.Join(h.iterDir, rel))
+	if err != nil {
+		return "", fmt.Errorf("attractor: resolve path: %w", err)
+	}
+	if abs != h.iterDir && !strings.HasPrefix(abs, h.iterDir+string(filepath.Separator)) {
+		return "", fmt.Errorf("%w: %s escapes workspace", errPathTraversal, rel)
+	}
+	return abs, nil
+}
+
+func (h *agentToolHandler) handleReadFile(raw json.RawMessage) (string, error) {
+	var input readFileInput
+	if err := json.Unmarshal(raw, &input); err != nil {
+		return "", fmt.Errorf("attractor: unmarshal read_file input: %w", err)
+	}
+	if err := validatePath(input.Path); err != nil {
+		return "", err
+	}
+	absPath, err := h.resolveContained(input.Path)
+	if err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(absPath)
+	if err != nil {
+		// File-not-found is returned as a string result so the agent can observe and adapt.
+		// Other I/O errors (permission denied, disk failure) are returned as Go errors.
+		if errors.Is(err, fs.ErrNotExist) {
+			return err.Error(), nil
+		}
+		return "", fmt.Errorf("attractor: read_file %s: %w", input.Path, err)
+	}
+	return string(data), nil
+}
+
+func (h *agentToolHandler) handleListFiles(raw json.RawMessage) (string, error) {
+	var input listFilesInput
+	if err := json.Unmarshal(raw, &input); err != nil {
+		return "", fmt.Errorf("attractor: unmarshal list_files input: %w", err)
+	}
+	dir := input.Directory
+	if dir == "" {
+		dir = "."
+	}
+	if err := validatePath(dir); err != nil {
+		return "", err
+	}
+	root, err := h.resolveContained(dir)
+	if err != nil {
+		return "", err
+	}
+	var paths []string
+	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, entryErr error) error {
+		if entryErr != nil {
+			return entryErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		paths = append(paths, rel)
+		return nil
+	})
+	if err != nil {
+		// Directory-not-found is returned as a string result so the agent can observe and adapt.
+		if errors.Is(err, fs.ErrNotExist) {
+			return err.Error(), nil
+		}
+		return "", fmt.Errorf("attractor: list_files walk: %w", err)
+	}
+	return strings.Join(paths, "\n"), nil
+}
+
+// agentTools returns the tool definitions available to the agent.
+func agentTools() []llm.ToolDef {
+	return []llm.ToolDef{
+		{
+			Name:        "write_file",
+			Description: "Write content to a file in the workspace. Creates parent directories as needed.",
+			InputSchema: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string","description":"Relative path of the file to write"},"content":{"type":"string","description":"Content to write to the file"}},"required":["path","content"]}`),
+		},
+		{
+			Name:        "read_file",
+			Description: "Read the content of a file in the workspace.",
+			InputSchema: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string","description":"Relative path of the file to read"}},"required":["path"]}`),
+		},
+		{
+			Name:        "list_files",
+			Description: "List all files in a directory of the workspace. Returns newline-separated relative paths.",
+			InputSchema: json.RawMessage(`{"type":"object","properties":{"directory":{"type":"string","description":"Relative path of the directory to list (default: \".\")"}}}`),
+		},
+	}
+}

--- a/internal/attractor/tools_test.go
+++ b/internal/attractor/tools_test.go
@@ -1,0 +1,289 @@
+package attractor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/foundatron/octopusgarden/internal/llm"
+)
+
+func newTestHandler(t *testing.T) *agentToolHandler {
+	t.Helper()
+	h, err := newAgentToolHandler(t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("newAgentToolHandler: %v", err)
+	}
+	return h
+}
+
+func toolCall(name string, input any) llm.ToolCall {
+	raw, err := json.Marshal(input)
+	if err != nil {
+		panic(err)
+	}
+	return llm.ToolCall{Name: name, Input: raw}
+}
+
+func TestAgentToolHandler(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("write_file basic", func(t *testing.T) {
+		h := newTestHandler(t)
+		result, err := h.Handle(ctx, toolCall("write_file", map[string]string{
+			"path":    "main.go",
+			"content": "package main\n",
+		}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result != "ok" {
+			t.Errorf("result = %q, want %q", result, "ok")
+		}
+		data, readErr := os.ReadFile(filepath.Join(h.iterDir, "main.go"))
+		if readErr != nil {
+			t.Fatalf("read file: %v", readErr)
+		}
+		if string(data) != "package main\n" {
+			t.Errorf("file content = %q, want %q", string(data), "package main\n")
+		}
+	})
+
+	t.Run("write_file nested", func(t *testing.T) {
+		h := newTestHandler(t)
+		_, err := h.Handle(ctx, toolCall("write_file", map[string]string{
+			"path":    "src/main.go",
+			"content": "package main\n",
+		}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, statErr := os.Stat(filepath.Join(h.iterDir, "src", "main.go")); statErr != nil {
+			t.Errorf("file not created: %v", statErr)
+		}
+	})
+
+	for _, tc := range []struct {
+		name string
+		path string
+	}{
+		{"traversal ../", "../escape.txt"},
+		{"absolute path", "/etc/passwd"},
+	} {
+		t.Run("write_file "+tc.name, func(t *testing.T) {
+			h := newTestHandler(t)
+			_, err := h.Handle(ctx, toolCall("write_file", map[string]string{
+				"path":    tc.path,
+				"content": "bad",
+			}))
+			if !errors.Is(err, errPathTraversal) {
+				t.Errorf("error = %v, want errPathTraversal", err)
+			}
+		})
+	}
+
+	t.Run("write_file empty content", func(t *testing.T) {
+		h := newTestHandler(t)
+		_, err := h.Handle(ctx, toolCall("write_file", map[string]string{
+			"path":    "empty.go",
+			"content": "",
+		}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		info, statErr := os.Stat(filepath.Join(h.iterDir, "empty.go"))
+		if statErr != nil {
+			t.Fatalf("stat: %v", statErr)
+		}
+		if info.Size() != 0 {
+			t.Errorf("size = %d, want 0", info.Size())
+		}
+	})
+
+	t.Run("read_file basic", func(t *testing.T) {
+		h := newTestHandler(t)
+		if err := os.WriteFile(filepath.Join(h.iterDir, "hello.go"), []byte("package main\n"), 0o600); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+		result, err := h.Handle(ctx, toolCall("read_file", map[string]string{"path": "hello.go"}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result != "package main\n" {
+			t.Errorf("result = %q, want %q", result, "package main\n")
+		}
+	})
+
+	t.Run("read_file nonexistent", func(t *testing.T) {
+		h := newTestHandler(t)
+		result, err := h.Handle(ctx, toolCall("read_file", map[string]string{"path": "missing.go"}))
+		if err != nil {
+			t.Fatalf("unexpected Go error: %v", err)
+		}
+		if result == "" {
+			t.Error("result should be non-empty error string")
+		}
+	})
+
+	t.Run("read_file round-trip", func(t *testing.T) {
+		h := newTestHandler(t)
+		content := "package foo\n\nfunc Foo() {}\n"
+		if _, err := h.Handle(ctx, toolCall("write_file", map[string]string{
+			"path":    "foo.go",
+			"content": content,
+		})); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		result, err := h.Handle(ctx, toolCall("read_file", map[string]string{"path": "foo.go"}))
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		if result != content {
+			t.Errorf("round-trip mismatch: got %q, want %q", result, content)
+		}
+	})
+
+	for _, tc := range []struct {
+		name string
+		path string
+	}{
+		{"traversal", "../../etc/passwd"},
+		{"absolute", "/etc/passwd"},
+	} {
+		t.Run("read_file "+tc.name, func(t *testing.T) {
+			h := newTestHandler(t)
+			_, err := h.Handle(ctx, toolCall("read_file", map[string]string{"path": tc.path}))
+			if !errors.Is(err, errPathTraversal) {
+				t.Errorf("error = %v, want errPathTraversal", err)
+			}
+		})
+	}
+
+	t.Run("list_files empty dir", func(t *testing.T) {
+		h := newTestHandler(t)
+		result, err := h.Handle(ctx, toolCall("list_files", map[string]string{"directory": "."}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result != "" {
+			t.Errorf("result = %q, want empty string", result)
+		}
+	})
+
+	t.Run("list_files with files", func(t *testing.T) {
+		h := newTestHandler(t)
+		for _, name := range []string{"a.go", "b.go", "c.go"} {
+			if _, err := h.Handle(ctx, toolCall("write_file", map[string]string{
+				"path":    name,
+				"content": "",
+			})); err != nil {
+				t.Fatalf("write %s: %v", name, err)
+			}
+		}
+		result, err := h.Handle(ctx, toolCall("list_files", map[string]string{"directory": "."}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		lines := nonEmptyLines(result)
+		for _, name := range []string{"a.go", "b.go", "c.go"} {
+			if !slices.Contains(lines, name) {
+				t.Errorf("%s not found in output: %q", name, result)
+			}
+		}
+	})
+
+	t.Run("list_files subdirectory", func(t *testing.T) {
+		h := newTestHandler(t)
+		for _, p := range []string{"sub/a.go", "other/b.go"} {
+			if _, err := h.Handle(ctx, toolCall("write_file", map[string]string{
+				"path":    p,
+				"content": "",
+			})); err != nil {
+				t.Fatalf("write %s: %v", p, err)
+			}
+		}
+		result, err := h.Handle(ctx, toolCall("list_files", map[string]string{"directory": "sub"}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		lines := nonEmptyLines(result)
+		if len(lines) != 1 || lines[0] != "a.go" {
+			t.Errorf("result = %q, want only \"a.go\"", result)
+		}
+	})
+
+	for _, tc := range []struct {
+		name string
+		dir  string
+	}{
+		{"traversal", "../"},
+		{"absolute", "/etc"},
+	} {
+		t.Run("list_files "+tc.name, func(t *testing.T) {
+			h := newTestHandler(t)
+			_, err := h.Handle(ctx, toolCall("list_files", map[string]string{"directory": tc.dir}))
+			if !errors.Is(err, errPathTraversal) {
+				t.Errorf("error = %v, want errPathTraversal", err)
+			}
+		})
+	}
+
+	t.Run("list_files nonexistent dir", func(t *testing.T) {
+		h := newTestHandler(t)
+		result, err := h.Handle(ctx, toolCall("list_files", map[string]string{"directory": "nosuchdir"}))
+		if err != nil {
+			t.Fatalf("unexpected Go error: %v", err)
+		}
+		if result == "" {
+			t.Error("result should be non-empty error string")
+		}
+	})
+
+	t.Run("unknown tool", func(t *testing.T) {
+		h := newTestHandler(t)
+		_, err := h.Handle(ctx, llm.ToolCall{Name: "delete_file", Input: json.RawMessage(`{}`)})
+		if !errors.Is(err, errUnknownTool) {
+			t.Errorf("error = %v, want errUnknownTool", err)
+		}
+	})
+
+	t.Run("agentTools schema", func(t *testing.T) {
+		tools := agentTools()
+		if len(tools) != 3 {
+			t.Fatalf("len(tools) = %d, want 3", len(tools))
+		}
+		for _, tool := range tools {
+			var schema map[string]any
+			if err := json.Unmarshal(tool.InputSchema, &schema); err != nil {
+				t.Errorf("tool %q: invalid JSON schema: %v", tool.Name, err)
+			}
+		}
+	})
+
+	t.Run("write_file bad JSON input", func(t *testing.T) {
+		h := newTestHandler(t)
+		_, err := h.Handle(ctx, llm.ToolCall{Name: "write_file", Input: json.RawMessage(`not json`)})
+		if err == nil {
+			t.Fatal("expected error for malformed JSON, got nil")
+		}
+	})
+}
+
+// nonEmptyLines splits s by newline and returns non-empty lines.
+func nonEmptyLines(s string) []string {
+	if s == "" {
+		return nil
+	}
+	var out []string
+	for line := range strings.SplitSeq(s, "\n") {
+		if line != "" {
+			out = append(out, line)
+		}
+	}
+	return out
+}


### PR DESCRIPTION
Closes #195

## Changes
**1. `internal/attractor/tools.go` (NEW)**

- **`var errUnknownTool = errors.New("attractor: unknown tool")`** -- package-level sentinel
- **`agentToolHandler` struct** -- fields: `iterDir string`, `files map[string]string`, `logger *slog.Logger`
- **`newAgentToolHandler(iterDir string, logger *slog.Logger) *agentToolHandler`** -- resolve `iterDir` via `filepath.Abs`, initialize empty `files` map
- **`(*agentToolHandler).Handle(ctx context.Context, call llm.ToolCall) (string, error)`** -- dispatch on `call.Name`:
  - `"write_file"`: unmarshal `writeFileInput{Path, Content}` from `call.Input` (return Go error on unmarshal failure), `validatePath(input.Path)`, `writeOneFile(h.iterDir, input.Path, input.Content)`, record in `h.files`, return `"ok", nil`
  - `"read_file"`: unmarshal `readFileInput{Path}`, `validatePath`, `os.ReadFile(filepath.Join(h.iterDir, input.Path))`. Success: return content string, nil. `os.ReadFile` error: return `err.Error(), nil` (string result, not Go error, so agent can observe)
  - `"list_files"`: unmarshal `listFilesInput{Directory}`, default empty to `"."`, `validatePath(directory)`, `filepath.WalkDir(filepath.Join(h.iterDir, directory), ...)`, collect paths relative to walked directory via `filepath.Rel`, return newline-joined string. Empty result returns `"", nil`
  - default: `"", errUnknownTool`
- **`agentTools() []llm.ToolDef`** -- returns 3 `llm.ToolDef` with JSON Schema `InputSchema` as `json.RawMessage` raw string literals
- **Unexported input structs**: `writeFileInput`, `readFileInput`, `listFilesInput` -- minimal, no tags needed (JSON field names match lowercase Go convention via `json:"path"` etc.)

Note: JSON struct tags are needed since Go fields are uppercase but JSON keys should be lowercase. Use `json:"path"`, `json:"content"`, `json:"directory"`.

## Review Findings
- Errors: 0
- Warnings: 3
- Nits: 4
- Assessment: **NEEDS CHANGES**

The main concern is the path containment inconsistency: `writeOneFile` does a post-join absolute path containment check, but `handleReadFile` and `handleListFiles` rely only on the pre-join `validatePath` which doesn't guard against symlink escapes. These should use the same containment strategy as `writeOneFile` for consistency and defense-in-depth. The `handleReadFile` error handling could also be tightened to only treat `fs.ErrNotExist` as a string result (matching the pattern already used in `handleListFiles`).
