### PR TITLE
feat(interview): core interview package with multi-turn LLM conversation

### DIFF
--- a/internal/interview/interview.go
+++ b/internal/interview/interview.go
@@ -1,0 +1,121 @@
+// Package interview provides a conversational spec-drafting assistant that uses
+// an LLM to interview the user and produce an NLSpec-format specification.
+package interview
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/foundatron/octopusgarden/internal/llm"
+)
+
+const maxRounds = 20
+
+const rePromptMsg = "Please enter a response (or type \"done\" to generate the spec)."
+
+const finalInstruction = "The user is done answering questions. " +
+	"Generate the complete NLSpec-format specification now based on everything discussed."
+
+// Interviewer conducts a conversational interview to produce a spec.
+type Interviewer struct {
+	client llm.Client
+	in     io.Reader
+	out    io.Writer
+	model  string
+}
+
+// New creates an Interviewer that reads from in, writes to out, and uses the
+// given LLM client and model.
+func New(client llm.Client, in io.Reader, out io.Writer, model string) *Interviewer {
+	return &Interviewer{
+		client: client,
+		in:     in,
+		out:    out,
+		model:  model,
+	}
+}
+
+// Run conducts the interview starting with initialPrompt and returns the final
+// spec content and total LLM cost in USD.
+func (i *Interviewer) Run(ctx context.Context, initialPrompt string) (string, float64, error) {
+	messages := []llm.Message{{Role: "user", Content: initialPrompt}}
+
+	resp, err := i.client.Generate(ctx, llm.GenerateRequest{
+		SystemPrompt: systemPrompt,
+		Messages:     messages,
+		Model:        i.model,
+	})
+	if err != nil {
+		return "", 0, fmt.Errorf("interview: generate: %w", err)
+	}
+
+	totalCost := resp.CostUSD
+	messages = append(messages, llm.Message{Role: "assistant", Content: resp.Content})
+	fmt.Fprintln(i.out, resp.Content) //nolint:errcheck
+
+	scanner := bufio.NewScanner(i.in)
+	round := 0
+
+	for scanner.Scan() {
+		if err := ctx.Err(); err != nil {
+			return "", totalCost, fmt.Errorf("interview: %w", err)
+		}
+
+		trimmed := strings.TrimSpace(scanner.Text())
+		if trimmed == "" {
+			fmt.Fprintln(i.out, rePromptMsg) //nolint:errcheck
+			continue
+		}
+
+		// round is incremented at the end of each loop body, so round >= maxRounds
+		// fires after maxRounds answers have been processed (0-indexed: rounds 0..maxRounds-1).
+		if strings.EqualFold(trimmed, "done") || round >= maxRounds {
+			if round >= maxRounds {
+				fmt.Fprintln(i.out, "Maximum rounds reached. Generating spec now.") //nolint:errcheck
+			}
+			spec, cost, genErr := i.generateFinal(ctx, messages)
+			return spec, totalCost + cost, genErr
+		}
+
+		messages = append(messages, llm.Message{Role: "user", Content: trimmed})
+		resp, err = i.client.Generate(ctx, llm.GenerateRequest{
+			SystemPrompt: systemPrompt,
+			Messages:     messages,
+			Model:        i.model,
+		})
+		if err != nil {
+			return "", totalCost, fmt.Errorf("interview: generate: %w", err)
+		}
+
+		totalCost += resp.CostUSD
+		messages = append(messages, llm.Message{Role: "assistant", Content: resp.Content})
+		fmt.Fprintln(i.out, resp.Content) //nolint:errcheck
+		round++
+	}
+
+	if err := scanner.Err(); err != nil {
+		return "", totalCost, fmt.Errorf("interview: scanner: %w", err)
+	}
+
+	// EOF without "done" — treat as auto-generate.
+	spec, cost, err := i.generateFinal(ctx, messages)
+	return spec, totalCost + cost, err
+}
+
+func (i *Interviewer) generateFinal(ctx context.Context, messages []llm.Message) (string, float64, error) {
+	msgs := make([]llm.Message, len(messages), len(messages)+1)
+	copy(msgs, messages)
+	msgs = append(msgs, llm.Message{Role: "user", Content: finalInstruction})
+	resp, err := i.client.Generate(ctx, llm.GenerateRequest{
+		SystemPrompt: systemPrompt,
+		Messages:     msgs,
+		Model:        i.model,
+	})
+	if err != nil {
+		return "", 0, fmt.Errorf("interview: generate: %w", err)
+	}
+	return resp.Content, resp.CostUSD, nil
+}

--- a/internal/interview/interview_test.go
+++ b/internal/interview/interview_test.go
@@ -1,0 +1,260 @@
+package interview
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/foundatron/octopusgarden/internal/llm"
+)
+
+type mockClient struct {
+	generateFn func(context.Context, llm.GenerateRequest) (llm.GenerateResponse, error)
+}
+
+func (m *mockClient) Generate(ctx context.Context, req llm.GenerateRequest) (llm.GenerateResponse, error) {
+	return m.generateFn(ctx, req)
+}
+
+func (m *mockClient) Judge(_ context.Context, _ llm.JudgeRequest) (llm.JudgeResponse, error) {
+	return llm.JudgeResponse{}, nil
+}
+
+func TestInterviewHappyPath(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	// 3 Generate calls: initial question, response to "Go", final spec on "done".
+	responses := []llm.GenerateResponse{
+		{Content: "What language?", CostUSD: 0.01},
+		{Content: "Got it. Any other requirements?", CostUSD: 0.01},
+		{Content: "# Spec\n\n## Purpose\nA todo app.", CostUSD: 0.02},
+	}
+
+	client := &mockClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			resp := responses[calls]
+			calls++
+			return resp, nil
+		},
+	}
+
+	in := strings.NewReader("Go\ndone\n")
+	var out bytes.Buffer
+
+	iv := New(client, in, &out, "test-model")
+	spec, cost, err := iv.Run(context.Background(), "I want to build a CLI app.")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if spec != "# Spec\n\n## Purpose\nA todo app." {
+		t.Errorf("unexpected spec: %q", spec)
+	}
+
+	const wantCost = 0.01 + 0.01 + 0.02
+	if cost != wantCost {
+		t.Errorf("cost = %v, want %v", cost, wantCost)
+	}
+}
+
+func TestInterviewEmptyInput(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	client := &mockClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			calls++
+			return llm.GenerateResponse{Content: "Tell me more.", CostUSD: 0.01}, nil
+		},
+	}
+
+	in := strings.NewReader("\n\nanswer\ndone\n")
+	var out bytes.Buffer
+
+	iv := New(client, in, &out, "test-model")
+	_, _, err := iv.Run(context.Background(), "I want to build something.")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(out.String(), rePromptMsg) {
+		t.Error("expected rePromptMsg written for empty lines")
+	}
+
+	// Only 1 initial call + 1 for "answer" + 1 final = 3 calls; empty lines don't add calls
+	if calls != 3 {
+		t.Errorf("expected 3 generate calls, got %d", calls)
+	}
+}
+
+func TestInterviewMaxRounds(t *testing.T) {
+	t.Parallel()
+	var lastReq llm.GenerateRequest
+	calls := 0
+	client := &mockClient{
+		generateFn: func(_ context.Context, req llm.GenerateRequest) (llm.GenerateResponse, error) {
+			lastReq = req
+			calls++
+			return llm.GenerateResponse{Content: "Next question.", CostUSD: 0.01}, nil
+		},
+	}
+
+	// 21 non-"done" lines to exceed maxRounds=20
+	lines := make([]string, 21)
+	for j := range lines {
+		lines[j] = "answer"
+	}
+	in := strings.NewReader(strings.Join(lines, "\n") + "\n")
+	var out bytes.Buffer
+
+	iv := New(client, in, &out, "test-model")
+	spec, _, err := iv.Run(context.Background(), "Start.")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(out.String(), "Maximum rounds reached") {
+		t.Error("expected max-rounds warning in output")
+	}
+
+	// Verify last Generate call included the final generation instruction.
+	found := false
+	for _, msg := range lastReq.Messages {
+		if strings.Contains(msg.Content, finalInstruction) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("final Generate call should include finalInstruction")
+	}
+
+	if spec == "" {
+		t.Error("expected non-empty spec")
+	}
+}
+
+func TestInterviewDoneCaseInsensitive(t *testing.T) {
+	t.Parallel()
+	tests := []string{"DONE", "Done", " done "}
+	for _, input := range tests {
+		t.Run(fmt.Sprintf("%q", input), func(t *testing.T) {
+			t.Parallel()
+			client := &mockClient{
+				generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+					return llm.GenerateResponse{Content: "spec content"}, nil
+				},
+			}
+			in := strings.NewReader(input + "\n")
+			var out bytes.Buffer
+			iv := New(client, in, &out, "test-model")
+			spec, _, err := iv.Run(context.Background(), "Start.")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if spec == "" {
+				t.Error("expected non-empty spec for input", input)
+			}
+		})
+	}
+}
+
+func TestInterviewContextCancellation(t *testing.T) {
+	t.Parallel()
+	client := &mockClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{Content: "question"}, nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	in := strings.NewReader("answer\n")
+	var out bytes.Buffer
+	iv := New(client, in, &out, "test-model")
+	_, _, err := iv.Run(ctx, "Start.")
+	if err == nil {
+		t.Fatal("expected error for canceled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestInterviewLLMError(t *testing.T) {
+	t.Parallel()
+	errLLM := errors.New("api failure")
+	client := &mockClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{}, errLLM
+		},
+	}
+
+	in := strings.NewReader("")
+	var out bytes.Buffer
+	iv := New(client, in, &out, "test-model")
+	_, _, err := iv.Run(context.Background(), "Start.")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.HasPrefix(err.Error(), "interview: generate:") {
+		t.Errorf("expected 'interview: generate:' prefix, got %q", err.Error())
+	}
+	if !errors.Is(err, errLLM) {
+		t.Errorf("expected wrapped errLLM, got %v", err)
+	}
+}
+
+func TestInterviewCostTracking(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	costs := []float64{0.10, 0.20, 0.30}
+	client := &mockClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			cost := costs[calls]
+			calls++
+			return llm.GenerateResponse{Content: "response", CostUSD: cost}, nil
+		},
+	}
+
+	// initial call + 1 round + done → 3 calls total
+	in := strings.NewReader("answer\ndone\n")
+	var out bytes.Buffer
+	iv := New(client, in, &out, "test-model")
+	_, total, err := iv.Run(context.Background(), "Start.")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	const want = 0.60
+	const epsilon = 1e-9
+	if total < want-epsilon || total > want+epsilon {
+		t.Errorf("total cost = %v, want %v", total, want)
+	}
+}
+
+func TestInterviewEOF(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	client := &mockClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			calls++
+			return llm.GenerateResponse{Content: "spec from eof"}, nil
+		},
+	}
+
+	// Reader exhausts without "done"
+	in := strings.NewReader("partial answer")
+	var out bytes.Buffer
+	iv := New(client, in, &out, "test-model")
+	spec, _, err := iv.Run(context.Background(), "Start.")
+	if err != nil {
+		t.Fatalf("unexpected error on EOF: %v", err)
+	}
+	if spec == "" {
+		t.Error("expected auto-generated spec on EOF")
+	}
+}

--- a/internal/interview/prompt.go
+++ b/internal/interview/prompt.go
@@ -1,0 +1,23 @@
+package interview
+
+const systemPrompt = `You are an expert software specification interviewer. Your role is to help users
+articulate their software ideas into a clear, complete NLSpec-format specification.
+
+An NLSpec document has these dimensions:
+- **Purpose**: What problem does the software solve? Who are the users?
+- **Behavior**: What does the software do? Key user flows and interactions.
+- **Data**: What data does it store, receive, or emit? Schemas, formats, persistence.
+- **Interfaces**: HTTP endpoints, CLI flags, event contracts, external integrations.
+- **Constraints**: Non-functional requirements (latency, scale, security, cost).
+- **Error handling**: How should the system behave when things go wrong?
+
+Your task:
+1. Ask targeted questions to uncover gaps in each NLSpec dimension.
+2. Ask at most one or two questions per turn. Do not overwhelm the user.
+3. Once you have enough to write a complete spec (usually 5–10 questions), generate it.
+4. When the user types "done" or you have reached the question limit, produce the final spec.
+
+Final spec format:
+- Use markdown with level-2 headings (##) for each NLSpec dimension.
+- Be precise and unambiguous. Avoid filler sentences.
+- Include only what is known; do not invent requirements.`


### PR DESCRIPTION
Closes #205

## Changes
**1. Create `internal/interview/prompt.go`**
- `systemPrompt() string` -- unexported function returning the interviewer system prompt
- Prompt content as described in the original plan (role, NLSpec dimensions, question count guidance, final output format)

**2. Create `internal/interview/interview.go`**
- `const maxRounds = 20`
- `const rePromptMsg = "Please enter a response (or type \"done\" to generate the spec)."` -- not a sentinel error, just a message string
- `Interviewer` struct: `client llm.Client`, `in io.Reader`, `out io.Writer`, `model string`
- `New(client llm.Client, in io.Reader, out io.Writer, model string) *Interviewer`
- `Run(ctx context.Context, initialPrompt string) (string, float64, error)`:
  1. Build `[]llm.Message` starting with `{Role: "user", Content: initialPrompt}`
  2. Call `client.Generate(ctx, llm.GenerateRequest{SystemPrompt: systemPrompt(), Messages: messages, Model: i.model})`
  3. Accumulate `resp.CostUSD`, append assistant message, write to `out`
  4. Loop via `bufio.Scanner(i.in)`:
     - Check `ctx.Err()` first; return wrapped if cancelled
     - Trim whitespace; if empty, write `rePromptMsg` to `out`, continue (no round increment)
     - If `strings.EqualFold(trimmed, "done")`: append user message with final generation instruction, call Generate, return content + total cost
     - If round == maxRounds: write warning, auto-trigger final generation same as "done"
     - Otherwise: append user message, call Generate, append assistant message, write to `out`, increment round
  5. After loop: if `scanner.Err() != nil`, return `fmt.Errorf("interview: scanner: %w", scanner.Err())`
  6. If scanner exhausted without "done" (EOF): treat as auto-generate (same as max rounds)

## Review Findings
- Errors: 0
- Warnings: 1
- Nits: 5
- Assessment: **NEEDS CHANGES**

The slice aliasing in `generateFinal` (finding 1) is the only item worth fixing before merge. A one-line change to copy the slice eliminates a subtle mutation hazard.
