### PR TITLE
feat(attractor): file-level triage for patch mode

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,7 +50,8 @@ octopusgarden/
 │   │   ├── languages.go          # Per-language templates (Go, Python, Node, Rust)
 │   │   ├── oscillation.go        # A→B→A→B oscillation detection (SHA-256 hashing)
 │   │   ├── prompts.go            # System prompt, feedback fidelity, steering text
-│   │   └── regression.go         # Per-scenario regression tracking
+│   │   ├── regression.go         # Per-scenario regression tracking
+│   │   └── triage.go             # LLM-based file triage: filter bestFiles to failure-relevant subset
 │   ├── container/docker.go       # Build and run Docker containers
 │   ├── llm/                      # LLM client abstraction
 │   │   ├── client.go             # Client + AgentClient interfaces, request/response types
@@ -112,7 +113,7 @@ content and failure feedback as strings. The validator (scenario runner + judge)
 
 | Package | Purpose | Key Files | Dependencies |
 | ------- | ------- | --------- | ------------ |
-| `attractor` | Convergence loop: generate code, build, validate, iterate | `attractor.go`, `convergence.go`, `diagnosis.go`, `escalation.go`, `oscillation.go`, `regression.go`, `prompts.go`, `fileparse.go`, `languages.go` | `llm`, `spec`, `container` |
+| `attractor` | Convergence loop: generate code, build, validate, iterate | `attractor.go`, `convergence.go`, `diagnosis.go`, `escalation.go`, `oscillation.go`, `regression.go`, `prompts.go`, `fileparse.go`, `languages.go`, `triage.go` | `llm`, `spec`, `container` |
 | `container` | Docker image build, container run, health check, exec sessions | `docker.go` | docker SDK |
 | `scenario` | Load YAML scenarios, execute steps, LLM-judge scoring | `types.go`, `loader.go`, `runner.go`, `judge.go`, `result.go`, `jsonpath.go`, `grpc.go` | `llm` |
 | `spec` | Parse markdown specs, pyramid summarization | `parser.go`, `types.go`, `summary.go` | (none) |
@@ -717,7 +718,9 @@ type RunResult struct {
    c. Select spec content (full or summarized with failure-relevant sections expanded)
    d. Build messages:
       - Normal mode: spec only (iter 1) or spec + last 3 failure summaries (iter N>1)
-      - Patch mode (iter 2+ with bestFiles): previous best files + failures
+      - Patch mode (iter 2+ with bestFiles): triage bestFiles via LLM (keep only files relevant to
+        current failures + entry points; skip triage when ≤5 files or no failures), then send
+        filtered files + failures; omitted-file count appended as a note in the prompt
    e. Apply minimalism suffix when last score > 80% (discourage over-engineering)
    f. Inject oscillation steering when A→B→A→B hash pattern detected
    g. Generate code:
@@ -795,6 +798,25 @@ file contents here
 
 In patch mode, `MergeFiles(newFiles, prevFiles)` copies all previous best files and overlays new
 output on top.
+
+### File Triage (`internal/attractor/triage.go`)
+
+`triageFiles(ctx, allFiles, failures, model)` narrows the file set sent to the LLM in patch mode.
+It asks the judge-tier model to return a JSON array of paths most relevant to the current failures,
+then merges in any entry-point files present in `allFiles` (Dockerfile, main.go, go.mod, etc.),
+regardless of LLM output.
+
+Skip conditions (returns `allFiles` unchanged, zero cost):
+
+- `len(allFiles) <= 5`
+- `len(failures) == 0`
+
+On error or empty result, falls back to the full file set. Cost is accumulated into `totalCost`.
+The count of omitted files is passed to `buildPatchMessages` as `omittedCount`; when > 0, a
+`(N other files not relevant to current failures, not shown)` note is appended to the prompt.
+
+Entry points always included: `Dockerfile`, `main.go`, `main.py`, `main.rs`, `app.py`, `app.js`,
+`server.js`, `index.js`, `index.ts`, `go.mod`, `cargo.toml`, `package.json`, `requirements.txt`.
 
 ## Convergence (`internal/attractor/convergence.go`)
 

--- a/internal/attractor/attractor.go
+++ b/internal/attractor/attractor.go
@@ -661,7 +661,10 @@ func (a *Attractor) generateStandard(ctx context.Context, specContent, iterDir s
 	// Build messages: patch mode sends previous best files + failures.
 	var messages []llm.Message
 	if patching {
-		messages = buildPatchMessages(s.history, s.bestFiles, s.bestSatisfaction)
+		relevantFiles, triageCost := a.triageFiles(ctx, s.bestFiles, s.lastFailures, s.opts.JudgeModel)
+		s.totalCost += triageCost
+		omitted := len(s.bestFiles) - len(relevantFiles)
+		messages = buildPatchMessages(s.history, relevantFiles, s.bestSatisfaction, omitted)
 	} else {
 		messages = buildMessages(iter, s.history)
 	}

--- a/internal/attractor/prompts.go
+++ b/internal/attractor/prompts.go
@@ -380,14 +380,20 @@ func buildMessages(iter int, history []iterationFeedback) []llm.Message {
 
 // buildPatchMessages constructs the user message for patch mode iterations.
 // It includes the previous best files as context and the most recent failures,
-// asking the LLM to output only changed files.
-func buildPatchMessages(history []iterationFeedback, bestFiles map[string]string, bestScore float64) []llm.Message {
+// asking the LLM to output only changed files. omittedCount is the number of
+// files excluded from bestFiles by triage; when > 0 a note is appended after
+// the file blocks.
+func buildPatchMessages(history []iterationFeedback, bestFiles map[string]string, bestScore float64, omittedCount int) []llm.Message {
 	var b strings.Builder
 	fmt.Fprintf(&b, "The current best version scored %.1f/100. Here are all current files:\n\n", bestScore)
 
 	paths := slices.Sorted(maps.Keys(bestFiles))
 	for _, p := range paths {
 		fmt.Fprintf(&b, "=== FILE: %s ===\n%s=== END FILE ===\n\n", p, bestFiles[p])
+	}
+
+	if omittedCount > 0 {
+		fmt.Fprintf(&b, "(%d other files not relevant to current failures, not shown)\n\n", omittedCount)
 	}
 
 	// Inject steering for scenarios stalling across consecutive iterations (full history).

--- a/internal/attractor/prompts_test.go
+++ b/internal/attractor/prompts_test.go
@@ -188,7 +188,7 @@ func TestBuildPatchMessagesCategorizedFeedback(t *testing.T) {
 		"main.go":    "package main\n",
 		"Dockerfile": "FROM scratch\n",
 	}
-	msgs := buildPatchMessages(history, bestFiles, 50.0)
+	msgs := buildPatchMessages(history, bestFiles, 50.0, 0)
 	content := msgs[0].Content
 
 	if !strings.Contains(content, "current best version scored 50.0/100") {
@@ -207,7 +207,7 @@ func TestBuildPatchMessagesCategorizedFeedback(t *testing.T) {
 
 func TestBuildPatchMessagesNoHistory(t *testing.T) {
 	bestFiles := map[string]string{"main.go": "package main\n"}
-	msgs := buildPatchMessages(nil, bestFiles, 70.0)
+	msgs := buildPatchMessages(nil, bestFiles, 70.0, 0)
 	content := msgs[0].Content
 
 	if strings.Contains(content, "Failures to fix") {
@@ -993,7 +993,7 @@ func TestBuildPatchMessagesWithSteering(t *testing.T) {
 	}
 	bestFiles := map[string]string{"main.go": "package main\n"}
 
-	msgs := buildPatchMessages(history, bestFiles, 50.0)
+	msgs := buildPatchMessages(history, bestFiles, 50.0, 0)
 	content := msgs[0].Content
 
 	if !strings.Contains(content, "STALL NOTICE") {
@@ -1376,5 +1376,23 @@ func TestBuildAgenticPatchMessages(t *testing.T) {
 	// Must NOT embed full file content.
 	if strings.Contains(content, "package main") {
 		t.Error("agentic patch message must not embed file content inline")
+	}
+}
+
+func TestBuildPatchMessagesOmittedCount(t *testing.T) {
+	bestFiles := map[string]string{"main.go": "package main\n"}
+	msgs := buildPatchMessages(nil, bestFiles, 80.0, 15)
+	content := msgs[0].Content
+	if !strings.Contains(content, "(15 other files not relevant to current failures, not shown)") {
+		t.Errorf("should contain omitted-files notice, got:\n%s", content)
+	}
+}
+
+func TestBuildPatchMessagesZeroOmitted(t *testing.T) {
+	bestFiles := map[string]string{"main.go": "package main\n"}
+	msgs := buildPatchMessages(nil, bestFiles, 80.0, 0)
+	content := msgs[0].Content
+	if strings.Contains(content, "other files not relevant") {
+		t.Errorf("should not contain omitted-files notice when omittedCount=0, got:\n%s", content)
 	}
 }

--- a/internal/attractor/triage.go
+++ b/internal/attractor/triage.go
@@ -1,0 +1,109 @@
+package attractor
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"maps"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/foundatron/octopusgarden/internal/llm"
+)
+
+// entryPointNames is the set of well-known entry point file base names (lower-cased)
+// that are always included in triage results regardless of LLM output.
+var entryPointNames = map[string]struct{}{
+	"dockerfile":       {},
+	"main.go":          {},
+	"main.py":          {},
+	"main.rs":          {},
+	"app.py":           {},
+	"app.js":           {},
+	"server.js":        {},
+	"index.js":         {},
+	"index.ts":         {},
+	"go.mod":           {},
+	"cargo.toml":       {},
+	"package.json":     {},
+	"requirements.txt": {},
+}
+
+// isEntryPoint reports whether path is a well-known entry point file.
+func isEntryPoint(path string) bool {
+	_, ok := entryPointNames[strings.ToLower(filepath.Base(path))]
+	return ok
+}
+
+// triageFiles asks the LLM to identify which files from allFiles are relevant to
+// the given failures. It returns a filtered map containing only the relevant files
+// plus any entry-point files present in allFiles.
+//
+// Skip conditions (returns allFiles, 0 with no LLM call):
+//   - len(allFiles) <= 5
+//   - len(failures) == 0
+//
+// On any error, logs a warning and returns allFiles, 0.
+func (a *Attractor) triageFiles(ctx context.Context, allFiles map[string]string, failures []string, model string) (map[string]string, float64) {
+	if len(allFiles) <= 5 || len(failures) == 0 {
+		return allFiles, 0
+	}
+
+	// Build sorted file path list for deterministic prompts.
+	paths := slices.Sorted(maps.Keys(allFiles))
+
+	var sb strings.Builder
+	sb.WriteString("Files in the current codebase:\n")
+	for _, p := range paths {
+		sb.WriteString(p)
+		sb.WriteString("\n")
+	}
+	sb.WriteString("\nFailures to fix:\n")
+	for _, f := range failures {
+		sb.WriteString(f)
+		sb.WriteString("\n")
+	}
+	sb.WriteString("\nReturn ONLY a JSON array of file paths (strings) that are most relevant to fixing these failures, no other text. Include only paths from the list above.")
+
+	resp, err := a.llm.Generate(ctx, llm.GenerateRequest{
+		SystemPrompt: "You are a code triage assistant. Respond with a raw JSON array only — no markdown, no explanation.",
+		Messages:     []llm.Message{{Role: "user", Content: sb.String()}},
+		Model:        model,
+		MaxTokens:    1024,
+	})
+	if err != nil {
+		slog.Warn("triage: LLM call failed, using all files", "error", err)
+		return allFiles, 0
+	}
+
+	cleaned := llm.ExtractJSON(resp.Content)
+	var suggested []string
+	if jsonErr := json.Unmarshal([]byte(cleaned), &suggested); jsonErr != nil {
+		slog.Warn("triage: failed to parse LLM response, using all files", "error", jsonErr)
+		return allFiles, resp.CostUSD
+	}
+
+	// Build result: LLM-suggested paths that actually exist + entry points from allFiles.
+	result := make(map[string]string)
+	for _, p := range suggested {
+		if content, ok := allFiles[p]; ok {
+			result[p] = content
+		}
+	}
+	// Always include entry points present in allFiles.
+	for p, content := range allFiles {
+		if isEntryPoint(p) {
+			result[p] = content
+		}
+	}
+
+	// Guard: if result is empty (LLM returned nothing useful), fall back to all files.
+	if len(result) == 0 {
+		slog.Warn("triage: result set empty after filtering, using all files")
+		return allFiles, resp.CostUSD
+	}
+
+	slog.Debug("triage: file set narrowed", "suggested", len(suggested), "result", len(result), "total", len(allFiles))
+	return result, resp.CostUSD
+}

--- a/internal/attractor/triage_test.go
+++ b/internal/attractor/triage_test.go
@@ -1,0 +1,193 @@
+package attractor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/foundatron/octopusgarden/internal/llm"
+)
+
+// makeFiles builds a map[string]string with n synthetic files plus any extras.
+func makeFiles(n int, extras ...string) map[string]string {
+	files := make(map[string]string, n+len(extras))
+	for i := range n {
+		files[fmt.Sprintf("file%02d.go", i)] = fmt.Sprintf("package main // file %d\n", i)
+	}
+	for _, e := range extras {
+		files[e] = "// entry\n"
+	}
+	return files
+}
+
+func TestTriageFilesSkipSmallSets(t *testing.T) {
+	a := &Attractor{
+		llm: &mockLLMClient{
+			generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+				panic("LLM should not be called for small file sets")
+			},
+		},
+	}
+	files := makeFiles(3)
+	failures := []string{"something broke"}
+	got, cost := a.triageFiles(context.Background(), files, failures, "")
+	if len(got) != len(files) {
+		t.Errorf("expected all %d files, got %d", len(files), len(got))
+	}
+	if cost != 0 {
+		t.Errorf("expected zero cost, got %f", cost)
+	}
+}
+
+func TestTriageFilesSkipNoFailures(t *testing.T) {
+	a := &Attractor{
+		llm: &mockLLMClient{
+			generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+				panic("LLM should not be called when there are no failures")
+			},
+		},
+	}
+	files := makeFiles(10)
+	got, cost := a.triageFiles(context.Background(), files, nil, "")
+	if len(got) != len(files) {
+		t.Errorf("expected all %d files, got %d", len(files), len(got))
+	}
+	if cost != 0 {
+		t.Errorf("expected zero cost, got %f", cost)
+	}
+}
+
+func TestTriageFilesReturnsSubset(t *testing.T) {
+	a := &Attractor{
+		llm: &mockLLMClient{
+			generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+				return llm.GenerateResponse{Content: `["file00.go","file01.go"]`}, nil
+			},
+		},
+	}
+	files := makeFiles(10)
+	failures := []string{"nil pointer in file00.go"}
+	got, _ := a.triageFiles(context.Background(), files, failures, "model")
+	if _, ok := got["file00.go"]; !ok {
+		t.Error("expected file00.go in result")
+	}
+	if _, ok := got["file01.go"]; !ok {
+		t.Error("expected file01.go in result")
+	}
+	// file05.go was not returned by LLM and is not an entry point.
+	if _, ok := got["file05.go"]; ok {
+		t.Error("file05.go should not be in result")
+	}
+}
+
+func TestTriageFilesAlwaysIncludesDockerfile(t *testing.T) {
+	a := &Attractor{
+		llm: &mockLLMClient{
+			generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+				return llm.GenerateResponse{Content: `["file00.go"]`}, nil
+			},
+		},
+	}
+	files := makeFiles(10, "Dockerfile")
+	failures := []string{"build failed"}
+	got, _ := a.triageFiles(context.Background(), files, failures, "model")
+	if _, ok := got["Dockerfile"]; !ok {
+		t.Error("Dockerfile should always be included")
+	}
+}
+
+func TestTriageFilesAlwaysIncludesEntryPoints(t *testing.T) {
+	a := &Attractor{
+		llm: &mockLLMClient{
+			generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+				return llm.GenerateResponse{Content: `["lib/util.go"]`}, nil
+			},
+		},
+	}
+	files := makeFiles(10, "main.go", "go.mod", "Dockerfile", "lib/util.go")
+	failures := []string{"compilation error"}
+	got, _ := a.triageFiles(context.Background(), files, failures, "model")
+	for _, ep := range []string{"main.go", "go.mod", "Dockerfile", "lib/util.go"} {
+		if _, ok := got[ep]; !ok {
+			t.Errorf("expected entry point %q in result", ep)
+		}
+	}
+}
+
+func TestTriageFilesFallbackOnError(t *testing.T) {
+	a := &Attractor{
+		llm: &mockLLMClient{
+			generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+				return llm.GenerateResponse{}, errors.New("network error")
+			},
+		},
+	}
+	files := makeFiles(10)
+	failures := []string{"something broke"}
+	got, cost := a.triageFiles(context.Background(), files, failures, "model")
+	if len(got) != len(files) {
+		t.Errorf("expected fallback to all %d files, got %d", len(files), len(got))
+	}
+	if cost != 0 {
+		t.Errorf("expected zero cost on error, got %f", cost)
+	}
+}
+
+func TestTriageFilesUnparseableJSON(t *testing.T) {
+	a := &Attractor{
+		llm: &mockLLMClient{
+			generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+				return llm.GenerateResponse{Content: "not json at all"}, nil
+			},
+		},
+	}
+	files := makeFiles(10)
+	failures := []string{"something broke"}
+	got, cost := a.triageFiles(context.Background(), files, failures, "model")
+	if len(got) != len(files) {
+		t.Errorf("expected fallback to all %d files on bad JSON, got %d", len(files), len(got))
+	}
+	if cost != 0 {
+		t.Errorf("expected zero cost on parse error, got %f", cost)
+	}
+}
+
+func TestTriageFilesUnknownPaths(t *testing.T) {
+	a := &Attractor{
+		llm: &mockLLMClient{
+			generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+				return llm.GenerateResponse{Content: `["nonexistent.go","file00.go"]`}, nil
+			},
+		},
+	}
+	files := makeFiles(10)
+	failures := []string{"error in file00.go"}
+	got, _ := a.triageFiles(context.Background(), files, failures, "model")
+	if _, ok := got["nonexistent.go"]; ok {
+		t.Error("nonexistent.go should be dropped from result")
+	}
+	if _, ok := got["file00.go"]; !ok {
+		t.Error("file00.go should be in result")
+	}
+}
+
+func TestTriageFilesCostTracked(t *testing.T) {
+	const wantCost = 0.001
+	a := &Attractor{
+		llm: &mockLLMClient{
+			generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+				return llm.GenerateResponse{
+					Content: `["file00.go"]`,
+					CostUSD: wantCost,
+				}, nil
+			},
+		},
+	}
+	files := makeFiles(10)
+	failures := []string{"error"}
+	_, cost := a.triageFiles(context.Background(), files, failures, "model")
+	if cost != wantCost {
+		t.Errorf("expected cost %f, got %f", wantCost, cost)
+	}
+}


### PR DESCRIPTION
Closes #198

## Changes
#### 1. `internal/attractor/triage.go` (new file)

Create `triageFiles()` method on `*Attractor`:

- **Signature**: `func (a *Attractor) triageFiles(ctx context.Context, allFiles map[string]string, failures []string, model string) (map[string]string, float64)`
- **Skip conditions** (no LLM call, return `allFiles, 0`):
  - `len(allFiles) <= 5`
  - `len(failures) == 0`
- **Build triage prompt**: System prompt: `"You are a code triage assistant."` User prompt: sorted file paths (one per line) + failure summaries, then instruction to return a JSON array of relevant file paths
- **LLM call**: `a.llm.Generate()` with the judge model, `MaxTokens: 1024`
- **Parse response**: `llm.ExtractJSON()` then `json.Unmarshal` into `[]string`
- **Build result**: Filter `allFiles` to only LLM-returned paths that exist in `allFiles` (silently drop unknowns)
- **Entry point heuristic**: Always include files whose `strings.ToLower(filepath.Base(path))` is in the entry point set: `dockerfile`, `main.go`, `main.py`, `main.rs`, `app.py`, `app.js`, `server.js`, `index.js`, `index.ts`, `go.mod`, `cargo.toml`, `package.json`, `requirements.txt`
- **Fallback**: On any error (LLM, JSON parse), `slog.Warn` and return `allFiles, 0`
- **Return**: `(relevant map[string]string, cost float64)`

Package-level: `var entryPointNames = map[string]bool{...}` and helper `func isEntryPoint(path string) bool`.

#### 2. `internal/attractor/prompts.go`

Modify `buildPatchMessages` signature to add `omittedCount int`:

```go
func buildPatchMessages(history []iterationFeedback, bestFiles map[string]string, bestScore float64, omittedCount int) []llm.Message
```

After the file blocks loop (after line 391, before steering text), when `omittedCount > 0`, append:
```go
fmt.Fprintf(&b, "\n(%d other files unchanged, not shown)\n\n", omittedCount)
```

#### 3. `internal/attractor/attractor.go`

In `generateStandard()` at the patch path (line 663-664):

```go
if patching {
    relevantFiles := s.bestFiles
    omitted := 0
    var triageCost float64
    relevantFiles, triageCost = a.triageFiles(ctx, s.bestFiles, s.lastFailures, s.opts.JudgeModel)
    s.totalCost += triageCost
    omitted = len(s.bestFiles) - len(relevantFiles)
    messages = buildPatchMessages(s.history, relevantFiles, s.bestSatisfaction, omitted)
}
```

Note: the `len > 5` and `len(failures) > 0` guards are inside `triageFiles`, so the call site stays simple.

## Review Findings
- Errors: 1
- Warnings: 3
- Nits: 5
- Assessment: **NEEDS CHANGES**

The main error is the cost tracking bug: when the LLM call succeeds but JSON parsing fails (or the result set is empty), `resp.CostUSD` is discarded and `0` is returned. This violates the "cost-aware by default" invariant. The fix is straightforward -- return `resp.CostUSD` instead of `0` on lines 78 and 91 of `triage.go`.
