### PR TITLE
feat(attractor): feed structured diagnostics into feedback prompt

### DIFF
--- a/cmd/octog/main.go
+++ b/cmd/octog/main.go
@@ -1380,6 +1380,9 @@ func formatFailedScenario(s scenario.ScoredScenario) string {
 			}
 			fmt.Fprintf(&b, "\n    %s: %s", label, obs) //nolint:gosec // G705 false positive: writing to strings.Builder, not an HTTP response
 		}
+		for _, d := range step.StepScore.Diagnostics {
+			fmt.Fprintf(&b, "\n    [%s] %s", d.Category, d.Detail) //nolint:gosec // G705 false positive: writing to strings.Builder, not an HTTP response
+		}
 	}
 	return b.String()
 }

--- a/cmd/octog/main_test.go
+++ b/cmd/octog/main_test.go
@@ -1465,6 +1465,85 @@ func TestBuildDetailedFailures(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "failing step with diagnostics",
+			agg: scenario.AggregateResult{
+				Scenarios: []scenario.ScoredScenario{
+					{ScenarioID: "diag", Score: 20, Steps: []scenario.ScoredStep{
+						{
+							StepScore: scenario.StepScore{
+								Score:     20,
+								Reasoning: "bad status",
+								Diagnostics: []llm.Diagnostic{
+									{Category: "missing_endpoint", Detail: "POST /users returned 404"},
+									{Category: "wrong_shape", Detail: "id field missing"},
+								},
+							},
+							StepResult: scenario.StepResult{Description: "create user", Observed: "got 404"},
+						},
+					}},
+				},
+			},
+			wantLen: 1,
+			wantCheck: func(t *testing.T, out []string) {
+				t.Helper()
+				if !strings.Contains(out[0], "[missing_endpoint] POST /users returned 404") {
+					t.Errorf("diagnostic line missing, got %q", out[0])
+				}
+				if !strings.Contains(out[0], "[wrong_shape] id field missing") {
+					t.Errorf("second diagnostic line missing, got %q", out[0])
+				}
+				// Diagnostics must appear after Observed.
+				obsIdx := strings.Index(out[0], "Observed:")
+				diagIdx := strings.Index(out[0], "[missing_endpoint]")
+				if obsIdx < 0 || diagIdx < 0 || diagIdx <= obsIdx {
+					t.Errorf("diagnostics should appear after Observed, got %q", out[0])
+				}
+			},
+		},
+		{
+			name: "passing step with diagnostics emits no diagnostic lines",
+			agg: scenario.AggregateResult{
+				Scenarios: []scenario.ScoredScenario{
+					{ScenarioID: "passdiag", Score: 95, Steps: []scenario.ScoredStep{
+						{
+							StepScore: scenario.StepScore{
+								Score:       95,
+								Diagnostics: []llm.Diagnostic{{Category: "latency", Detail: "slow"}},
+							},
+							StepResult: scenario.StepResult{Description: "ping"},
+						},
+					}},
+				},
+			},
+			wantLen: 1,
+			wantCheck: func(t *testing.T, out []string) {
+				t.Helper()
+				if strings.Contains(out[0], "[latency]") {
+					t.Errorf("passing step diagnostics must not appear in output, got %q", out[0])
+				}
+			},
+		},
+		{
+			name: "empty diagnostics slice produces no extra output",
+			agg: scenario.AggregateResult{
+				Scenarios: []scenario.ScoredScenario{
+					{ScenarioID: "nodiag", Score: 10, Steps: []scenario.ScoredStep{
+						{
+							StepScore:  scenario.StepScore{Score: 10, Reasoning: "fail", Diagnostics: []llm.Diagnostic{}},
+							StepResult: scenario.StepResult{Description: "check"},
+						},
+					}},
+				},
+			},
+			wantLen: 1,
+			wantCheck: func(t *testing.T, out []string) {
+				t.Helper()
+				if strings.Contains(out[0], "[]") {
+					t.Errorf("empty diagnostics must not produce bracket output, got %q", out[0])
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -233,7 +233,7 @@ type Client interface {
 ```
 
 Request/response types (`GenerateRequest`, `GenerateResponse`, `JudgeRequest`, `JudgeResponse`,
-`Message`, `CacheControl`) are defined in `internal/llm/client.go`.
+`Message`, `CacheControl`, `Diagnostic`) are defined in `internal/llm/client.go`.
 
 ### Agent Loop Interface
 
@@ -869,11 +869,11 @@ called after each iteration with whether satisfaction strictly improved. When es
 
 Validation feedback sent to the LLM is scaled by iteration to balance cost and signal:
 
-| Level      | Iterations | Max bytes | Detail                                     |
-| ---------- | ---------- | --------- | ------------------------------------------ |
-| `compact`  | 1–2        | 4 KB      | Scenario summary lines only                |
-| `standard` | 3–4        | 12 KB     | Failing step detail, observed truncated    |
-| `full`     | 5+         | 24 KB     | All step detail, full observed output      |
+| Level      | Iterations | Max bytes | Detail                                                          |
+| ---------- | ---------- | --------- | --------------------------------------------------------------- |
+| `compact`  | 1–2        | 4 KB      | Scenario summary lines only                                     |
+| `standard` | 3–4        | 12 KB     | Failing step detail, observed truncated, structured diagnostics |
+| `full`     | 5+         | 24 KB     | All step detail, full observed output, structured diagnostics   |
 
 Stalls escalate fidelity by one level (e.g. compact → standard after 2 consecutive stalls).
 

--- a/internal/attractor/prompts_test.go
+++ b/internal/attractor/prompts_test.go
@@ -1155,7 +1155,7 @@ func TestObservedTruncationUTF8Safe(t *testing.T) {
 func TestFidelityRoundTrip(t *testing.T) {
 	// Build a canonical failure entry: one failing step and one passing step.
 	scenarioLine := FormatScenarioFailureLine("round-trip", 50)
-	failStep := "  ✗ failing step (30/100)\n    Reasoning: broke\n    Observed: " + strings.Repeat("a", 100)
+	failStep := "  ✗ failing step (30/100)\n    Reasoning: broke\n    Observed: " + strings.Repeat("a", 100) + "\n    [missing_endpoint] POST /users returned 404"
 	passStep := "  ✓ passing step (100/100)\n    Reasoning: fine"
 	entry := scenarioLine + "\n" + failStep + "\n" + passStep
 
@@ -1169,6 +1169,9 @@ func TestFidelityRoundTrip(t *testing.T) {
 		}
 		if strings.Contains(result, "passing step") {
 			t.Error("compact: must not contain passing step")
+		}
+		if strings.Contains(result, "[missing_endpoint]") {
+			t.Error("compact: must not contain diagnostic lines")
 		}
 	})
 
@@ -1189,6 +1192,9 @@ func TestFidelityRoundTrip(t *testing.T) {
 		if strings.Contains(result, "Reasoning: fine") {
 			t.Error("standard: must not contain passing step reasoning")
 		}
+		if !strings.Contains(result, "[missing_endpoint] POST /users returned 404") {
+			t.Error("standard: must contain diagnostic lines under failing step")
+		}
 	})
 
 	t.Run("full", func(t *testing.T) {
@@ -1201,6 +1207,9 @@ func TestFidelityRoundTrip(t *testing.T) {
 		}
 		if !strings.Contains(result, "Reasoning: fine") {
 			t.Error("full: must contain passing step reasoning")
+		}
+		if !strings.Contains(result, "[missing_endpoint] POST /users returned 404") {
+			t.Error("full: must contain diagnostic lines")
 		}
 	})
 }


### PR DESCRIPTION
Closes #180

## Changes
1. **`cmd/octog/main.go`** — In `formatFailedScenario()`, after the Observed block (line ~1382), append diagnostic lines from `step.StepScore.Diagnostics`. For each diagnostic, emit:
   ```
       [category] detail
   ```
   (4-space indent, matching Reasoning/Observed). Only emitted for failing steps (the code already `continue`s past passing steps). Roughly 3-5 lines of new code in the failing-step branch.

## Review Findings
- Errors: 0
- Warnings: 0
- Nits: 3
- Assessment: **PASS**

The diff is clean and well-scoped. It adds diagnostic display in the CLI failure output with three solid test cases covering the key paths (failing with diagnostics, passing with diagnostics, empty diagnostics slice). The fidelity round-trip tests correctly validate that compact mode strips diagnostics while standard/full modes preserve them. Ranging over a nil/empty `Diagnostics` slice is safe in Go, so no nil guard is needed.
