### PR TITLE
feat(cmd): CLI wiring for agentic generation mode

### DIFF
--- a/cmd/octog/main.go
+++ b/cmd/octog/main.go
@@ -63,6 +63,7 @@ var (
 	errSourceDirNotExist          = errors.New("--source-dir does not exist")
 	errSourceDirNotDir            = errors.New("--source-dir is not a directory")
 	errNoLanguageDetected         = errors.New("no recognized language in source directory (need go.mod, package.json, Cargo.toml, pyproject.toml, or requirements.txt)")
+	errAgenticRequiresAnthropic   = errors.New("--agentic requires AgentClient support; use --provider anthropic")
 )
 
 func main() {
@@ -161,6 +162,8 @@ func runCmd(ctx context.Context, logger *slog.Logger, args []string) error {
 	skipPreflight := fs.Bool("skip-preflight", false, "skip the spec clarity preflight check")
 	preflightThreshold := fs.Float64("preflight-threshold", 0.8, "aggregate clarity score threshold for preflight (0.0–1.0)")
 	verbose := fs.Int("v", 0, "verbosity level: 0=quiet, 1=per-scenario summary after each iteration, 2=full step detail with reasoning")
+	agenticFlag := fs.Bool("agentic", false, "enable agentic generation mode (multi-turn tool-use)")
+	agentMaxTurnsFlag := fs.Int("agent-max-turns", 0, "max tool-use turns per iteration (0 = use attractor default)")
 
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: octog run [flags]\n\nFlags:\n")
@@ -199,6 +202,11 @@ func runCmd(ctx context.Context, logger *slog.Logger, args []string) error {
 	if err != nil {
 		return err
 	}
+	if *agenticFlag {
+		if _, ok := clients.client.(llm.AgentClient); !ok {
+			return errAgenticRequiresAnthropic
+		}
+	}
 	applyModelDefaults(model, judgeModel, clients.provider)
 
 	if err := validateJudgeFlags(*threshold, *judgeModel); err != nil {
@@ -234,6 +242,8 @@ func runCmd(ctx context.Context, logger *slog.Logger, args []string) error {
 		GenesGuide:        genesGuide,
 		GeneLanguage:      genesLanguage,
 		Verbosity:         *verbose,
+		Agentic:           *agenticFlag,
+		AgentMaxTurns:     *agentMaxTurnsFlag,
 	})
 }
 
@@ -287,6 +297,8 @@ type runLoopParams struct {
 	GenesGuide        string
 	GeneLanguage      string
 	Verbosity         int
+	Agentic           bool
+	AgentMaxTurns     int
 }
 
 func runAttractorLoop(ctx context.Context, logger *slog.Logger, llmClient llm.Client, p runLoopParams) error {
@@ -369,6 +381,8 @@ func runAttractorLoop(ctx context.Context, logger *slog.Logger, llmClient llm.Cl
 		Genes:             p.GenesGuide,
 		GeneLanguage:      p.GeneLanguage,
 		TestCommand:       parsedSpec.TestCommand,
+		Agentic:           p.Agentic,
+		AgentMaxTurns:     p.AgentMaxTurns,
 	}
 
 	startedAt := time.Now()
@@ -416,14 +430,18 @@ func detectStepCaps(caps *attractor.ScenarioCapabilities, step scenario.Step) {
 
 func progressFn(ctx context.Context, logger *slog.Logger, st *store.Store, w io.Writer, verbosity int) func(attractor.IterationProgress) {
 	return func(p attractor.IterationProgress) {
+		turnsStr := ""
+		if p.Turns > 0 {
+			turnsStr = fmt.Sprintf("  turns=%d", p.Turns)
+		}
 		if p.Outcome != attractor.OutcomeValidated {
-			_, _ = fmt.Fprintf(w, "iter %d/%d  %s  cost: $%.2f  [%s]\n", //nolint:gosec // G705 false positive: writing to injected io.Writer, not an HTTP response
+			_, _ = fmt.Fprintf(w, "iter %d/%d  %s  cost: $%.2f%s  [%s]\n", //nolint:gosec // G705 false positive: writing to injected io.Writer, not an HTTP response
 				p.Iteration, p.MaxIterations, p.Outcome,
-				p.TotalCostUSD, p.Elapsed.Truncate(time.Second))
+				p.TotalCostUSD, turnsStr, p.Elapsed.Truncate(time.Second))
 		} else {
-			_, _ = fmt.Fprintf(w, "iter %d/%d  satisfaction: %.1f/%.1f  cost: $%.2f  trend: %s  [%s]\n", //nolint:gosec // G705 false positive: writing to injected io.Writer, not an HTTP response
+			_, _ = fmt.Fprintf(w, "iter %d/%d  satisfaction: %.1f/%.1f  cost: $%.2f%s  trend: %s  [%s]\n", //nolint:gosec // G705 false positive: writing to injected io.Writer, not an HTTP response
 				p.Iteration, p.MaxIterations, p.Satisfaction, p.Threshold,
-				p.TotalCostUSD, p.Trend, p.Elapsed.Truncate(time.Second))
+				p.TotalCostUSD, turnsStr, p.Trend, p.Elapsed.Truncate(time.Second))
 		}
 
 		// p.Failures holds per-scenario feedback strings (both passing and failing scenarios);

--- a/cmd/octog/main_test.go
+++ b/cmd/octog/main_test.go
@@ -1968,3 +1968,75 @@ func TestRunAndScoreParallelRestartSkipped(t *testing.T) {
 		t.Errorf("expected restart not called when parallelism>1, got %d calls", got)
 	}
 }
+
+// TestRunCmdAgenticRequiresAgentClient verifies that --agentic is rejected when the
+// resolved LLM client does not implement AgentClient (e.g. OpenAI provider).
+func TestRunCmdAgenticRequiresAgentClient(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "fake-key-for-testing")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	logger := testLogger()
+	ctx := context.Background()
+
+	err := runCmd(ctx, logger, []string{
+		"--spec", "s.md", "--scenarios", "s/",
+		"--provider", "openai",
+		"--agentic",
+	})
+	if !errors.Is(err, errAgenticRequiresAnthropic) {
+		t.Errorf("expected errAgenticRequiresAnthropic, got: %v", err)
+	}
+}
+
+// TestProgressFnTurns verifies that a non-zero Turns value is included in progress output.
+func TestProgressFnTurns(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+	st, err := store.NewStore(ctx, ":memory:")
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+
+	tests := []struct {
+		name      string
+		turns     int
+		wantTurns bool
+	}{
+		{
+			name:      "turns=0 omitted",
+			turns:     0,
+			wantTurns: false,
+		},
+		{
+			name:      "turns>0 included in validated outcome",
+			turns:     7,
+			wantTurns: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			fn := progressFn(ctx, logger, st, &buf, 0)
+			fn(attractor.IterationProgress{
+				RunID:         "test-run",
+				Iteration:     1,
+				MaxIterations: 5,
+				Outcome:       attractor.OutcomeValidated,
+				Satisfaction:  80.0,
+				Threshold:     95.0,
+				TotalCostUSD:  0.01,
+				Elapsed:       time.Second,
+				Turns:         tt.turns,
+			})
+			out := buf.String()
+			containsTurns := strings.Contains(out, fmt.Sprintf("turns=%d", tt.turns))
+			if tt.wantTurns && !containsTurns {
+				t.Errorf("expected turns=%d in output, got: %s", tt.turns, out)
+			}
+			if !tt.wantTurns && strings.Contains(out, "turns=") {
+				t.Errorf("expected no turns= in output, got: %s", out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #199

## Changes
**File: `cmd/octog/main.go`** (single file, 7 edits)

1. **Sentinel error** (~line 43 var block): Add `errAgenticRequiresAnthropic = errors.New("--agentic requires Anthropic provider (tool-use not supported for OpenAI)")`.

2. **Flags** (~line 163, after `verbose`): Add `agenticFlag := fs.Bool("agentic", false, "enable agentic generation mode (multi-turn tool-use)")` and `agentMaxTurnsFlag := fs.Int("agent-max-turns", 0, "max tool-use turns per iteration (default 50)")`.

3. **Provider validation** (~line 201, after `newLLMClient` returns): 
   ```go
   if *agenticFlag && clients.provider != "anthropic" {
       return errAgenticRequiresAnthropic
   }
   ```

4. **`runLoopParams` struct** (~line 273): Add `Agentic bool` and `AgentMaxTurns int` fields.

5. **Pass to `runLoopParams`** (~line 220, in the `runAttractorLoop` call): Add `Agentic: *agenticFlag, AgentMaxTurns: *agentMaxTurnsFlag,` fields.

6. **Wire into `RunOptions`** (~line 357, in the `opts` struct literal inside `runAttractorLoop`): Add `Agentic: p.Agentic, AgentMaxTurns: p.AgentMaxTurns,`.

7. **Progress display** (~line 417, in `progressFn`): When `p.Turns > 0`, include `turns=%d` in both the validated and non-validated format strings. Build a conditional string fragment to keep it clean.

## Review Findings
- Errors: 0
- Warnings: 2
- Nits: 3
- Assessment: **NEEDS CHANGES** (the missing test coverage for the new error path and progress output change should be addressed before merge)
