### PR TITLE
feat(interview): CLI wiring for octog interview command

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ octog configure
 export ANTHROPIC_API_KEY=sk-...
 ```
 
+Draft a spec interactively:
+
+```bash
+# Conversational spec-drafting (outputs spec.md by default)
+octog interview --output my-spec.md
+```
+
 Run the factory on the included examples:
 
 ```bash

--- a/cmd/octog/main.go
+++ b/cmd/octog/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/foundatron/octopusgarden/internal/attractor"
 	"github.com/foundatron/octopusgarden/internal/container"
 	"github.com/foundatron/octopusgarden/internal/gene"
+	"github.com/foundatron/octopusgarden/internal/interview"
 	"github.com/foundatron/octopusgarden/internal/lint"
 	"github.com/foundatron/octopusgarden/internal/llm"
 	"github.com/foundatron/octopusgarden/internal/observability"
@@ -95,6 +96,8 @@ func main() {
 		err = modelsCmd(ctx, logger, os.Args[2:])
 	case "extract":
 		err = extractCmd(ctx, logger, os.Args[2:])
+	case "interview":
+		err = interviewCmd(ctx, logger, os.Args[2:])
 	case "preflight":
 		err = preflightCmd(ctx, logger, os.Args[2:])
 	case "configure":
@@ -130,6 +133,7 @@ func printUsage() {
 	fmt.Fprintf(os.Stderr, `Usage: octog <command> [flags]
 
 Commands:
+  interview  Interactively draft a spec through conversation
   run        Run the attractor loop to generate software from a spec
   validate   Validate a running service against scenarios
   preflight  Assess spec clarity before running the attractor loop
@@ -1585,6 +1589,55 @@ func printResult(result *attractor.RunResult, language string) {
 	fmt.Printf("  Satisfaction: %.1f%%\n", result.Satisfaction)
 	fmt.Printf("  Cost:         $%.4f\n", result.CostUSD)
 	fmt.Printf("  Output:       %s\n", result.OutputDir)
+}
+
+func interviewCmd(ctx context.Context, logger *slog.Logger, args []string) error {
+	fs := flag.NewFlagSet("interview", flag.ContinueOnError)
+	output := fs.String("output", "spec.md", "output file path for the generated spec")
+	model := fs.String("model", "", "LLM model to use (default: provider-specific)")
+	provider := fs.String("provider", "", "LLM provider: anthropic or openai (auto-detected from env if omitted)")
+	prompt := fs.String("prompt", "What would you like to build?", "opening question to start the interview")
+
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: octog interview [flags]\n\nInteractively draft a spec through conversation.\n\nFlags:\n")
+		fs.PrintDefaults()
+	}
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	clients, err := newLLMClient(*provider, logger)
+	if err != nil {
+		return err
+	}
+	if *model == "" {
+		*model = defaultModel(clients.provider)
+	}
+	logger.Info("starting interview", "provider", clients.provider, "model", *model)
+
+	return interviewRun(ctx, clients.client, *model, *prompt, *output, os.Stdin, os.Stdout, os.Stderr)
+}
+
+// interviewRun runs the interview conversation and writes the resulting spec to
+// outputPath. Separated from interviewCmd for testability.
+func interviewRun(ctx context.Context, client llm.Client, model, initialPrompt, outputPath string, in io.Reader, out, errOut io.Writer) error {
+	iv := interview.New(client, in, out, model)
+	spec, cost, err := iv.Run(ctx, initialPrompt)
+	if err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(outputPath, []byte(spec), 0o644); err != nil { //nolint:gosec // G306: spec.md is a user-facing document, 0644 is intentional
+		return fmt.Errorf("write spec: %w", err)
+	}
+
+	costStr := fmt.Sprintf("$%.4f", cost)
+	if cost == 0 {
+		costStr = "free"
+	}
+	fmt.Fprintf(errOut, "Spec written to %s (cost: %s)\n", outputPath, costStr) //nolint:gosec,errcheck // G705 false positive: writing to stderr, not an HTTP response
+	return nil
 }
 
 func configureCmd(_ context.Context, _ *slog.Logger, args []string) error {

--- a/cmd/octog/main_test.go
+++ b/cmd/octog/main_test.go
@@ -26,10 +26,14 @@ import (
 
 // mockLLMClient implements llm.Client for testing.
 type mockLLMClient struct {
-	judgeFn func(ctx context.Context, req llm.JudgeRequest) (llm.JudgeResponse, error)
+	generateFn func(ctx context.Context, req llm.GenerateRequest) (llm.GenerateResponse, error)
+	judgeFn    func(ctx context.Context, req llm.JudgeRequest) (llm.JudgeResponse, error)
 }
 
-func (m *mockLLMClient) Generate(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+func (m *mockLLMClient) Generate(ctx context.Context, req llm.GenerateRequest) (llm.GenerateResponse, error) {
+	if m.generateFn != nil {
+		return m.generateFn(ctx, req)
+	}
 	return llm.GenerateResponse{}, nil
 }
 
@@ -976,6 +980,113 @@ func TestWriteConfigFile(t *testing.T) {
 	if anthIdx > openIdx {
 		t.Errorf("ANTHROPIC_API_KEY should come before OPENAI_API_KEY in output")
 	}
+}
+
+func TestInterviewRun(t *testing.T) {
+	tests := []struct {
+		name       string
+		responses  []string  // Generate responses in order: opening question, then final spec
+		costs      []float64 // CostUSD per Generate call
+		userInput  string    // lines typed by the user
+		wantSpec   string    // expected content written to output file
+		wantErrOut string    // expected fragment in errOut
+		wantErr    bool
+	}{
+		{
+			name:       "happy path writes spec and reports cost",
+			responses:  []string{"What are you building?", "## My Spec\n\nA task manager."},
+			costs:      []float64{0.001, 0.002},
+			userInput:  "done\n",
+			wantSpec:   "## My Spec\n\nA task manager.",
+			wantErrOut: "$0.0030",
+		},
+		{
+			name:       "zero cost prints free",
+			responses:  []string{"What are you building?", "## Spec\n\nFree spec."},
+			costs:      []float64{0, 0},
+			userInput:  "done\n",
+			wantSpec:   "## Spec\n\nFree spec.",
+			wantErrOut: "free",
+		},
+		{
+			name:      "LLM error propagates",
+			responses: nil,
+			costs:     nil,
+			userInput: "",
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			callIdx := 0
+			client := &mockLLMClient{
+				generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+					if tt.responses == nil {
+						return llm.GenerateResponse{}, errors.New("LLM unavailable")
+					}
+					if callIdx >= len(tt.responses) {
+						t.Fatalf("unexpected Generate call %d", callIdx)
+					}
+					resp := llm.GenerateResponse{
+						Content: tt.responses[callIdx],
+						CostUSD: tt.costs[callIdx],
+					}
+					callIdx++
+					return resp, nil
+				},
+			}
+
+			dir := t.TempDir()
+			outputPath := filepath.Join(dir, "spec.md")
+			in := strings.NewReader(tt.userInput)
+			var out, errOut bytes.Buffer
+
+			err := interviewRun(context.Background(), client, "test-model", "What would you like to build?", outputPath, in, &out, &errOut)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("interviewRun: %v", err)
+			}
+
+			content, readErr := os.ReadFile(outputPath)
+			if readErr != nil {
+				t.Fatalf("read output file: %v", readErr)
+			}
+			if string(content) != tt.wantSpec {
+				t.Errorf("spec content = %q, want %q", string(content), tt.wantSpec)
+			}
+
+			if tt.wantErrOut != "" && !strings.Contains(errOut.String(), tt.wantErrOut) {
+				t.Errorf("errOut = %q, want it to contain %q", errOut.String(), tt.wantErrOut)
+			}
+		})
+	}
+
+	t.Run("file write error returns error", func(t *testing.T) {
+		callIdx := 0
+		responses := []string{"Question?", "## Spec"}
+		client := &mockLLMClient{
+			generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+				resp := llm.GenerateResponse{Content: responses[callIdx]}
+				callIdx++
+				return resp, nil
+			},
+		}
+		// Use a path under a non-existent nested directory to force write failure.
+		badPath := filepath.Join(t.TempDir(), "does-not-exist", "sub", "spec.md")
+		in := strings.NewReader("done\n")
+		var out, errOut bytes.Buffer
+
+		err := interviewRun(context.Background(), client, "model", "start", badPath, in, &out, &errOut)
+		if err == nil {
+			t.Fatal("expected write error, got nil")
+		}
+	})
 }
 
 func TestExtractCmdSourceDirNotExist(t *testing.T) {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,6 +60,7 @@ octopusgarden/
 │   │   ├── models.go             # Model registry, cost tracking
 │   │   └── prompt.go             # Prompt templates
 │   ├── gene/                     # Gene transfusion (scan, analyze, gene types)
+│   ├── interview/                # Conversational spec-drafting assistant
 │   ├── lint/                     # Spec and scenario structural linting
 │   ├── preflight/                # LLM-based spec/scenario quality assessment
 │   │   ├── preflight.go          # Check(): spec clarity (goal, constraint, success)
@@ -85,6 +86,8 @@ cmd/octog
     │       ├── internal/llm
     │       ├── internal/spec
     │       └── internal/container
+    ├── internal/interview      (conversational spec-drafting, multi-turn LLM)
+    │       └── internal/llm
     ├── internal/preflight      (spec clarity, scenario quality assessment)
     │       └── internal/llm
     ├── internal/gene           (scan, analyze, gene types)
@@ -115,6 +118,7 @@ content and failure feedback as strings. The validator (scenario runner + judge)
 | `spec` | Parse markdown specs, pyramid summarization | `parser.go`, `types.go`, `summary.go` | (none) |
 | `llm` | Model-agnostic LLM client, cost tracking, prompt templates | `client.go`, `anthropic.go`, `openai.go`, `models.go`, `json.go`, `prompt.go` | anthropic-sdk, openai-sdk |
 | `gene` | Scan exemplar codebases, LLM pattern extraction | `gene.go`, `scan.go`, `analyze.go` | `llm`, `spec` |
+| `interview` | Conversational spec-drafting via multi-turn LLM interview | `interview.go`, `prompt.go` | `llm` |
 | `preflight` | Pre-run quality assessment of specs and scenarios | `preflight.go`, `scenario.go` | `llm` |
 | `lint` | Structural linting for specs and scenario YAML | `spec.go`, `scenario.go`, `diagnostic.go`, `varcheck.go` | (none) |
 | `observability` | OpenTelemetry tracing wrappers | `setup.go` | `llm`, `container`, otel SDK |
@@ -924,6 +928,7 @@ implement it). The service name is `octog`.
 ## CLI Interface
 
 ```text
+octog interview  [--output spec.md] [--model ...] [--provider anthropic|openai] [--prompt "What would you like to build?"]
 octog run        --spec <path> --scenarios <dir> [--model claude-sonnet-4-6] [--frugal-model ...] [--judge-model claude-haiku-4-5] [--budget 5.00] [--threshold 95] [--genes genes.json] [--language go] [--patch] [--block-on-regression] [--context-budget 0] [--otel-endpoint ...] [--skip-preflight] [--preflight-threshold 0.8] [-v 0|1|2] [--provider anthropic|openai]
 octog validate   --scenarios <dir> --target <url> [--grpc-target host:port] [--judge-model claude-haiku-4-5] [--threshold 0] [--format text|json] [-v 0|1|2] [--provider anthropic|openai]
 octog preflight  [--judge-model claude-haiku-4-5] [--threshold 0.8] [--verbose] [--scenarios <dir>] <spec-path>
@@ -934,7 +939,7 @@ octog models     [--provider anthropic|openai]
 octog configure
 ```
 
-Subcommands: `run`, `validate`, `preflight`, `status`, `lint`, `extract`, `models`, `configure`.
+Subcommands: `interview`, `run`, `validate`, `preflight`, `status`, `lint`, `extract`, `models`, `configure`.
 
 Provider is auto-detected from which API key is set. Use `--provider` to disambiguate when both are
 present. Config file (`~/.octopusgarden/config`) supports `ANTHROPIC_API_KEY` and `OPENAI_API_KEY`;


### PR DESCRIPTION
Closes #206

## Changes
**1. `cmd/octog/main.go`** (modify)

- **Add import**: `"github.com/foundatron/octopusgarden/internal/interview"`
- **Add `"interview"` case** to the switch block (before `"configure"`):
  ```go
  case "interview":
      err = interviewCmd(ctx, logger, os.Args[2:])
  ```
- **Add `interviewCmd` function** following the `extractCmd` pattern:
  - `flag.NewFlagSet("interview", flag.ContinueOnError)` with flags:
    - `--output` (string, default `"spec.md"`)
    - `--model` (string, default `""`)
    - `--provider` (string, default `""`)
    - `--prompt` (string, default `""`)
  - `fs.Usage` closure
  - Parse flags, call `newLLMClient(*provider, logger)` to resolve provider and create client
  - Apply default model: `if *model == "" { *model = defaultModel(clients.provider) }`
  - Set default prompt: `if *prompt == "" { *prompt = "What would you like to build?" }`
  - Create `interview.New(clients.client, os.Stdin, os.Stdout, *model)`
  - Call `iv.Run(ctx, *prompt)` -- returns `(string, float64, error)`
  - Write spec to `*output` using `os.WriteFile(..., 0o644)`
  - Print summary to stderr: `fmt.Fprintf(os.Stderr, "Spec written to %s (cost: $%.4f)\n", *output, cost)` -- use `%.4f` not `%.2f` since interview costs will often be sub-cent
- **Update `printUsage`**: Add `interview` line before `run`:
  ```
    interview  Interactively draft a spec through conversation
  ```

**2. No new files.**

## Review Findings
- Errors: 0
- Warnings: 1
- Nits: 4
- Assessment: **NEEDS CHANGES** (warning #3: no test coverage for the wiring layer)
