### PR TITLE
feat(scenario): add structured diagnostics to judge output

### DIFF
--- a/internal/llm/anthropic.go
+++ b/internal/llm/anthropic.go
@@ -444,9 +444,10 @@ func (c *AnthropicClient) Judge(ctx context.Context, req JudgeRequest) (JudgeRes
 	}
 
 	return JudgeResponse{
-		Score:     result.Score,
-		Reasoning: result.Reasoning,
-		Failures:  result.Failures,
-		CostUSD:   m.cost,
+		Score:       result.Score,
+		Reasoning:   result.Reasoning,
+		Failures:    result.Failures,
+		Diagnostics: result.Diagnostics,
+		CostUSD:     m.cost,
 	}, nil
 }

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -56,12 +56,19 @@ type JudgeRequest struct {
 	CacheControl *CacheControl
 }
 
+// Diagnostic holds a structured failure detail from the judge.
+type Diagnostic struct {
+	Category string `json:"category"`
+	Detail   string `json:"detail"`
+}
+
 // JudgeResponse contains the result of a judge call.
 type JudgeResponse struct {
-	Score     int
-	Reasoning string
-	Failures  []string
-	CostUSD   float64
+	Score       int
+	Reasoning   string
+	Failures    []string
+	Diagnostics []Diagnostic
+	CostUSD     float64
 }
 
 // Message represents a single message in a conversation.

--- a/internal/llm/json.go
+++ b/internal/llm/json.go
@@ -4,9 +4,10 @@ import "strings"
 
 // judgeResult is the expected JSON structure from the judge LLM.
 type judgeResult struct {
-	Score     int      `json:"score"`
-	Reasoning string   `json:"reasoning"`
-	Failures  []string `json:"failures"`
+	Score       int          `json:"score"`
+	Reasoning   string       `json:"reasoning"`
+	Failures    []string     `json:"failures"`
+	Diagnostics []Diagnostic `json:"diagnostics"`
 }
 
 // ExtractJSON strips markdown code fences from LLM output to get raw JSON.

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -168,10 +168,11 @@ func (c *OpenAIClient) Judge(ctx context.Context, req JudgeRequest) (JudgeRespon
 	}
 
 	return JudgeResponse{
-		Score:     result.Score,
-		Reasoning: result.Reasoning,
-		Failures:  result.Failures,
-		CostUSD:   m.cost,
+		Score:       result.Score,
+		Reasoning:   result.Reasoning,
+		Failures:    result.Failures,
+		Diagnostics: result.Diagnostics,
+		CostUSD:     m.cost,
 	}, nil
 }
 

--- a/internal/llm/prompt.go
+++ b/internal/llm/prompt.go
@@ -4,7 +4,9 @@ package llm
 const SatisfactionJudgeSystem = `You are a QA evaluator. Score how well this software behavior matches the expected behavior.
 
 Respond with JSON only:
-{"score": <0-100>, "reasoning": "<brief explanation>", "failures": ["<specific failure>"]}
+{"score": <0-100>, "reasoning": "<brief explanation>", "failures": ["<specific failure>"], "diagnostics": [{"category": "<slug>", "detail": "<one-line detail>"}]}
+
+Include the diagnostics array only when score < 100; each entry has a short category slug and a one-line detail string.
 
 Scoring guide:
 - 100: Perfect match to expected behavior

--- a/internal/scenario/judge.go
+++ b/internal/scenario/judge.go
@@ -54,11 +54,17 @@ func (j *Judge) Score(ctx context.Context, scenario Scenario, step Step, observe
 		"cost", resp.CostUSD,
 	)
 
+	var diagnostics []llm.Diagnostic
+	if len(resp.Diagnostics) > 0 {
+		diagnostics = resp.Diagnostics
+	}
+
 	return StepScore{
-		Score:     resp.Score,
-		Reasoning: resp.Reasoning,
-		Failures:  resp.Failures,
-		CostUSD:   resp.CostUSD,
+		Score:       resp.Score,
+		Reasoning:   resp.Reasoning,
+		Failures:    resp.Failures,
+		Diagnostics: diagnostics,
+		CostUSD:     resp.CostUSD,
 	}, nil
 }
 

--- a/internal/scenario/judge_test.go
+++ b/internal/scenario/judge_test.go
@@ -231,6 +231,95 @@ func TestJudgeScoreScenarioStepCountMismatch(t *testing.T) {
 	}
 }
 
+func TestJudgeScoreDiagnosticsPresent(t *testing.T) {
+	client := &mockClient{
+		judgeFunc: func(_ context.Context, _ llm.JudgeRequest) (llm.JudgeResponse, error) {
+			return llm.JudgeResponse{
+				Score:     40,
+				Reasoning: "Multiple issues",
+				Diagnostics: []llm.Diagnostic{
+					{Category: "missing_endpoint", Detail: "POST /users returned 404"},
+					{Category: "wrong_response_shape", Detail: "missing email field"},
+				},
+				CostUSD: 0.002,
+			}, nil
+		},
+	}
+
+	judge := NewJudge(client, "test-model", newTestLogger())
+	score, err := judge.Score(context.Background(), Scenario{Description: "Test"}, Step{Description: "Step 1", Expect: "201 with user"}, "HTTP 404\nBody:\nnot found")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(score.Diagnostics) != 2 {
+		t.Fatalf("got %d diagnostics, want 2", len(score.Diagnostics))
+	}
+	if score.Diagnostics[0].Category != "missing_endpoint" {
+		t.Errorf("diagnostics[0].Category = %q, want %q", score.Diagnostics[0].Category, "missing_endpoint")
+	}
+	if score.Diagnostics[0].Detail != "POST /users returned 404" {
+		t.Errorf("diagnostics[0].Detail = %q, want %q", score.Diagnostics[0].Detail, "POST /users returned 404")
+	}
+	if score.Diagnostics[1].Category != "wrong_response_shape" {
+		t.Errorf("diagnostics[1].Category = %q, want %q", score.Diagnostics[1].Category, "wrong_response_shape")
+	}
+}
+
+func TestJudgeScoreDiagnosticsAbsent(t *testing.T) {
+	client := &mockClient{
+		judgeFunc: func(_ context.Context, _ llm.JudgeRequest) (llm.JudgeResponse, error) {
+			return llm.JudgeResponse{
+				Score:     100,
+				Reasoning: "Perfect",
+				CostUSD:   0.001,
+			}, nil
+		},
+	}
+
+	judge := NewJudge(client, "test-model", newTestLogger())
+	score, err := judge.Score(context.Background(), Scenario{Description: "Test"}, Step{Description: "Step 1", Expect: "200 OK"}, "HTTP 200\nBody:\nok")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if score.Diagnostics != nil {
+		t.Errorf("got diagnostics %v, want nil", score.Diagnostics)
+	}
+}
+
+func TestJudgeScoreDiagnosticsWithFailures(t *testing.T) {
+	client := &mockClient{
+		judgeFunc: func(_ context.Context, _ llm.JudgeRequest) (llm.JudgeResponse, error) {
+			return llm.JudgeResponse{
+				Score:     30,
+				Reasoning: "Broken",
+				Failures:  []string{"status code wrong", "body malformed"},
+				Diagnostics: []llm.Diagnostic{
+					{Category: "bad_status", Detail: "expected 200 got 500"},
+				},
+				CostUSD: 0.003,
+			}, nil
+		},
+	}
+
+	judge := NewJudge(client, "test-model", newTestLogger())
+	score, err := judge.Score(context.Background(), Scenario{Description: "Test"}, Step{Description: "Step 1", Expect: "200 with body"}, "HTTP 500\nBody:\nerror")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(score.Failures) != 2 {
+		t.Errorf("got %d failures, want 2", len(score.Failures))
+	}
+	if len(score.Diagnostics) != 1 {
+		t.Errorf("got %d diagnostics, want 1", len(score.Diagnostics))
+	}
+	if score.Diagnostics[0].Category != "bad_status" {
+		t.Errorf("diagnostics[0].Category = %q, want %q", score.Diagnostics[0].Category, "bad_status")
+	}
+}
+
 func TestAggregateSingleScenario(t *testing.T) {
 	scenarios := []ScoredScenario{
 		{

--- a/internal/scenario/result.go
+++ b/internal/scenario/result.go
@@ -1,13 +1,18 @@
 package scenario
 
-import "time"
+import (
+	"time"
+
+	"github.com/foundatron/octopusgarden/internal/llm"
+)
 
 // StepScore holds the LLM judge's evaluation of a single step.
 type StepScore struct {
-	Score     int
-	Reasoning string
-	Failures  []string
-	CostUSD   float64
+	Score       int
+	Reasoning   string
+	Failures    []string
+	Diagnostics []llm.Diagnostic
+	CostUSD     float64
 }
 
 // StepResult captures the outcome of executing a single scenario step.


### PR DESCRIPTION
Closes #179

## Changes
1. **`internal/scenario/result.go`** -- Add `Diagnostic` struct with `Category string` and `Detail string`. Add `Diagnostics []Diagnostic` to `StepScore`.

2. **`internal/llm/client.go`** -- Add `Diagnostic` struct with `Category string`, `Detail string`, and JSON tags (`json:"category"`, `json:"detail"`). Add `Diagnostics []Diagnostic` to `JudgeResponse`.

3. **`internal/llm/json.go`** -- Add `Diagnostics []Diagnostic` field (with `json:"diagnostics"` tag) to `judgeResult`. No new types, no helper functions.

4. **`internal/llm/prompt.go`** -- Update `SatisfactionJudgeSystem` JSON example to: `{"score": <0-100>, "reasoning": "...", "failures": [...], "diagnostics": [{"category": "...", "detail": "..."}]}`. Add one line: "Include the diagnostics array only when score < 100; each entry has a short category slug and a one-line detail string."

5. **`internal/llm/anthropic.go`** (~line 446-451) -- Add `Diagnostics: result.Diagnostics` to the `JudgeResponse` literal. One line.

6. **`internal/llm/openai.go`** (~line 170-175) -- Same: add `Diagnostics: result.Diagnostics`. One line.

7. **`internal/scenario/judge.go`** (~line 57-62) -- In `Score()`, convert `resp.Diagnostics` (type `[]llm.Diagnostic`) to `[]Diagnostic` (type `[]scenario.Diagnostic`) with a simple loop, then set `StepScore.Diagnostics`. ~4 lines inline, no helper.

## Review Findings
- Errors: 0
- Warnings: 0
- Nits: 4
- Assessment: **PASS**

Clean change. The new `Diagnostic` type threads correctly through all layers (prompt, JSON parsing, LLM clients, scenario judge, result types). Tests cover the three key states (present, absent, coexisting with failures). No logic errors, no security concerns, no broken invariants.
