### PR TITLE
feat(attractor): agentic generation path

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -676,6 +676,8 @@ type RunOptions struct {
 	Genes             string               // extracted pattern guide to inject into system prompt (empty = no genes)
 	GeneLanguage      string               // source language of the gene exemplar (for cross-language note)
 	TestCommand       string               // optional shell command run inside HTTP container after health check; non-zero exit = test_fail
+	Agentic           bool                 // if true, use AgentLoop for code generation (tool-use mode)
+	AgentMaxTurns     int                  // max turns per AgentLoop call; 0 = default (50 when Agentic is true)
 }
 ```
 
@@ -764,6 +766,7 @@ type IterationProgress struct {
 	OutputTokens     int
 	Failures         []string
 	Model            string // model used for generation in this iteration
+	Turns            int    // number of agent turns used (0 for non-agentic iterations)
 }
 ```
 

--- a/internal/attractor/attractor.go
+++ b/internal/attractor/attractor.go
@@ -26,6 +26,7 @@ var (
 	errEmptySpec            = errors.New("attractor: spec content is empty")
 	errUnsupportedLanguage  = errors.New("attractor: unsupported language")
 	errMinimalismNoMessages = errors.New("attractor: minimalism suffix: no messages to append to")
+	errAgentClientRequired  = errors.New("attractor: agentic mode requires AgentClient implementation")
 
 	_ ContainerManager = (*container.Manager)(nil)
 )
@@ -33,6 +34,10 @@ var (
 // summarizeModel is the cheap model used for spec summarization.
 // Haiku is also the default --judge-model for cost efficiency.
 const summarizeModel = "claude-haiku-4-5"
+
+// defaultAgentMaxTurns is the default maximum number of agent turns per iteration
+// when no AgentMaxTurns is specified in RunOptions.
+const defaultAgentMaxTurns = 50
 
 // Status constants for RunResult.
 const (
@@ -74,6 +79,7 @@ type IterationProgress struct {
 	OutputTokens     int
 	Failures         []string
 	Model            string // model used for generation in this iteration
+	Turns            int    // number of agent turns used (0 for non-agentic iterations)
 }
 
 // ProgressFunc is called synchronously after each iteration completes.
@@ -140,6 +146,8 @@ type RunOptions struct {
 	Genes             string               // extracted pattern guide to inject into system prompt (empty = no genes)
 	GeneLanguage      string               // source language of the gene exemplar (for cross-language note)
 	TestCommand       string               // optional shell command run inside HTTP container after health check; non-zero exit = test_fail
+	Agentic           bool                 // if true, use AgentLoop for code generation (tool-use mode)
+	AgentMaxTurns     int                  // max turns per AgentLoop call; 0 = default (50 when Agentic is true)
 }
 
 // RunResult holds the outcome of an attractor run.
@@ -188,6 +196,7 @@ type runState struct {
 	scenarioScoreIteration int                     // iteration number corresponding to scenarioScores
 	codeHashes             []string                // SHA-256 hashes of generated file sets, in iteration order
 	escalation             *escalationState        // nil when FrugalModel is empty (escalation disabled)
+	lastTurns              int                     // number of agent turns used in the last iteration (0 for non-agentic)
 }
 
 // currentModel returns the model to use for generation, respecting escalation state.
@@ -233,6 +242,7 @@ func (s *runState) buildProgress(iter int, costBefore float64) IterationProgress
 		OutputTokens:     s.lastOutputTokens,
 		Failures:         s.lastFailures,
 		Model:            s.currentModel(),
+		Turns:            s.lastTurns,
 	}
 }
 
@@ -489,6 +499,7 @@ func (a *Attractor) wonderReflect(ctx context.Context, rawSpec string, iter int,
 // Returns (result, nil) for terminal conditions, (nil, nil) to continue, or (nil, err) for hard errors.
 func (a *Attractor) iterate(ctx context.Context, rawSpec string, iter int, s *runState, validate ValidateFn) (*RunResult, error) {
 	s.lastImproved = false // reset at start of each iteration; set true only by processValidation on strict improvement
+	s.lastTurns = 0
 
 	// Select spec content: use summarized view when available to respect context budget.
 	// SelectContent returns full spec if it fits the budget, so iteration 1 (no failures)
@@ -502,22 +513,150 @@ func (a *Attractor) iterate(ctx context.Context, rawSpec string, iter int, s *ru
 		specContent = specpkg.SelectContent(s.summarized, s.opts.ContextBudget, failures)
 	}
 
+	// Compute iterDir once before the generation branch.
+	iterDir := filepath.Join(s.baseDir, fmt.Sprintf("iter_%d", iter))
+
+	var files map[string]string
+
+	if s.opts.Agentic {
+		// Agentic path: use AgentLoop for tool-use code generation.
+		// The handler writes files directly to iterDir; no ParseFiles/writeFiles needed.
+		var agentErr error
+		files, agentErr = a.generateAgentic(ctx, specContent, iterDir, iter, s)
+		if errors.Is(agentErr, errNoFiles) {
+			a.logger.Warn("agentic generation produced no files", "iteration", iter)
+			s.lastOutcome = OutcomeParseFail
+			s.lastSatisfaction = 0
+			s.recordStall(iter, feedbackParseError, "Agent produced no files")
+			return a.checkStalled(iter, s), nil
+		}
+		if agentErr != nil {
+			return nil, agentErr
+		}
+	} else {
+		// Standard single-call generation path.
+		// stall is non-nil when stall limit reached; stdFiles is nil on any parse failure.
+		stall, stdFiles, stdErr := a.generateStandard(ctx, specContent, iterDir, iter, s)
+		if stdErr != nil || stall != nil || stdFiles == nil {
+			return stall, stdErr
+		}
+		files = stdFiles
+	}
+
+	s.lastFailures = nil
+
+	// Record the hash of the file set for oscillation detection.
+	s.codeHashes = append(s.codeHashes, hashFiles(files))
+
+	// Build, run, and validate.
+	return a.buildRunValidate(ctx, iter, iterDir, files, s, validate)
+}
+
+// generateAgentic runs the AgentLoop to generate files via tool use.
+// iterDir must be computed by the caller before this is called.
+// If patch mode is active (iter > 1 and bestFiles non-nil), pre-seeds iterDir with the current
+// best files so the agent can read_file them.
+// Returns the generated file map, or errNoFiles if the agent wrote no files.
+//
+// Wonder/reflect is intentionally skipped in agentic mode. The agent's multi-turn tool-use loop
+// already handles self-correction through iterative read_file/write_file cycles — it can observe
+// its own output and refine it within a single AgentLoop call. Injecting a separate wonder/reflect
+// diagnosis pass would duplicate this capability and send an extra Generate call that bypasses the
+// agent's stateful context.
+func (a *Attractor) generateAgentic(ctx context.Context, specContent, iterDir string, iter int, s *runState) (map[string]string, error) {
+	agentClient, ok := a.llm.(llm.AgentClient)
+	if !ok {
+		return nil, errAgentClientRequired
+	}
+
+	patching := s.patchActive && s.bestFiles != nil && iter > 1
+
+	// Pre-seed iterDir with best files in patch mode so the agent can read them.
+	if patching {
+		if err := writeFiles(iterDir, s.bestFiles); err != nil {
+			return nil, fmt.Errorf("attractor: pre-seed agentic iterDir iteration %d: %w", iter, err)
+		}
+	}
+
+	var messages []llm.Message
+	if patching {
+		messages = buildAgenticPatchMessages(s.history, s.bestFiles, s.bestSatisfaction)
+	} else {
+		messages = buildAgenticMessages(iter, s.history)
+	}
+
+	if err := applyMinimalismSuffix(messages, s.scoreHistory, s.history); err != nil {
+		return nil, err
+	}
+
+	if detectOscillation(s.codeHashes) {
+		messages[len(messages)-1].Content += "\n\n" + buildOscillationSteering()
+	}
+
+	handler, err := newAgentToolHandler(iterDir, a.logger)
+	if err != nil {
+		return nil, fmt.Errorf("attractor: create agentic tool handler iteration %d: %w", iter, err)
+	}
+
+	// In patch mode, pre-populate the handler's file map with the seeded files so that
+	// hashFiles() and bestFiles tracking operate on the complete file set. The agent's
+	// write_file calls overwrite entries for files it modifies; files it doesn't touch remain.
+	if patching {
+		maps.Copy(handler.files, s.bestFiles)
+	}
+
+	resp, err := agentClient.AgentLoop(ctx, llm.AgentRequest{
+		SystemPrompt: buildAgenticSystemPrompt(specContent, s.opts.Capabilities, s.opts.Language, s.opts.Genes, s.opts.GeneLanguage),
+		Messages:     messages,
+		Tools:        agentTools(),
+		Model:        s.currentModel(),
+		MaxTurns:     s.opts.AgentMaxTurns,
+		CacheControl: &llm.CacheControl{Type: "ephemeral"},
+	}, handler.Handle)
+	if err != nil {
+		return nil, fmt.Errorf("attractor: agent loop iteration %d: %w", iter, err)
+	}
+
+	s.totalCost += resp.TotalCost
+	s.lastInputTokens = resp.InputTokens
+	s.lastOutputTokens = resp.OutputTokens
+	s.lastTurns = resp.Turns
+
+	files := handler.Files()
+
+	a.logger.Debug("agentic generation complete",
+		"iteration", iter,
+		"turns", resp.Turns,
+		"cost_usd", resp.TotalCost,
+		"files_written", len(files),
+	)
+
+	if len(files) == 0 {
+		return nil, errNoFiles
+	}
+	return files, nil
+}
+
+// generateStandard runs the standard single-call generation path for one iteration.
+// Returns (stall, files, nil) when generation succeeds, (stall, nil, nil) when a stall
+// is recorded (parse failure), or (nil, nil, err) on a hard error.
+func (a *Attractor) generateStandard(ctx context.Context, specContent, iterDir string, iter int, s *runState) (*RunResult, map[string]string, error) {
+	patching := s.patchActive && s.bestFiles != nil && iter > 1
+
 	// Build messages: patch mode sends previous best files + failures.
 	var messages []llm.Message
-	if s.patchActive && s.bestFiles != nil && iter > 1 {
+	if patching {
 		messages = buildPatchMessages(s.history, s.bestFiles, s.bestSatisfaction)
 	} else {
 		messages = buildMessages(iter, s.history)
 	}
 
 	// Inject minimalism suffix when the previous validated score is above the threshold.
-	// This discourages adding complexity when the solution is already close to passing.
 	if err := applyMinimalismSuffix(messages, s.scoreHistory, s.history); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Inject oscillation steering when the last 4 code hashes form an A→B→A→B pattern.
-	// Appended after applyMinimalismSuffix for highest salience at the end of the message.
 	if detectOscillation(s.codeHashes) {
 		messages[len(messages)-1].Content += "\n\n" + buildOscillationSteering()
 	}
@@ -525,36 +664,30 @@ func (a *Attractor) iterate(ctx context.Context, rawSpec string, iter int, s *ru
 	// Generate code: wonder/reflect on stall, normal generation otherwise.
 	generatedContent, err := a.generateContent(ctx, specContent, messages, iter, s)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	s.lastFailures = nil
 
 	// Parse files from LLM output.
-	files, err := ParseFiles(generatedContent)
-	if err != nil {
-		a.logger.Warn("parse files failed", "iteration", iter, "error", err)
+	files, parseErr := ParseFiles(generatedContent)
+	if parseErr != nil {
+		a.logger.Warn("parse files failed", "iteration", iter, "error", parseErr)
 		s.lastOutcome = OutcomeParseFail
 		s.lastSatisfaction = 0
-		s.recordStall(iter, feedbackParseError, fmt.Sprintf("Failed to parse generated files: %s", err))
-		return a.checkStalled(iter, s), nil
+		s.recordStall(iter, feedbackParseError, fmt.Sprintf("Failed to parse generated files: %s", parseErr))
+		return a.checkStalled(iter, s), nil, nil
 	}
 
 	// In patch mode, merge new output over previous best to carry forward unchanged files.
-	if s.patchActive && s.bestFiles != nil && iter > 1 {
+	if patching {
 		files = MergeFiles(files, s.bestFiles)
 	}
 
-	// Record the hash of the merged file set for oscillation detection.
-	s.codeHashes = append(s.codeHashes, hashFiles(files))
-
 	// Write files to iteration directory.
-	iterDir := filepath.Join(s.baseDir, fmt.Sprintf("iter_%d", iter))
 	if err := writeFiles(iterDir, files); err != nil {
-		return nil, fmt.Errorf("attractor: write files iteration %d: %w", iter, err)
+		return nil, nil, fmt.Errorf("attractor: write files iteration %d: %w", iter, err)
 	}
 
-	// Build, run, and validate.
-	return a.buildRunValidate(ctx, iter, iterDir, files, s, validate)
+	return nil, files, nil
 }
 
 // buildRunValidate handles the Docker build → container setup → validate pipeline.
@@ -955,6 +1088,9 @@ func withDefaults(opts RunOptions) RunOptions {
 	}
 	if opts.HealthTimeout == 0 {
 		opts.HealthTimeout = 30 * time.Second
+	}
+	if opts.Agentic && opts.AgentMaxTurns == 0 {
+		opts.AgentMaxTurns = defaultAgentMaxTurns
 	}
 	return opts
 }

--- a/internal/attractor/attractor_test.go
+++ b/internal/attractor/attractor_test.go
@@ -2239,3 +2239,349 @@ func TestNoEscalationWithoutFrugalModel(t *testing.T) {
 		}
 	}
 }
+
+// mockAgentClient embeds mockLLMClient and adds AgentLoop support.
+type mockAgentClient struct {
+	mockLLMClient
+	agentLoopFn func(ctx context.Context, req llm.AgentRequest, handler llm.ToolHandler) (llm.AgentResponse, error)
+}
+
+func (m *mockAgentClient) AgentLoop(ctx context.Context, req llm.AgentRequest, handler llm.ToolHandler) (llm.AgentResponse, error) {
+	if m.agentLoopFn != nil {
+		return m.agentLoopFn(ctx, req, handler)
+	}
+	return llm.AgentResponse{}, nil
+}
+
+// agentWritesFiles is a helper that calls handler with write_file for main.go and Dockerfile.
+func agentWritesFiles(ctx context.Context, handler llm.ToolHandler) error {
+	calls := []struct {
+		name  string
+		input string
+	}{
+		{"write_file", `{"path":"main.go","content":"package main\n\nfunc main() {}\n"}`},
+		{"write_file", `{"path":"Dockerfile","content":"FROM scratch\n"}`},
+	}
+	for i, c := range calls {
+		_, err := handler(ctx, llm.ToolCall{ID: fmt.Sprintf("call_%d", i), Name: c.name, Input: []byte(c.input)})
+		if err != nil {
+			return fmt.Errorf("tool call %s: %w", c.name, err)
+		}
+	}
+	return nil
+}
+
+func agenticOpts(t *testing.T) RunOptions {
+	t.Helper()
+	opts := defaultOpts(t)
+	opts.Agentic = true
+	return opts
+}
+
+func TestAgenticConverge(t *testing.T) {
+	client := &mockAgentClient{
+		agentLoopFn: func(ctx context.Context, _ llm.AgentRequest, handler llm.ToolHandler) (llm.AgentResponse, error) {
+			if err := agentWritesFiles(ctx, handler); err != nil {
+				return llm.AgentResponse{}, err
+			}
+			return llm.AgentResponse{Turns: 2, TotalCost: 0.05}, nil
+		},
+	}
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+		return 100, nil, 0.005, nil
+	}
+
+	a := New(client, &mockContainerMgr{}, testLogger(), nil)
+	result, err := a.Run(context.Background(), "Build a hello world app", agenticOpts(t), validate, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != StatusConverged {
+		t.Errorf("expected status %q, got %q", StatusConverged, result.Status)
+	}
+	if result.Iterations != 1 {
+		t.Errorf("expected 1 iteration, got %d", result.Iterations)
+	}
+
+	// Verify files were written to bestDir.
+	mainPath := filepath.Join(result.OutputDir, "main.go")
+	if _, statErr := os.Stat(mainPath); statErr != nil {
+		t.Errorf("expected main.go in bestDir: %v", statErr)
+	}
+}
+
+func TestAgenticCostTracking(t *testing.T) {
+	const agentCost = 0.50
+	client := &mockAgentClient{
+		agentLoopFn: func(ctx context.Context, _ llm.AgentRequest, handler llm.ToolHandler) (llm.AgentResponse, error) {
+			if err := agentWritesFiles(ctx, handler); err != nil {
+				return llm.AgentResponse{}, err
+			}
+			return llm.AgentResponse{Turns: 1, TotalCost: agentCost}, nil
+		},
+	}
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+		return 100, nil, 0.005, nil
+	}
+
+	a := New(client, &mockContainerMgr{}, testLogger(), nil)
+	result, err := a.Run(context.Background(), "Build an app", agenticOpts(t), validate, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.CostUSD < agentCost {
+		t.Errorf("expected CostUSD >= %.2f, got %.2f", agentCost, result.CostUSD)
+	}
+}
+
+func TestAgenticTurnsReported(t *testing.T) {
+	const wantTurns = 5
+	var capturedProgress []IterationProgress
+	client := &mockAgentClient{
+		agentLoopFn: func(ctx context.Context, _ llm.AgentRequest, handler llm.ToolHandler) (llm.AgentResponse, error) {
+			if err := agentWritesFiles(ctx, handler); err != nil {
+				return llm.AgentResponse{}, err
+			}
+			return llm.AgentResponse{Turns: wantTurns, TotalCost: 0.01}, nil
+		},
+	}
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+		return 100, nil, 0.005, nil
+	}
+
+	opts := agenticOpts(t)
+	opts.Progress = func(p IterationProgress) {
+		capturedProgress = append(capturedProgress, p)
+	}
+
+	a := New(client, &mockContainerMgr{}, testLogger(), nil)
+	_, err := a.Run(context.Background(), "Build an app", opts, validate, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(capturedProgress) == 0 {
+		t.Fatal("expected at least one progress callback")
+	}
+	if capturedProgress[0].Turns != wantTurns {
+		t.Errorf("expected Turns=%d, got %d", wantTurns, capturedProgress[0].Turns)
+	}
+}
+
+func TestAgenticPatchPreSeed(t *testing.T) {
+	// First iteration writes files; second iteration verifies pre-seeded files are readable.
+	var iterCount atomic.Int32
+	var readResult string
+
+	client := &mockAgentClient{
+		agentLoopFn: func(ctx context.Context, req llm.AgentRequest, handler llm.ToolHandler) (llm.AgentResponse, error) {
+			n := iterCount.Add(1)
+			if n == 1 {
+				// First iteration: write files normally.
+				if err := agentWritesFiles(ctx, handler); err != nil {
+					return llm.AgentResponse{}, err
+				}
+			} else {
+				// Second iteration: read the pre-seeded main.go, then write files.
+				result, err := handler(ctx, llm.ToolCall{
+					ID:    "read_1",
+					Name:  "read_file",
+					Input: []byte(`{"path":"main.go"}`),
+				})
+				if err != nil {
+					return llm.AgentResponse{}, fmt.Errorf("read_file: %w", err)
+				}
+				readResult = result
+				if err := agentWritesFiles(ctx, handler); err != nil {
+					return llm.AgentResponse{}, err
+				}
+			}
+			return llm.AgentResponse{Turns: 1, TotalCost: 0.01}, nil
+		},
+	}
+
+	var callCount atomic.Int32
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+		n := callCount.Add(1)
+		if n == 1 {
+			return 60, []string{"needs work"}, 0.005, nil
+		}
+		return 100, nil, 0.005, nil
+	}
+
+	opts := agenticOpts(t)
+	opts.PatchMode = true
+
+	a := New(client, &mockContainerMgr{}, testLogger(), nil)
+	result, err := a.Run(context.Background(), "Build an app", opts, validate, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != StatusConverged {
+		t.Errorf("expected converged, got %q", result.Status)
+	}
+	// The second iteration's read_file should have returned the pre-seeded content.
+	if !strings.Contains(readResult, "package main") {
+		t.Errorf("expected pre-seeded main.go content to be readable, got: %q", readResult)
+	}
+}
+
+func TestAgenticPatchMergesUnchangedFiles(t *testing.T) {
+	// In patch mode, the agent only writes files it modifies. The files map returned by
+	// generateAgentic must include unchanged files from bestFiles so that hashFiles() and
+	// bestFiles tracking operate on the complete file set.
+	var iterCount atomic.Int32
+
+	client := &mockAgentClient{
+		agentLoopFn: func(ctx context.Context, _ llm.AgentRequest, handler llm.ToolHandler) (llm.AgentResponse, error) {
+			n := iterCount.Add(1)
+			if n == 1 {
+				// First iteration: write both main.go and Dockerfile.
+				if err := agentWritesFiles(ctx, handler); err != nil {
+					return llm.AgentResponse{}, err
+				}
+			} else {
+				// Second iteration (patch mode): agent only writes main.go, leaving Dockerfile unchanged.
+				_, err := handler(ctx, llm.ToolCall{
+					ID:    "write_1",
+					Name:  "write_file",
+					Input: []byte(`{"path":"main.go","content":"package main\n\nfunc main() { println(\"v2\") }\n"}`),
+				})
+				if err != nil {
+					return llm.AgentResponse{}, err
+				}
+			}
+			return llm.AgentResponse{Turns: 1, TotalCost: 0.01}, nil
+		},
+	}
+
+	var callCount atomic.Int32
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+		n := callCount.Add(1)
+		if n == 1 {
+			return 60, []string{"needs work"}, 0.005, nil
+		}
+		return 100, nil, 0.005, nil
+	}
+
+	opts := agenticOpts(t)
+	opts.PatchMode = true
+
+	a := New(client, &mockContainerMgr{}, testLogger(), nil)
+	result, err := a.Run(context.Background(), "Build an app", opts, validate, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != StatusConverged {
+		t.Errorf("expected converged, got %q", result.Status)
+	}
+	// Both files should be in the output (bestFiles) even though the agent only wrote main.go
+	// in the second iteration. The patch merge must carry forward unchanged files.
+	for _, want := range []string{"main.go", "Dockerfile"} {
+		if _, err := os.Stat(filepath.Join(result.OutputDir, want)); err != nil {
+			t.Errorf("expected %s in output dir after patch convergence: %v", want, err)
+		}
+	}
+}
+
+func TestAgenticRequiresAgentClient(t *testing.T) {
+	// Plain mockLLMClient does not implement AgentClient.
+	client := &mockLLMClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{Content: validLLMOutput()}, nil
+		},
+	}
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+		return 100, nil, 0.005, nil
+	}
+
+	a := New(client, &mockContainerMgr{}, testLogger(), nil)
+	_, err := a.Run(context.Background(), "Build an app", agenticOpts(t), validate, nil, nil)
+	if err == nil {
+		t.Fatal("expected error when AgentClient not implemented")
+	}
+	if !errors.Is(err, errAgentClientRequired) {
+		t.Errorf("expected errAgentClientRequired, got %v", err)
+	}
+}
+
+func TestAgenticBuildFailure(t *testing.T) {
+	client := &mockAgentClient{
+		agentLoopFn: func(ctx context.Context, _ llm.AgentRequest, handler llm.ToolHandler) (llm.AgentResponse, error) {
+			if err := agentWritesFiles(ctx, handler); err != nil {
+				return llm.AgentResponse{}, err
+			}
+			return llm.AgentResponse{Turns: 1, TotalCost: 0.01}, nil
+		},
+	}
+	buildErr := fmt.Errorf("docker build failed: exit 1")
+	mgr := &mockContainerMgr{
+		buildFn: func(_ context.Context, _, _ string) error {
+			return buildErr
+		},
+	}
+
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+		return 100, nil, 0.005, nil
+	}
+
+	opts := agenticOpts(t)
+	opts.StallLimit = 1
+
+	a := New(client, mgr, testLogger(), nil)
+	result, err := a.Run(context.Background(), "Build an app", opts, validate, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != StatusStalled {
+		t.Errorf("expected stalled after build failure, got %q", result.Status)
+	}
+}
+
+func TestAgenticWonderReflectSkipped(t *testing.T) {
+	// Agentic mode should call AgentLoop and NOT call Generate even during stall history.
+	var generateCalled atomic.Bool
+	var agentLoopCalls atomic.Int32
+
+	client := &mockAgentClient{
+		mockLLMClient: mockLLMClient{
+			generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+				generateCalled.Store(true)
+				return llm.GenerateResponse{Content: validLLMOutput()}, nil
+			},
+		},
+		agentLoopFn: func(ctx context.Context, _ llm.AgentRequest, handler llm.ToolHandler) (llm.AgentResponse, error) {
+			agentLoopCalls.Add(1)
+			if err := agentWritesFiles(ctx, handler); err != nil {
+				return llm.AgentResponse{}, err
+			}
+			return llm.AgentResponse{Turns: 1, TotalCost: 0.01}, nil
+		},
+	}
+
+	var callCount atomic.Int32
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+		n := callCount.Add(1)
+		if n < 3 {
+			return 50, []string{"scenario-a (50/100)"}, 0.005, nil
+		}
+		return 100, nil, 0.005, nil
+	}
+
+	opts := agenticOpts(t)
+	opts.StallLimit = 5
+
+	a := New(client, &mockContainerMgr{}, testLogger(), nil)
+	result, err := a.Run(context.Background(), "Build an app", opts, validate, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != StatusConverged {
+		t.Errorf("expected converged, got %q", result.Status)
+	}
+	if generateCalled.Load() {
+		t.Error("Generate should not be called in agentic mode")
+	}
+	if agentLoopCalls.Load() == 0 {
+		t.Error("AgentLoop should have been called at least once")
+	}
+}

--- a/internal/attractor/prompts.go
+++ b/internal/attractor/prompts.go
@@ -651,6 +651,99 @@ func buildMinimalismSuffix(score float64, failedScenarios map[string]float64) st
 	return b.String()
 }
 
+// buildAgenticSystemPrompt creates the system prompt for agentic (tool-use) code generation.
+// Structurally similar to buildSystemPrompt but replaces the file-format suffix with
+// tool-use instructions via buildAgenticCapabilitySuffix.
+func buildAgenticSystemPrompt(spec string, caps ScenarioCapabilities, language, genes, geneLanguage string) string {
+	var b strings.Builder
+	b.WriteString(systemPromptPrefix)
+	b.WriteString(spec)
+	if genes != "" {
+		b.WriteString(buildGeneSection(genes, language, geneLanguage))
+	}
+	b.WriteString(buildAgenticCapabilitySuffix(caps, language))
+	b.WriteString(buildDepRules(language))
+	return b.String()
+}
+
+// buildAgenticCapabilitySuffix assembles instruction text for agentic tool-use mode.
+// Uses the same capability instructions as buildCapabilitySuffix but replaces the
+// === FILE: === format instructions with write_file tool-use instructions.
+// No language example block is included.
+func buildAgenticCapabilitySuffix(caps ScenarioCapabilities, language string) string {
+	var b strings.Builder
+	b.WriteString("\n\nINSTRUCTIONS:\n")
+	b.WriteString(capabilityInstructions(caps))
+	b.WriteString("\n- Use the write_file tool to create each file in the workspace")
+	if _, ok := LookupLanguage(language); ok {
+		b.WriteString("\n- Use read_file to inspect existing files and list_files to see what is present")
+	}
+	b.WriteString("\n- Write ALL required files; do not skip any file needed for a working application\n")
+	b.WriteString("- Minimize explanatory text; focus on writing the files\n")
+	b.WriteString(capabilityTrailingInstructions(caps))
+	return b.String()
+}
+
+// buildAgenticMessages constructs the user message for agentic generation.
+// Iteration 1 gets a simple "Generate" prompt using tool calls.
+// Subsequent iterations include failure feedback.
+func buildAgenticMessages(iter int, history []iterationFeedback) []llm.Message {
+	if iter == 1 || len(history) == 0 {
+		return []llm.Message{
+			{Role: "user", Content: "Generate the application according to the specification. Use the write_file tool to create each file."},
+		}
+	}
+
+	var b strings.Builder
+	b.WriteString("The previous attempt did not fully satisfy the specification. Here is the feedback:\n\n")
+
+	if steeringText := buildSteeringText(history); steeringText != "" {
+		b.WriteString(steeringText)
+		b.WriteString("\n")
+	}
+
+	start := max(len(history)-maxFeedbackEntries, 0)
+	writeCategorizedFeedback(&b, history[start:])
+
+	b.WriteString("Please generate a corrected version of the application. Use the write_file tool to create ALL required files.")
+
+	return []llm.Message{
+		{Role: "user", Content: b.String()},
+	}
+}
+
+// buildAgenticPatchMessages constructs the user message for agentic patch mode.
+// Lists current files as paths only (agent can read_file to inspect content).
+// Includes failure feedback and asks the agent to use write_file to update files.
+func buildAgenticPatchMessages(history []iterationFeedback, bestFiles map[string]string, bestScore float64) []llm.Message {
+	var b strings.Builder
+	fmt.Fprintf(&b, "The current best version scored %.1f/100. Current files in the workspace:\n\n", bestScore)
+
+	paths := slices.Sorted(maps.Keys(bestFiles))
+	for _, p := range paths {
+		fmt.Fprintf(&b, "- %s\n", p)
+	}
+	b.WriteString("\nUse read_file to inspect any file you need to review before making changes.\n\n")
+
+	if steeringText := buildSteeringText(history); steeringText != "" {
+		b.WriteString(steeringText)
+		b.WriteString("\n")
+	}
+
+	if len(history) > 0 {
+		b.WriteString("Here is the feedback:\n\n")
+		start := max(len(history)-maxFeedbackEntries, 0)
+		writeCategorizedFeedback(&b, history[start:])
+	}
+
+	b.WriteString("Use the write_file tool to write any files that need to change. ")
+	b.WriteString("You only need to write files that require modification; unchanged files are already present.")
+
+	return []llm.Message{
+		{Role: "user", Content: b.String()},
+	}
+}
+
 // formatScoreTrajectory formats a slice of scores as "50 → 45 → 40".
 func formatScoreTrajectory(scores []float64) string {
 	parts := make([]string, len(scores))

--- a/internal/attractor/prompts_test.go
+++ b/internal/attractor/prompts_test.go
@@ -1269,3 +1269,103 @@ func capsSuffix(caps ScenarioCapabilities) string {
 		return "default"
 	}
 }
+
+func TestBuildAgenticSystemPrompt(t *testing.T) {
+	spec := "Build a REST API for managing widgets"
+	prompt := buildAgenticSystemPrompt(spec, ScenarioCapabilities{NeedsHTTP: true}, "go", "", "")
+
+	if !strings.Contains(prompt, spec) {
+		t.Error("agentic system prompt should contain the spec")
+	}
+	if !strings.Contains(prompt, "write_file") {
+		t.Error("agentic system prompt should mention write_file tool")
+	}
+	// Must NOT contain the === FILE: format instruction.
+	if strings.Contains(prompt, "=== FILE:") {
+		t.Error("agentic system prompt must not contain === FILE: format instruction")
+	}
+	// Must NOT contain the EXAMPLE block.
+	if strings.Contains(prompt, "=== FILE: main.go ===") {
+		t.Error("agentic system prompt must not contain language example block")
+	}
+}
+
+func TestBuildAgenticSystemPromptContainsGenes(t *testing.T) {
+	genes := "Use dependency injection pattern"
+	prompt := buildAgenticSystemPrompt("some spec", ScenarioCapabilities{}, "", genes, "")
+	if !strings.Contains(prompt, genes) {
+		t.Error("agentic system prompt should include gene content when provided")
+	}
+}
+
+func TestBuildAgenticMessages_Iteration1(t *testing.T) {
+	msgs := buildAgenticMessages(1, nil)
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+	if msgs[0].Role != "user" {
+		t.Errorf("expected role user, got %q", msgs[0].Role)
+	}
+	if !strings.Contains(msgs[0].Content, "write_file") {
+		t.Error("iteration 1 message should mention write_file tool")
+	}
+	// Must NOT contain the === FILE: format instruction.
+	if strings.Contains(msgs[0].Content, "=== FILE:") {
+		t.Error("agentic message must not contain === FILE: format instruction")
+	}
+}
+
+func TestBuildAgenticMessages_Iteration2(t *testing.T) {
+	history := []iterationFeedback{
+		{iteration: 1, kind: feedbackValidation, message: "Satisfaction score: 50.0/100\nneeds work"},
+	}
+	msgs := buildAgenticMessages(2, history)
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+	if !strings.Contains(msgs[0].Content, "write_file") {
+		t.Error("iteration 2 message should mention write_file tool")
+	}
+	if !strings.Contains(msgs[0].Content, "previous attempt") {
+		t.Error("iteration 2 message should reference previous attempt")
+	}
+	// Must NOT contain the === FILE: format instruction.
+	if strings.Contains(msgs[0].Content, "=== FILE:") {
+		t.Error("agentic message must not contain === FILE: format instruction")
+	}
+}
+
+func TestBuildAgenticPatchMessages(t *testing.T) {
+	bestFiles := map[string]string{
+		"main.go":    "package main\n",
+		"Dockerfile": "FROM scratch\n",
+	}
+	history := []iterationFeedback{
+		{iteration: 1, kind: feedbackValidation, message: "Satisfaction score: 60.0/100\nmissing endpoint"},
+	}
+	msgs := buildAgenticPatchMessages(history, bestFiles, 60.0)
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+	content := msgs[0].Content
+
+	// Should list file paths, not file content.
+	if !strings.Contains(content, "main.go") {
+		t.Error("patch message should list main.go path")
+	}
+	if !strings.Contains(content, "Dockerfile") {
+		t.Error("patch message should list Dockerfile path")
+	}
+	// Should mention read_file for inspection.
+	if !strings.Contains(content, "read_file") {
+		t.Error("patch message should mention read_file for inspecting files")
+	}
+	// Should mention write_file for output.
+	if !strings.Contains(content, "write_file") {
+		t.Error("patch message should mention write_file for output")
+	}
+	// Must NOT embed full file content.
+	if strings.Contains(content, "package main") {
+		t.Error("agentic patch message must not embed file content inline")
+	}
+}

--- a/internal/attractor/tools.go
+++ b/internal/attractor/tools.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"io/fs"
 	"log/slog"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/foundatron/octopusgarden/internal/llm"
 )
@@ -17,9 +19,14 @@ import (
 var errUnknownTool = errors.New("attractor: unknown tool")
 
 // agentToolHandler dispatches agent tool calls for file operations within an iteration directory.
+// mu guards files against concurrent access in case AgentLoop implementations issue parallel tool
+// calls. The current AnthropicClient.AgentLoop is sequential, but the ToolHandler contract does
+// not guarantee single-threaded access.
 type agentToolHandler struct {
 	iterDir string
 	logger  *slog.Logger
+	mu      sync.Mutex
+	files   map[string]string // tracks files written by write_file calls; guarded by mu
 }
 
 // newAgentToolHandler creates a handler rooted at iterDir.
@@ -32,7 +39,17 @@ func newAgentToolHandler(iterDir string, logger *slog.Logger) (*agentToolHandler
 	return &agentToolHandler{
 		iterDir: abs,
 		logger:  logger,
+		files:   make(map[string]string),
 	}, nil
+}
+
+// Files returns a copy of the map of files written by the handler.
+func (h *agentToolHandler) Files() map[string]string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make(map[string]string, len(h.files))
+	maps.Copy(out, h.files)
+	return out
 }
 
 type writeFileInput struct {
@@ -73,6 +90,9 @@ func (h *agentToolHandler) handleWriteFile(raw json.RawMessage) (string, error) 
 	if err := writeOneFile(h.iterDir, input.Path, input.Content); err != nil {
 		return "", err
 	}
+	h.mu.Lock()
+	h.files[input.Path] = input.Content
+	h.mu.Unlock()
 	if h.logger != nil {
 		h.logger.Debug("agent wrote file", "path", input.Path)
 	}


### PR DESCRIPTION
Closes #196

## Changes
#### 1. `internal/attractor/tools.go` -- add `files` tracking to handler

- Add `files map[string]string` field to `agentToolHandler` struct
- Initialize `files` to `make(map[string]string)` in `newAgentToolHandler`
- In `handleWriteFile`, after `writeOneFile` succeeds, store `input.Content` into `h.files[input.Path]`
- Add getter method `Files() map[string]string` (returns the map directly; caller can `maps.Clone` if needed)

#### 2. `internal/attractor/attractor.go` -- core agentic integration

**New sentinel error:**
```go
var errAgentClientRequired = errors.New("attractor: agentic mode requires AgentClient implementation")
```

**`RunOptions` additions:**
- `Agentic bool`
- `AgentMaxTurns int` -- max turns per agent loop call; 0 = default (50)

**`IterationProgress` addition:**
- `Turns int`

**`runState` addition:**
- `lastTurns int`

**`withDefaults()` change:**
- When `AgentMaxTurns == 0` and `Agentic == true`, set to 50

**`buildProgress()` change:**
- Add `Turns: s.lastTurns`

**New method `generateAgentic()`:**
```go
func (a *Attractor) generateAgentic(ctx context.Context, specContent string, iterDir string, iter int, s *runState) (map[string]string, error)
```
- Accepts `iterDir` as a parameter (computed by caller before the agentic/single-call branch)
- If patch mode active (iter > 1 and bestFiles non-nil), pre-seed iterDir via `writeFiles(iterDir, s.bestFiles)`
- Type-assert `a.llm` to `llm.AgentClient`; return `errAgentClientRequired` on failure
- Build system prompt via `buildAgenticSystemPrompt()`
- Build messages via `buildAgenticMessages()` or `buildAgenticPatchMessages()` based on patch state
- Apply `applyMinimalismSuffix` + oscillation steering to messages
- Create handler via `newAgentToolHandler(iterDir, a.logger)`, handle error return
- Call `agentClient.AgentLoop()` with `handler.Handle`, `agentTools()`, model, cache control, max turns
- Update cost/token tracking and `s.lastTurns`
- Return `handler.files, nil` (or `errNoFiles` if empty)

**`iterate()` modification:**
- Compute `iterDir` before the branch point
- Reset `s.lastTurns = 0` at start
- If `s.opts.Agentic`: call `generateAgentic(ctx, specContent, iterDir, iter, s)`, skip ParseFiles/MergeFiles/writeFiles
- If not agentic: existing path (generateContent → ParseFiles → MergeFiles → writeFiles)
- Both paths: `s.codeHashes = append(s.codeHashes, hashFiles(files))`, then `buildRunValidate(ctx, iter, iterDir, files, s, validate)`

#### 3. `internal/attractor/prompts.go` -- agentic prompt variants

**`buildAgenticSystemPrompt(specContent, caps, language, genes, geneLanguage string) string`:**
- Reuses `systemPromptPrefix`, `buildGeneSection`, `buildDepRules`
- Calls `buildAgenticCapabilitySuffix(caps, language)` instead of `buildCapabilitySuffix`

**`buildAgenticCapabilitySuffix(caps, language) string`:**
- Uses `capabilityInstructions(caps)` for port/Dockerfile/healthcheck rules
- Replaces `=== FILE:` format instructions with tool-use instructions
- No example block (no `buildLanguageExample` call)
- Keeps `capabilityTrailingInstructions(caps)` and "minimize explanatory text"

**`buildAgenticMessages(iter int, history []iterationFeedback) []llm.Message`:**
- Iteration 1: "Generate the application. Use `write_file` to create each file."
- Iteration 2+: Same feedback structure as `buildMessages` but replaces file format instructions with tool-use instructions

**`buildAgenticPatchMessages(history, bestFiles, bestScore) []llm.Message`:**
- Lists current files as paths only (agent can `read_file` to inspect)
- Replaces "Output ONLY the files that need to change" with tool-use instructions
- Same feedback/steering structure as `buildPatchMessages`

## Review Findings
- Errors: 0
- Warnings: 3
- Nits: 4
- Assessment: **NEEDS CHANGES**

The most significant issue is finding #2 — the agentic patch path doesn't merge `bestFiles` into the returned `files` map, so `hashFiles` and any subsequent `bestFiles` tracking will operate on a partial file set. This breaks the consistency guarantee that `files` represents the complete application state, which the standard path maintains via `MergeFiles`. The fix is straightforward: after `generateAgentic` returns, merge with `bestFiles` when in patch mode (similar to the standard path), or have `generateAgentic` pre-populate `handler.files` with the seeded files.
