### PR TITLE
feat(interview): NLSpec completeness scoring for spec quality assessment

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,7 +60,7 @@ octopusgarden/
 │   │   ├── models.go             # Model registry, cost tracking
 │   │   └── prompt.go             # Prompt templates
 │   ├── gene/                     # Gene transfusion (scan, analyze, gene types)
-│   ├── interview/                # Conversational spec-drafting assistant
+│   ├── interview/                # Conversational spec-drafting assistant + spec-completeness scorer
 │   ├── lint/                     # Spec and scenario structural linting
 │   ├── preflight/                # LLM-based spec/scenario quality assessment
 │   │   ├── preflight.go          # Check(): spec clarity (goal, constraint, success)
@@ -118,7 +118,7 @@ content and failure feedback as strings. The validator (scenario runner + judge)
 | `spec` | Parse markdown specs, pyramid summarization | `parser.go`, `types.go`, `summary.go` | (none) |
 | `llm` | Model-agnostic LLM client, cost tracking, prompt templates | `client.go`, `anthropic.go`, `openai.go`, `models.go`, `json.go`, `prompt.go` | anthropic-sdk, openai-sdk |
 | `gene` | Scan exemplar codebases, LLM pattern extraction | `gene.go`, `scan.go`, `analyze.go` | `llm`, `spec` |
-| `interview` | Conversational spec-drafting via multi-turn LLM interview | `interview.go`, `prompt.go` | `llm` |
+| `interview` | Conversational spec-drafting and spec-completeness scoring | `interview.go`, `prompt.go`, `scoring.go`, `scoring_prompt.go` | `llm` |
 | `preflight` | Pre-run quality assessment of specs and scenarios | `preflight.go`, `scenario.go` | `llm` |
 | `lint` | Structural linting for specs and scenario YAML | `spec.go`, `scenario.go`, `diagnostic.go`, `varcheck.go` | (none) |
 | `observability` | OpenTelemetry tracing wrappers | `setup.go` | `llm`, `container`, otel SDK |
@@ -913,6 +913,49 @@ Four dimensions, each scored 0.0–1.0 (unweighted average):
 - **Chains** — Are multi-step variable captures and substitutions correct?
 
 Returns per-scenario issues with dimension and actionable detail.
+
+## Spec-Completeness Scoring (`interview.Scorer`)
+
+`interview.NewScorer(client llm.Client, model string) *Scorer` — scores a spec against five
+weighted dimensions using an LLM judge. Distinct from `preflight.Check` (which gates the attractor
+loop); this scorer is used by the `octog interview` command to show the user how complete their
+drafted spec is.
+
+```go
+type Scorer struct { client llm.Client; model string }
+
+func (s *Scorer) Score(ctx context.Context, specContent string) (CompletenessResult, error)
+
+type CompletenessResult struct {
+    Dimensions []DimensionScore
+    Overall    int     // weighted average, rounded
+    CostUSD    float64
+}
+
+type DimensionScore struct {
+    Name   string
+    Score  int     // 0–100, clamped
+    Weight float64
+    Gaps   []string
+}
+```
+
+Five dimensions (weights sum to 1.0), iterated in canonical order (stable output):
+
+| Dimension                  | Weight | Description                                                         |
+| -------------------------- | ------ | ------------------------------------------------------------------- |
+| `behavioral_completeness`  | 0.25   | Happy paths, error paths, edge cases, state transitions             |
+| `interface_precision`      | 0.25   | API endpoints, CLI flags, config, data formats, field types         |
+| `defaults_and_boundaries`  | 0.20   | Default values, limits, ranges, boundary conditions                 |
+| `acceptance_criteria`      | 0.20   | Testable criteria a QA engineer can automate without assumptions    |
+| `economy`                  | 0.10   | Free of redundancy, contradictions, and misleading noise            |
+
+Scoring uses the two-implementer test (would two engineers produce interoperable implementations?)
+and the recreatability test (could a new engineer recreate equivalent behavior from the spec alone?).
+
+LLM is called with `Temperature=0`, `MaxTokens=4096`, and `CacheControl: ephemeral` on the system
+prompt. Response must be a JSON object with exactly five named dimensions; scores are clamped to
+[0, 100]. Sentinel errors: `errEmptySpec`, `errMalformedResponse`, `errIncompleteDimensions`.
 
 ## Observability
 

--- a/internal/interview/scoring.go
+++ b/internal/interview/scoring.go
@@ -1,0 +1,136 @@
+package interview
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/foundatron/octopusgarden/internal/llm"
+)
+
+var (
+	errEmptySpec            = errors.New("spec content is empty")
+	errMalformedResponse    = errors.New("malformed scoring response")
+	errIncompleteDimensions = errors.New("incomplete dimensions in scoring response")
+)
+
+// dimensionOrder defines the canonical output order for spec-completeness dimensions.
+// Weights must sum to 1.0. Always iterate this slice (never a map) to guarantee
+// stable ordering in CompletenessResult.Dimensions.
+var dimensionOrder = []struct {
+	name   string
+	weight float64
+}{
+	{"behavioral_completeness", 0.25},
+	{"interface_precision", 0.25},
+	{"defaults_and_boundaries", 0.20},
+	{"acceptance_criteria", 0.20},
+	{"economy", 0.10},
+}
+
+// DimensionScore holds the score and gap details for a single completeness dimension.
+type DimensionScore struct {
+	Name   string
+	Score  int
+	Weight float64
+	Gaps   []string
+}
+
+// CompletenessResult is the output of a spec-completeness scoring call.
+type CompletenessResult struct {
+	Dimensions []DimensionScore
+	Overall    int
+	CostUSD    float64
+}
+
+// Scorer scores spec completeness using an LLM judge.
+type Scorer struct {
+	client llm.Client
+	model  string
+}
+
+// NewScorer creates a Scorer that uses the given LLM client and model.
+func NewScorer(client llm.Client, model string) *Scorer {
+	return &Scorer{client: client, model: model}
+}
+
+// scoringResponse is the expected JSON structure from the scoring LLM.
+type scoringResponse struct {
+	Dimensions []struct {
+		Name  string   `json:"name"`
+		Score int      `json:"score"`
+		Gaps  []string `json:"gaps"`
+	} `json:"dimensions"`
+}
+
+// Score evaluates the completeness of specContent and returns a CompletenessResult.
+func (s *Scorer) Score(ctx context.Context, specContent string) (CompletenessResult, error) {
+	if strings.TrimSpace(specContent) == "" {
+		return CompletenessResult{}, errEmptySpec
+	}
+
+	var zeroTemp float64
+	req := llm.GenerateRequest{
+		SystemPrompt: scoringSystemPrompt,
+		Messages:     []llm.Message{{Role: "user", Content: specContent}},
+		Model:        s.model,
+		MaxTokens:    4096,
+		Temperature:  &zeroTemp,
+		CacheControl: &llm.CacheControl{Type: "ephemeral"},
+	}
+
+	resp, err := s.client.Generate(ctx, req)
+	if err != nil {
+		return CompletenessResult{}, fmt.Errorf("scorer: %w", err)
+	}
+
+	cleaned := llm.ExtractJSON(resp.Content)
+	var sr scoringResponse
+	if err := json.Unmarshal([]byte(cleaned), &sr); err != nil {
+		return CompletenessResult{}, fmt.Errorf("%w: %w", errMalformedResponse, err)
+	}
+
+	// Require exactly the known dimensions -- no more, no less.
+	if len(sr.Dimensions) != len(dimensionOrder) {
+		return CompletenessResult{}, errIncompleteDimensions
+	}
+
+	// Index response by name for exact lookup.
+	idxByName := make(map[string]int, len(sr.Dimensions))
+	for i, d := range sr.Dimensions {
+		idxByName[d.Name] = i
+	}
+
+	// Iterate dimensionOrder (not a map) to guarantee stable output ordering.
+	dimensions := make([]DimensionScore, 0, len(dimensionOrder))
+	for _, dim := range dimensionOrder {
+		idx, ok := idxByName[dim.name]
+		if !ok {
+			return CompletenessResult{}, errIncompleteDimensions
+		}
+		d := sr.Dimensions[idx]
+		dimensions = append(dimensions, DimensionScore{
+			Name:   dim.name,
+			Score:  min(max(d.Score, 0), 100),
+			Weight: dim.weight,
+			Gaps:   d.Gaps,
+		})
+	}
+
+	return CompletenessResult{
+		Dimensions: dimensions,
+		Overall:    computeOverall(dimensions),
+		CostUSD:    resp.CostUSD,
+	}, nil
+}
+
+func computeOverall(dimensions []DimensionScore) int {
+	var sum float64
+	for _, d := range dimensions {
+		sum += float64(d.Score) * d.Weight
+	}
+	return int(math.Round(sum))
+}

--- a/internal/interview/scoring_prompt.go
+++ b/internal/interview/scoring_prompt.go
@@ -1,0 +1,78 @@
+package interview
+
+const scoringSystemPrompt = `You are a spec-completeness evaluator. Your job is to score a software specification
+against five dimensions and identify specific gaps that would prevent an engineer from implementing
+the feature without follow-up questions.
+
+## Two-Implementer Test
+A good spec passes the "two-implementer test": two engineers working independently from the spec
+should produce interoperable implementations. Score each dimension by asking: would this spec allow
+two engineers to reach the same observable behavior?
+
+## Recreatability Test
+A good spec also passes the "recreatability test": given only the spec (not the implementation),
+a new engineer could recreate functionally equivalent behavior.
+
+## Dimensions
+
+Score each dimension from 0 to 100:
+- **0**: Completely missing or so vague as to be useless.
+- **50**: Present but with significant ambiguity or missing cases.
+- **100**: Complete, unambiguous, and actionable.
+
+### behavioral_completeness (weight: 0.25)
+Does the spec describe all significant behaviors: happy paths, error paths, edge cases, and
+state transitions? Are there implicit behaviors that should be made explicit?
+
+### interface_precision (weight: 0.25)
+Are all interfaces (API endpoints, CLI flags, config options, data formats, types, field names)
+specified with enough precision that two engineers would produce identical interfaces?
+
+### defaults_and_boundaries (weight: 0.20)
+Are default values, limits, ranges, and boundary conditions explicitly stated? Would an engineer
+know what to do when input is at or beyond a boundary?
+
+### acceptance_criteria (weight: 0.20)
+Does the spec include testable acceptance criteria? Can a QA engineer write automated tests
+directly from the spec without making assumptions?
+
+### economy (weight: 0.10)
+Is the spec free of redundancy, contradictions, and unnecessary detail? Does it say what needs
+to be said without noise that could mislead implementers?
+
+## Output Format
+
+Respond with ONLY a JSON object — no prose, no markdown fences:
+
+{
+  "dimensions": [
+    {
+      "name": "behavioral_completeness",
+      "score": 85,
+      "gaps": ["Error behavior when token expires is not specified", "Concurrent request handling is undefined"]
+    },
+    {
+      "name": "interface_precision",
+      "score": 70,
+      "gaps": ["Field type for 'created_at' not specified (string? epoch? ISO 8601?)"]
+    },
+    {
+      "name": "defaults_and_boundaries",
+      "score": 60,
+      "gaps": ["Maximum payload size not stated", "Default timeout value missing"]
+    },
+    {
+      "name": "acceptance_criteria",
+      "score": 90,
+      "gaps": []
+    },
+    {
+      "name": "economy",
+      "score": 80,
+      "gaps": ["Section 3 repeats the same constraint stated in Section 1"]
+    }
+  ]
+}
+
+Use the exact snake_case dimension names shown above. Include all five dimensions. Gaps must be
+specific and actionable — cite the missing information, not just "more detail needed".`

--- a/internal/interview/scoring_test.go
+++ b/internal/interview/scoring_test.go
@@ -1,0 +1,249 @@
+package interview
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/foundatron/octopusgarden/internal/llm"
+)
+
+func TestScorerHappyPath(t *testing.T) {
+	t.Parallel()
+	var capturedReq llm.GenerateRequest
+	client := &mockClient{
+		generateFn: func(_ context.Context, req llm.GenerateRequest) (llm.GenerateResponse, error) {
+			capturedReq = req
+			return llm.GenerateResponse{
+				Content: `{"dimensions":[` +
+					`{"name":"behavioral_completeness","score":85,"gaps":["Missing error for expired token"]},` +
+					`{"name":"interface_precision","score":70,"gaps":["Type of created_at unspecified"]},` +
+					`{"name":"defaults_and_boundaries","score":60,"gaps":["Max payload size missing"]},` +
+					`{"name":"acceptance_criteria","score":90,"gaps":[]},` +
+					`{"name":"economy","score":75,"gaps":[]}` +
+					`]}`,
+				CostUSD: 0.05,
+			}, nil
+		},
+	}
+
+	scorer := NewScorer(client, "test-model")
+	result, err := scorer.Score(context.Background(), "# My Spec\n\nSome content.")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Cache control should be set.
+	if capturedReq.CacheControl == nil || capturedReq.CacheControl.Type != "ephemeral" {
+		t.Errorf("expected CacheControl ephemeral, got %+v", capturedReq.CacheControl)
+	}
+
+	if result.CostUSD != 0.05 {
+		t.Errorf("CostUSD = %v, want 0.05", result.CostUSD)
+	}
+
+	if len(result.Dimensions) != 5 {
+		t.Fatalf("expected 5 dimensions, got %d", len(result.Dimensions))
+	}
+
+	// Find behavioral_completeness and verify gaps.
+	var found bool
+	for _, d := range result.Dimensions {
+		if d.Name == "behavioral_completeness" {
+			found = true
+			if d.Score != 85 {
+				t.Errorf("behavioral_completeness score = %d, want 85", d.Score)
+			}
+			if d.Weight != 0.25 {
+				t.Errorf("behavioral_completeness weight = %v, want 0.25", d.Weight)
+			}
+			if len(d.Gaps) != 1 || d.Gaps[0] != "Missing error for expired token" {
+				t.Errorf("unexpected gaps: %v", d.Gaps)
+			}
+		}
+	}
+	if !found {
+		t.Error("behavioral_completeness dimension missing from result")
+	}
+
+	// Overall: 85*0.25 + 70*0.25 + 60*0.20 + 90*0.20 + 75*0.10
+	// = 21.25 + 17.5 + 12 + 18 + 7.5 = 76.25 → 76
+	if result.Overall != 76 {
+		t.Errorf("Overall = %d, want 76", result.Overall)
+	}
+}
+
+func TestScorerEmptySpec(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"empty", ""},
+		{"whitespace", "   "},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			input := tc.input
+			t.Parallel()
+			calls := 0
+			client := &mockClient{
+				generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+					calls++
+					return llm.GenerateResponse{}, nil
+				},
+			}
+			scorer := NewScorer(client, "test-model")
+			_, err := scorer.Score(context.Background(), input)
+			if !errors.Is(err, errEmptySpec) {
+				t.Errorf("expected errEmptySpec, got %v", err)
+			}
+			if calls != 0 {
+				t.Errorf("expected 0 LLM calls, got %d", calls)
+			}
+		})
+	}
+}
+
+func TestScorerLLMError(t *testing.T) {
+	t.Parallel()
+	errAPI := errors.New("api failure")
+	client := &mockClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{}, errAPI
+		},
+	}
+	scorer := NewScorer(client, "test-model")
+	_, err := scorer.Score(context.Background(), "some spec")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.HasPrefix(err.Error(), "scorer:") {
+		t.Errorf("expected 'scorer:' prefix, got %q", err.Error())
+	}
+	if !errors.Is(err, errAPI) {
+		t.Errorf("expected wrapped errAPI, got %v", err)
+	}
+}
+
+func TestScorerMalformedJSON(t *testing.T) {
+	t.Parallel()
+	client := &mockClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{Content: "not json"}, nil
+		},
+	}
+	scorer := NewScorer(client, "test-model")
+	_, err := scorer.Score(context.Background(), "some spec")
+	if !errors.Is(err, errMalformedResponse) {
+		t.Errorf("expected errMalformedResponse, got %v", err)
+	}
+}
+
+func TestScorerMissingDimensions(t *testing.T) {
+	t.Parallel()
+	// Only 3 of 5 dimensions returned.
+	client := &mockClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{
+				Content: `{"dimensions":[` +
+					`{"name":"behavioral_completeness","score":80,"gaps":[]},` +
+					`{"name":"interface_precision","score":70,"gaps":[]},` +
+					`{"name":"economy","score":90,"gaps":[]}` +
+					`]}`,
+			}, nil
+		},
+	}
+	scorer := NewScorer(client, "test-model")
+	_, err := scorer.Score(context.Background(), "some spec")
+	if !errors.Is(err, errIncompleteDimensions) {
+		t.Errorf("expected errIncompleteDimensions, got %v", err)
+	}
+}
+
+func TestScorerScoreClamping(t *testing.T) {
+	t.Parallel()
+	client := &mockClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{
+				Content: `{"dimensions":[` +
+					`{"name":"behavioral_completeness","score":150,"gaps":[]},` +
+					`{"name":"interface_precision","score":-10,"gaps":[]},` +
+					`{"name":"defaults_and_boundaries","score":80,"gaps":[]},` +
+					`{"name":"acceptance_criteria","score":80,"gaps":[]},` +
+					`{"name":"economy","score":80,"gaps":[]}` +
+					`]}`,
+			}, nil
+		},
+	}
+	scorer := NewScorer(client, "test-model")
+	result, err := scorer.Score(context.Background(), "some spec")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, d := range result.Dimensions {
+		if d.Score < 0 || d.Score > 100 {
+			t.Errorf("dimension %q has out-of-range score %d", d.Name, d.Score)
+		}
+		if d.Name == "behavioral_completeness" && d.Score != 100 {
+			t.Errorf("expected clamped score 100, got %d", d.Score)
+		}
+		if d.Name == "interface_precision" && d.Score != 0 {
+			t.Errorf("expected clamped score 0, got %d", d.Score)
+		}
+	}
+}
+
+func TestScorerWeightedAverage(t *testing.T) {
+	t.Parallel()
+	// behavioral_completeness=80, interface_precision=60, defaults_and_boundaries=50,
+	// acceptance_criteria=70, economy=90
+	// Expected: 80*0.25 + 60*0.25 + 50*0.20 + 70*0.20 + 90*0.10
+	//         = 20 + 15 + 10 + 14 + 9 = 68
+	client := &mockClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{
+				Content: `{"dimensions":[` +
+					`{"name":"behavioral_completeness","score":80,"gaps":[]},` +
+					`{"name":"interface_precision","score":60,"gaps":[]},` +
+					`{"name":"defaults_and_boundaries","score":50,"gaps":[]},` +
+					`{"name":"acceptance_criteria","score":70,"gaps":[]},` +
+					`{"name":"economy","score":90,"gaps":[]}` +
+					`]}`,
+			}, nil
+		},
+	}
+	scorer := NewScorer(client, "test-model")
+	result, err := scorer.Score(context.Background(), "some spec")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Overall != 68 {
+		t.Errorf("Overall = %d, want 68", result.Overall)
+	}
+}
+
+func TestScorerUnknownDimensionName(t *testing.T) {
+	t.Parallel()
+	// 5 dimensions returned but one has an unrecognized name.
+	client := &mockClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{
+				Content: `{"dimensions":[` +
+					`{"name":"behavioral_completeness","score":80,"gaps":[]},` +
+					`{"name":"interface_precision","score":70,"gaps":[]},` +
+					`{"name":"defaults_and_boundaries","score":60,"gaps":[]},` +
+					`{"name":"acceptance_criteria","score":90,"gaps":[]},` +
+					`{"name":"unknown_dimension","score":75,"gaps":[]}` +
+					`]}`,
+			}, nil
+		},
+	}
+	scorer := NewScorer(client, "test-model")
+	_, err := scorer.Score(context.Background(), "some spec")
+	if !errors.Is(err, errIncompleteDimensions) {
+		t.Errorf("expected errIncompleteDimensions for unknown dimension, got %v", err)
+	}
+}


### PR DESCRIPTION
Closes #191

## Changes
**1. Create `internal/interview/scoring.go`**

- Sentinel errors at package level: `errEmptySpec`, `errMalformedResponse`, `errIncompleteDimensions`
- Types:
  - `DimensionScore` struct: `Name string`, `Score int`, `Weight float64`, `Gaps []string`
  - `CompletenessResult` struct: `Dimensions []DimensionScore`, `Overall int`, `CostUSD float64`
- Package-level var: `dimensionWeights = map[string]float64{...}` with the 5 dimensions (snake_case keys)
- `Scorer` struct with fields: `client llm.Client`, `model string` (unexported fields, no logger)
- `NewScorer(client llm.Client, model string) *Scorer` constructor
- `(s *Scorer) Score(ctx context.Context, specContent string) (CompletenessResult, error)`:
  - Return `errEmptySpec` if `strings.TrimSpace(specContent)` is empty
  - Build `llm.GenerateRequest` with `scoringSystemPrompt` as system prompt, spec as user message, `CacheControl: &llm.CacheControl{Type: "ephemeral"}`, `MaxTokens: 4096`, `Temperature: &zeroTemp` (where `var zeroTemp float64`)
  - Call `s.client.Generate(ctx, req)`
  - Call `llm.ExtractJSON(resp.Content)` then `json.Unmarshal` into `scoringResponse`
  - If unmarshal fails, return `fmt.Errorf("%w: %w", errMalformedResponse, err)`
  - Build `[]DimensionScore` by iterating `dimensionWeights` map: for each expected dimension, find matching entry in response (exact name match). If not found, return `errIncompleteDimensions`
  - Clamp scores to [0, 100]
  - Compute weighted average via `computeOverall`
  - Return `CompletenessResult` with `CostUSD: resp.CostUSD`
- Unexported `scoringResponse` struct: `Dimensions []struct { Name string \`json:"name"\`; Score int \`json:"score"\`; Gaps []string \`json:"gaps"\` }`
- Helper `computeOverall(dimensions []DimensionScore) int`: weighted sum with `math.Round`

**2. Create `internal/interview/scoring_prompt.go`**

- `const scoringSystemPrompt` containing:
  - The five dimensions with descriptions (behavioral_completeness, interface_precision, defaults_and_boundaries, acceptance_criteria, economy) -- using exact snake_case keys
  - Two-implementer test and recreatability test descriptions
  - Scoring guidance (what 0, 50, 100 means per dimension)
  - Expected JSON output: `{"dimensions": [{"name": "behavioral_completeness", "score": 85, "gaps": ["..."]}]}`
  - Instruction for actionable, specific gap descriptions

**3. Create `internal/interview/scoring_test.go`**

See Tests section.

## Review Findings
- Errors: 0
- Warnings: 2
- Nits: 3
- Assessment: **NEEDS CHANGES** (the non-deterministic ordering is a latent bug that will bite downstream consumers; the missing mock may be a compilation issue)
