### PR TITLE
feat(llm): auto max-tokens management

### DIFF
--- a/cmd/octog/main.go
+++ b/cmd/octog/main.go
@@ -162,6 +162,7 @@ func runCmd(ctx context.Context, logger *slog.Logger, args []string) error {
 	skipPreflight := fs.Bool("skip-preflight", false, "skip the spec clarity preflight check")
 	preflightThreshold := fs.Float64("preflight-threshold", 0.8, "aggregate clarity score threshold for preflight (0.0–1.0)")
 	verbose := fs.Int("v", 0, "verbosity level: 0=quiet, 1=per-scenario summary after each iteration, 2=full step detail with reasoning")
+	maxTokensFlag := fs.Int("max-tokens", 0, "max output tokens for generation (0 = auto-scale per model)")
 	agenticFlag := fs.Bool("agentic", false, "enable agentic generation mode (multi-turn tool-use)")
 	agentMaxTurnsFlag := fs.Int("agent-max-turns", 0, "max tool-use turns per iteration (0 = use attractor default)")
 
@@ -242,6 +243,7 @@ func runCmd(ctx context.Context, logger *slog.Logger, args []string) error {
 		GenesGuide:        genesGuide,
 		GeneLanguage:      genesLanguage,
 		Verbosity:         *verbose,
+		MaxTokens:         *maxTokensFlag,
 		Agentic:           *agenticFlag,
 		AgentMaxTurns:     *agentMaxTurnsFlag,
 	})
@@ -297,6 +299,7 @@ type runLoopParams struct {
 	GenesGuide        string
 	GeneLanguage      string
 	Verbosity         int
+	MaxTokens         int
 	Agentic           bool
 	AgentMaxTurns     int
 }
@@ -381,6 +384,7 @@ func runAttractorLoop(ctx context.Context, logger *slog.Logger, llmClient llm.Cl
 		Genes:             p.GenesGuide,
 		GeneLanguage:      p.GeneLanguage,
 		TestCommand:       parsedSpec.TestCommand,
+		MaxTokens:         p.MaxTokens,
 		Agentic:           p.Agentic,
 		AgentMaxTurns:     p.AgentMaxTurns,
 	}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -676,6 +676,7 @@ type RunOptions struct {
 	Genes             string               // extracted pattern guide to inject into system prompt (empty = no genes)
 	GeneLanguage      string               // source language of the gene exemplar (for cross-language note)
 	TestCommand       string               // optional shell command run inside HTTP container after health check; non-zero exit = test_fail
+	MaxTokens         int                  // max output tokens for generation; 0 = auto-scale per model
 	Agentic           bool                 // if true, use AgentLoop for code generation (tool-use mode)
 	AgentMaxTurns     int                  // max turns per AgentLoop call; 0 = default (50 when Agentic is true)
 }

--- a/internal/attractor/attractor.go
+++ b/internal/attractor/attractor.go
@@ -146,6 +146,7 @@ type RunOptions struct {
 	Genes             string               // extracted pattern guide to inject into system prompt (empty = no genes)
 	GeneLanguage      string               // source language of the gene exemplar (for cross-language note)
 	TestCommand       string               // optional shell command run inside HTTP container after health check; non-zero exit = test_fail
+	MaxTokens         int                  // max output tokens for generation; 0 = auto-scale per model
 	Agentic           bool                 // if true, use AgentLoop for code generation (tool-use mode)
 	AgentMaxTurns     int                  // max turns per AgentLoop call; 0 = default (50 when Agentic is true)
 }
@@ -388,14 +389,23 @@ func (a *Attractor) setRunSpanAttrs(span trace.Span, result *RunResult) {
 // When scenarios are stalling (buildSteeringText returns non-empty), it first tries
 // the wonder/reflect two-phase process. If that yields output, it is used directly.
 // Otherwise it falls back to the standard single-call generation path.
-func (a *Attractor) generateContent(ctx context.Context, specContent string, messages []llm.Message, iter int, s *runState) (string, error) {
+// Returns the full GenerateResponse so callers can inspect FinishReason.
+func (a *Attractor) generateContent(ctx context.Context, specContent string, messages []llm.Message, iter int, s *runState) (llm.GenerateResponse, error) {
 	if buildSteeringText(s.history) != "" {
-		content, err := a.wonderReflect(ctx, specContent, iter, s)
+		content, finishReason, wrCost, err := a.wonderReflect(ctx, specContent, iter, s)
 		if err != nil {
-			return "", err
+			return llm.GenerateResponse{}, err
 		}
 		if content != "" {
-			return content, nil
+			// Wonder/reflect path: construct a synthetic response.
+			// Token counts and cost are already recorded as side effects in wonderReflect.
+			return llm.GenerateResponse{
+				Content:      content,
+				FinishReason: finishReason,
+				InputTokens:  s.lastInputTokens,
+				OutputTokens: s.lastOutputTokens,
+				CostUSD:      wrCost,
+			}, nil
 		}
 	}
 
@@ -403,24 +413,26 @@ func (a *Attractor) generateContent(ctx context.Context, specContent string, mes
 	genResp, err := a.llm.Generate(ctx, llm.GenerateRequest{
 		SystemPrompt: buildSystemPrompt(specContent, s.opts.Capabilities, s.opts.Language, s.opts.Genes, s.opts.GeneLanguage),
 		Messages:     messages,
+		MaxTokens:    s.opts.MaxTokens,
 		Model:        s.currentModel(),
 		CacheControl: &llm.CacheControl{Type: "ephemeral"},
 	})
 	if err != nil {
-		return "", fmt.Errorf("attractor: generate iteration %d: %w", iter, err)
+		return llm.GenerateResponse{}, fmt.Errorf("attractor: generate iteration %d: %w", iter, err)
 	}
 	s.totalCost += genResp.CostUSD
 	s.lastInputTokens = genResp.InputTokens
 	s.lastOutputTokens = genResp.OutputTokens
-	return genResp.Content, nil
+	return genResp, nil
 }
 
 // wonderReflect runs a two-phase wonder/reflect process when scenarios are stalling.
 // Wonder phase: uses the judge model at high temperature to diagnose why attempts are failing.
 // Reflect phase: uses the generator model at low temperature to produce new code from the diagnosis.
-// Returns the reflect output (non-empty means use it instead of normal generation).
-// Returns ("", nil) to signal graceful fallback to normal generation.
-func (a *Attractor) wonderReflect(ctx context.Context, rawSpec string, iter int, s *runState) (string, error) {
+// Returns the reflect output (non-empty means use it instead of normal generation),
+// the reflect phase's finish reason, and the combined cost of both phases.
+// Returns ("", "", 0, nil) to signal graceful fallback to normal generation.
+func (a *Attractor) wonderReflect(ctx context.Context, rawSpec string, iter int, s *runState) (content, finishReason string, combinedCost float64, err error) {
 	opts := s.opts
 
 	// Resolve judge model — fall back to the primary generation model when unset.
@@ -445,11 +457,11 @@ func (a *Attractor) wonderReflect(ctx context.Context, rawSpec string, iter int,
 	if err != nil {
 		// Context cancellation is a hard error; other LLM errors fall back to normal generation.
 		if ctx.Err() != nil {
-			return "", fmt.Errorf("attractor: wonder phase iteration %d: %w", iter, err)
+			return "", "", 0, fmt.Errorf("attractor: wonder phase iteration %d: %w", iter, err)
 		}
 		a.logger.Warn("wonder/reflect: wonder phase failed, falling back to normal generation",
 			"iteration", iter, "error", err)
-		return "", nil
+		return "", "", 0, nil
 	}
 	s.totalCost += wonderResp.CostUSD
 	a.logger.Debug("wonder phase complete", "iteration", iter, "cost_usd", wonderResp.CostUSD)
@@ -457,14 +469,14 @@ func (a *Attractor) wonderReflect(ctx context.Context, rawSpec string, iter int,
 	// Check budget before proceeding to reflect phase.
 	if s.budgetExceeded() {
 		a.logger.Debug("budget exceeded after wonder phase, skipping reflect", "iteration", iter)
-		return "", nil
+		return "", "", 0, nil
 	}
 
 	diagnosis, err := parseDiagnosis(wonderResp.Content)
 	if err != nil {
 		a.logger.Warn("wonder/reflect: failed to parse diagnosis, falling back to normal generation",
 			"iteration", iter, "error", err)
-		return "", nil
+		return "", "", 0, nil
 	}
 
 	// Determine whether minimalism prompting should be included.
@@ -475,24 +487,27 @@ func (a *Attractor) wonderReflect(ctx context.Context, rawSpec string, iter int,
 	reflectResp, err := a.llm.Generate(ctx, llm.GenerateRequest{
 		SystemPrompt: buildSystemPrompt(rawSpec, s.opts.Capabilities, s.opts.Language, s.opts.Genes, s.opts.GeneLanguage),
 		Messages:     []llm.Message{{Role: "user", Content: reflectPrompt}},
+		MaxTokens:    s.opts.MaxTokens,
 		Model:        opts.Model, // always use primary model; reflect crafts the next steering prompt
 		Temperature:  &reflectTemp,
 	})
 	if err != nil {
 		// Context cancellation is a hard error; other LLM errors fall back to normal generation.
 		if ctx.Err() != nil {
-			return "", fmt.Errorf("attractor: reflect phase iteration %d: %w", iter, err)
+			return "", "", 0, fmt.Errorf("attractor: reflect phase iteration %d: %w", iter, err)
 		}
 		a.logger.Warn("wonder/reflect: reflect phase failed, falling back to normal generation",
 			"iteration", iter, "error", err)
-		return "", nil
+		return "", "", 0, nil
 	}
 	s.totalCost += reflectResp.CostUSD
 	s.lastInputTokens = wonderResp.InputTokens + reflectResp.InputTokens
 	s.lastOutputTokens = wonderResp.OutputTokens + reflectResp.OutputTokens
 	a.logger.Debug("reflect phase complete", "iteration", iter, "cost_usd", reflectResp.CostUSD)
 
-	return reflectResp.Content, nil
+	// Return the reflect phase's FinishReason intentionally: wonder output is diagnostic
+	// (not code), so only the reflect phase's truncation status matters for downstream handling.
+	return reflectResp.Content, reflectResp.FinishReason, wonderResp.CostUSD + reflectResp.CostUSD, nil
 }
 
 // iterate runs a single iteration of the attractor loop.
@@ -662,14 +677,23 @@ func (a *Attractor) generateStandard(ctx context.Context, specContent, iterDir s
 	}
 
 	// Generate code: wonder/reflect on stall, normal generation otherwise.
-	generatedContent, err := a.generateContent(ctx, specContent, messages, iter, s)
+	genResp, err := a.generateContent(ctx, specContent, messages, iter, s)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	// Parse files from LLM output.
-	files, parseErr := ParseFiles(generatedContent)
+	files, parseErr := ParseFiles(genResp.Content)
 	if parseErr != nil {
+		// When the output was truncated, surface truncation as the feedback kind
+		// instead of a generic parse error -- this gives the LLM actionable signal.
+		if genResp.FinishReason == "max_tokens" {
+			a.logger.Warn("parse files failed due to truncation", "iteration", iter, "error", parseErr)
+			s.lastOutcome = OutcomeParseFail
+			s.lastSatisfaction = 0
+			s.recordStall(iter, feedbackTruncation, "Output truncated at model limit -- response was cut off")
+			return a.checkStalled(iter, s), nil, nil
+		}
 		a.logger.Warn("parse files failed", "iteration", iter, "error", parseErr)
 		s.lastOutcome = OutcomeParseFail
 		s.lastSatisfaction = 0

--- a/internal/attractor/attractor_test.go
+++ b/internal/attractor/attractor_test.go
@@ -2585,3 +2585,78 @@ func TestAgenticWonderReflectSkipped(t *testing.T) {
 		t.Error("AgentLoop should have been called at least once")
 	}
 }
+
+func TestTruncationFeedback(t *testing.T) {
+	// When the LLM returns FinishReason "max_tokens" and ParseFiles fails,
+	// the feedback kind should be feedbackTruncation, not feedbackParseError.
+	var lastUserMsg string
+	var mu sync.Mutex
+	client := &mockLLMClient{
+		generateFn: func(_ context.Context, req llm.GenerateRequest) (llm.GenerateResponse, error) {
+			mu.Lock()
+			if len(req.Messages) > 0 {
+				lastUserMsg = req.Messages[0].Content
+			}
+			mu.Unlock()
+			// Return truncated output that will fail ParseFiles (no === FILE: blocks).
+			return llm.GenerateResponse{
+				Content:      "This is truncated output without any file blocks...",
+				CostUSD:      0.01,
+				FinishReason: "max_tokens",
+			}, nil
+		},
+	}
+
+	opts := defaultOpts(t)
+	opts.StallLimit = 2
+	opts.MaxIterations = 3
+
+	a := New(client, &mockContainerMgr{}, testLogger(), nil)
+	result, err := a.Run(context.Background(), "Build an app", opts, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != StatusStalled {
+		t.Errorf("expected status %q, got %q", StatusStalled, result.Status)
+	}
+
+	mu.Lock()
+	msg := lastUserMsg
+	mu.Unlock()
+
+	if !strings.Contains(msg, "TRUNCATION") {
+		t.Errorf("expected TRUNCATION header in feedback prompt, got: %s", msg)
+	}
+	if strings.Contains(msg, "PARSE ERROR") {
+		t.Errorf("expected truncation feedback instead of parse error, got: %s", msg)
+	}
+	if !strings.Contains(msg, "truncated at model limit") {
+		t.Errorf("expected truncation message mentioning model limit, got: %s", msg)
+	}
+}
+
+func TestTruncationWithParsableOutput(t *testing.T) {
+	// When the LLM returns FinishReason "max_tokens" but ParseFiles succeeds,
+	// the output should proceed normally (build/validate).
+	client := &mockLLMClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{
+				Content:      validLLMOutput(),
+				CostUSD:      0.01,
+				FinishReason: "max_tokens",
+			}, nil
+		},
+	}
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+		return 100, nil, 0.005, nil
+	}
+
+	a := New(client, &mockContainerMgr{}, testLogger(), nil)
+	result, err := a.Run(context.Background(), "Build an app", defaultOpts(t), validate, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != StatusConverged {
+		t.Errorf("expected status %q, got %q (truncated but parsable output should proceed)", StatusConverged, result.Status)
+	}
+}

--- a/internal/attractor/prompts.go
+++ b/internal/attractor/prompts.go
@@ -18,6 +18,7 @@ const (
 	feedbackRegression  = "regression"
 	feedbackRunError    = "run_error"
 	feedbackTestError   = "test_error"
+	feedbackTruncation  = "truncation"
 	feedbackValidation  = "validation"
 )
 
@@ -62,6 +63,8 @@ func feedbackHeader(kind string) string {
 		return "RUN FAILURE"
 	case feedbackTestError:
 		return "TEST FAILURE"
+	case feedbackTruncation:
+		return "TRUNCATION"
 	case feedbackValidation:
 		return "VALIDATION FAILURES"
 	default:

--- a/internal/llm/anthropic.go
+++ b/internal/llm/anthropic.go
@@ -73,7 +73,7 @@ func (c *AnthropicClient) logUsage(prefix, model string, usage anthropic.Usage) 
 func (c *AnthropicClient) Generate(ctx context.Context, req GenerateRequest) (GenerateResponse, error) {
 	maxTokens := int64(req.MaxTokens)
 	if maxTokens == 0 {
-		maxTokens = defaultGenerateMaxTokens
+		maxTokens = int64(MaxOutputTokens(req.Model))
 	}
 
 	// Build system prompt blocks.
@@ -125,6 +125,10 @@ func (c *AnthropicClient) Generate(ctx context.Context, req GenerateRequest) (Ge
 		content = text.Text
 	}
 
+	if resp.StopReason == "max_tokens" {
+		c.logger.Warn("generation truncated", "model", req.Model, "max_tokens", maxTokens)
+	}
+
 	m := c.logUsage("anthropic generate", req.Model, resp.Usage)
 
 	return GenerateResponse{
@@ -172,7 +176,7 @@ func (c *AnthropicClient) AgentLoop(ctx context.Context, req AgentRequest, handl
 	}
 	maxTokens := int64(req.MaxTokens)
 	if maxTokens == 0 {
-		maxTokens = defaultGenerateMaxTokens
+		maxTokens = int64(MaxOutputTokens(req.Model))
 	}
 
 	// Build system blocks using same pattern as Generate.

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -13,8 +13,8 @@ var (
 )
 
 const (
-	defaultGenerateMaxTokens = 8192
-	defaultJudgeMaxTokens    = 4096
+	defaultMaxOutputTokens = 8192
+	defaultJudgeMaxTokens  = 4096
 )
 
 // Client is the model-agnostic LLM interface used by the attractor loop and judge.

--- a/internal/llm/models.go
+++ b/internal/llm/models.go
@@ -142,6 +142,43 @@ var fallbackPricing = ModelPricing{
 	CacheReadPerMillion:  1.50,
 }
 
+// modelMaxOutputTokens maps model IDs to their maximum output token limits.
+// Used by MaxOutputTokens to auto-scale max_tokens per model.
+var modelMaxOutputTokens = map[string]int{
+	// Anthropic models
+	"claude-haiku-3-5-20241022": 8192,
+	"claude-haiku-4-5-20251001": 8192,
+	"claude-haiku-4-5":          8192,
+	"claude-sonnet-4-20250514":  16384, // up to 64K with output-128k beta
+	"claude-sonnet-4-6":         16384, // up to 64K with output-128k beta
+	"claude-opus-4-5":           32768, // up to 128K with output-128k beta
+	// OpenAI GPT models
+	"gpt-4o":       16384,
+	"gpt-4o-mini":  16384,
+	"gpt-4.1":      32768,
+	"gpt-4.1-mini": 32768,
+	"gpt-4.1-nano": 32768,
+	"gpt-5":        32768,
+	"gpt-5-mini":   32768,
+	"gpt-5-nano":   32768,
+	"gpt-5.1":      32768,
+	"gpt-5.2":      32768,
+	// OpenAI reasoning models
+	"o1":      65536,
+	"o3":      65536,
+	"o3-mini": 65536,
+	"o4-mini": 65536,
+}
+
+// MaxOutputTokens returns the maximum output token limit for the given model.
+// Unknown models return defaultMaxOutputTokens (8192).
+func MaxOutputTokens(model string) int {
+	if v, ok := modelMaxOutputTokens[model]; ok {
+		return v
+	}
+	return defaultMaxOutputTokens
+}
+
 // CalculateCost returns the estimated USD cost for a request given token counts.
 // The bool return indicates whether fallback pricing was used (true = unknown model).
 func CalculateCost(model string, regularInputTokens, cacheCreationTokens, cacheReadTokens, outputTokens int) (float64, bool) {

--- a/internal/llm/models_test.go
+++ b/internal/llm/models_test.go
@@ -1,0 +1,66 @@
+package llm
+
+import "testing"
+
+func TestMaxOutputTokens(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		model string
+		want  int
+	}{
+		{name: "claude haiku 3.5", model: "claude-haiku-3-5-20241022", want: 8192},
+		{name: "claude haiku 4.5 dated", model: "claude-haiku-4-5-20251001", want: 8192},
+		{name: "claude haiku 4.5", model: "claude-haiku-4-5", want: 8192},
+		{name: "claude sonnet 4 dated", model: "claude-sonnet-4-20250514", want: 16384},
+		{name: "claude sonnet 4.6", model: "claude-sonnet-4-6", want: 16384},
+		{name: "claude opus 4.5", model: "claude-opus-4-5", want: 32768},
+		{name: "gpt-4o", model: "gpt-4o", want: 16384},
+		{name: "gpt-4o-mini", model: "gpt-4o-mini", want: 16384},
+		{name: "gpt-4.1", model: "gpt-4.1", want: 32768},
+		{name: "gpt-4.1-mini", model: "gpt-4.1-mini", want: 32768},
+		{name: "gpt-4.1-nano", model: "gpt-4.1-nano", want: 32768},
+		{name: "gpt-5", model: "gpt-5", want: 32768},
+		{name: "gpt-5-mini", model: "gpt-5-mini", want: 32768},
+		{name: "gpt-5-nano", model: "gpt-5-nano", want: 32768},
+		{name: "gpt-5.1", model: "gpt-5.1", want: 32768},
+		{name: "gpt-5.2", model: "gpt-5.2", want: 32768},
+		{name: "o1", model: "o1", want: 65536},
+		{name: "o3", model: "o3", want: 65536},
+		{name: "o3-mini", model: "o3-mini", want: 65536},
+		{name: "o4-mini", model: "o4-mini", want: 65536},
+		{name: "unknown model returns default", model: "llama-42b", want: defaultMaxOutputTokens},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := MaxOutputTokens(tt.model)
+			if got != tt.want {
+				t.Errorf("MaxOutputTokens(%q) = %d, want %d", tt.model, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPricingTableCoverage(t *testing.T) {
+	t.Parallel()
+	// Every model in pricingTable must have a corresponding entry in modelMaxOutputTokens.
+	for model := range pricingTable {
+		t.Run(model, func(t *testing.T) {
+			t.Parallel()
+			if _, ok := modelMaxOutputTokens[model]; !ok {
+				t.Errorf("model %q is in pricingTable but missing from modelMaxOutputTokens", model)
+			}
+		})
+	}
+	// Every model in modelMaxOutputTokens must have a corresponding entry in pricingTable.
+	for model := range modelMaxOutputTokens {
+		t.Run(model, func(t *testing.T) {
+			t.Parallel()
+			if _, ok := pricingTable[model]; !ok {
+				t.Errorf("model %q is in modelMaxOutputTokens but missing from pricingTable", model)
+			}
+		})
+	}
+}

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -74,7 +74,7 @@ func (c *OpenAIClient) logUsage(prefix, model string, usage openai.CompletionUsa
 func (c *OpenAIClient) Generate(ctx context.Context, req GenerateRequest) (GenerateResponse, error) {
 	maxTokens := req.MaxTokens
 	if maxTokens == 0 {
-		maxTokens = defaultGenerateMaxTokens
+		maxTokens = MaxOutputTokens(req.Model)
 	}
 
 	messages := make([]openai.ChatCompletionMessageParamUnion, 0, len(req.Messages)+1)
@@ -111,6 +111,13 @@ func (c *OpenAIClient) Generate(ctx context.Context, req GenerateRequest) (Gener
 
 	content := resp.Choices[0].Message.Content
 	finishReason := resp.Choices[0].FinishReason
+	// Normalize OpenAI's "length" to the canonical "max_tokens" used by Anthropic,
+	// and warn on truncation.
+	if finishReason == "length" || finishReason == "max_tokens" {
+		finishReason = "max_tokens"
+		c.logger.Warn("generation truncated", "model", req.Model, "max_tokens", maxTokens)
+	}
+
 	m := c.logUsage("openai generate", req.Model, resp.Usage)
 
 	return GenerateResponse{

--- a/internal/llm/openai_test.go
+++ b/internal/llm/openai_test.go
@@ -83,7 +83,7 @@ func TestOpenAIGenerate(t *testing.T) {
 			wantFinishReason: "stop",
 		},
 		{
-			name:             "finish reason length",
+			name:             "finish reason length normalized to max_tokens",
 			content:          "truncated output",
 			model:            "gpt-4o",
 			promptTokens:     100,
@@ -94,7 +94,7 @@ func TestOpenAIGenerate(t *testing.T) {
 			wantOutputTokens: 8192,
 			wantCacheHit:     false,
 			wantCost:         (100*2.50 + 8192*10.00) / 1_000_000,
-			wantFinishReason: "length",
+			wantFinishReason: "max_tokens",
 		},
 		{
 			name:             "cache hit",


### PR DESCRIPTION
Closes #197

## Changes
**1. `internal/llm/models.go`** -- Add `MaxOutputTokens()` function + output token map

- Add `modelMaxOutputTokens` map with exact model IDs (same IDs as `pricingTable`):
  - `claude-haiku-3-5-20241022`, `claude-haiku-4-5-20251001`, `claude-haiku-4-5`: 8192
  - `claude-sonnet-4-20250514`, `claude-sonnet-4-6`: 16384
  - `claude-opus-4-5`: 32768
  - `gpt-4o`, `gpt-4o-mini`: 16384
  - `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`: 32768
  - `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5.1`, `gpt-5.2`: 32768
  - `o1`, `o3`, `o3-mini`, `o4-mini`: 65536 (reasoning models have 100k but 65536 is the controllable output portion)
- Add exported `MaxOutputTokens(model string) int` -- exact map lookup, returns `defaultMaxOutputTokens` (8192) for unknown models

**2. `internal/llm/client.go`** -- Rename constant

- Rename `defaultGenerateMaxTokens` to `defaultMaxOutputTokens` (value stays 8192)
- Keep `defaultJudgeMaxTokens = 4096` unchanged

**3. `internal/llm/anthropic.go`** -- Use `MaxOutputTokens()`, add truncation warning

- In `Generate()`: replace `defaultGenerateMaxTokens` with `MaxOutputTokens(req.Model)` when `req.MaxTokens == 0`
- After API call: if `resp.StopReason == "max_tokens"`, log `slog.Warn("generation truncated", "model", req.Model, "max_tokens", maxTokens)`
- In `AgentLoop()`: keep existing per-turn max tokens behavior (4096 or whatever is currently hardcoded); do NOT use `MaxOutputTokens()` for agent turns

**4. `internal/llm/openai.go`** -- Same auto-scaling + normalize finish reason

- In `Generate()`: replace `defaultGenerateMaxTokens` with `MaxOutputTokens(req.Model)` when `req.MaxTokens == 0`
- Normalize `finishReason`: map `"length"` to `"max_tokens"` before returning in `GenerateResponse.FinishReason`
- After API call: if normalized finish reason is `"max_tokens"`, log `slog.Warn("generation truncated", ...)`

**5. `internal/attractor/prompts.go`** -- Add truncation feedback constant

- Add `feedbackTruncation = "truncation"` to the feedback kind constants

**6. `internal/attractor/attractor.go`** -- Truncation-aware generation

- Change `generateContent()` return type from `(string, error)` to `(GenerateResponse, error)` -- return the full `llm.GenerateResponse` instead of just the content string. For the wonder/reflect path, construct a synthetic `GenerateResponse` from the reflect phase response.
- In `generateStandard()`: after `generateContent()`, check `genResp.FinishReason == "max_tokens"`. If truncated, still attempt `ParseFiles` on the content. If `ParseFiles` fails, record stall with `feedbackTruncation` kind and message `"Output truncated at model limit -- response was cut off"` instead of `feedbackParseError`. If `ParseFiles` succeeds, proceed normally (truncated output that still parses is fine).
- Add `MaxTokens int` field to `RunOptions`
- In `generateContent()`, pass `s.opts.MaxTokens` as `req.MaxTokens` in the `GenerateRequest` (non-zero bypasses auto-scaling in the client)

**7. `cmd/octog/main.go`** -- Add `--max-tokens` flag

- Add `--max-tokens` flag to `runCmd` FlagSet (default 0 = auto)
- Pass value to `attractor.RunOptions.MaxTokens`

## Review Findings
- Errors: 0
- Warnings: 2
- Nits: 4
- Assessment: **NEEDS CHANGES**

The most significant issue is finding #1: the reflect phase (which generates actual code output) does not honor `--max-tokens`, creating an inconsistency where the normal generation path respects the flag but the wonder/reflect path silently ignores it. This should be straightforward to fix by passing `MaxTokens: s.opts.MaxTokens` in the reflect `GenerateRequest`.
