### PR TITLE
feat(interview): seed mode for improving existing specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ Draft a spec interactively:
 ```bash
 # Conversational spec-drafting (outputs spec.md by default)
 octog interview --output my-spec.md
+
+# Improve an existing spec through targeted questions
+octog interview --seed my-spec.md --output my-spec.md
 ```
 
 Run the factory on the included examples:

--- a/cmd/octog/main.go
+++ b/cmd/octog/main.go
@@ -54,6 +54,7 @@ var (
 	errNoJudgeModelPricing        = errors.New("judge model has no pricing entry")
 	errInvalidFormat              = errors.New("--format must be \"text\" or \"json\"")
 	errInvalidProvider            = errors.New("--provider must be \"anthropic\" or \"openai\"")
+	errSeedAndPromptConflict      = errors.New("--seed and --prompt are mutually exclusive")
 	errInvalidParallelScenarios   = errors.New("--parallel-scenarios must be >= 1")
 	errInvalidLanguage            = errors.New("--language must be one of: go, python, node, rust, auto")
 	errListModelsUnsupported      = errors.New("provider does not support listing models")
@@ -1600,6 +1601,7 @@ func interviewCmd(ctx context.Context, logger *slog.Logger, args []string) error
 	model := fs.String("model", "", "LLM model to use (default: provider-specific)")
 	provider := fs.String("provider", "", "LLM provider: anthropic or openai (auto-detected from env if omitted)")
 	prompt := fs.String("prompt", "What would you like to build?", "opening question to start the interview")
+	seed := fs.String("seed", "", "path to existing spec file to improve (mutually exclusive with --prompt)")
 
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: octog interview [flags]\n\nInteractively draft a spec through conversation.\n\nFlags:\n")
@@ -1608,6 +1610,25 @@ func interviewCmd(ctx context.Context, logger *slog.Logger, args []string) error
 
 	if err := fs.Parse(args); err != nil {
 		return err
+	}
+
+	promptExplicit := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "prompt" {
+			promptExplicit = true
+		}
+	})
+	if *seed != "" && promptExplicit {
+		return errSeedAndPromptConflict
+	}
+
+	var seedContent string
+	if *seed != "" {
+		data, err := os.ReadFile(*seed)
+		if err != nil {
+			return fmt.Errorf("read seed: %w", err)
+		}
+		seedContent = string(data)
 	}
 
 	clients, err := newLLMClient(*provider, logger)
@@ -1619,14 +1640,24 @@ func interviewCmd(ctx context.Context, logger *slog.Logger, args []string) error
 	}
 	logger.Info("starting interview", "provider", clients.provider, "model", *model)
 
-	return interviewRun(ctx, clients.client, *model, *prompt, *output, os.Stdin, os.Stdout, os.Stderr)
+	return interviewRun(ctx, clients.client, *model, *prompt, *output, seedContent, os.Stdin, os.Stdout, os.Stderr)
 }
 
 // interviewRun runs the interview conversation and writes the resulting spec to
 // outputPath. Separated from interviewCmd for testability.
-func interviewRun(ctx context.Context, client llm.Client, model, initialPrompt, outputPath string, in io.Reader, out, errOut io.Writer) error {
+// When seedContent is non-empty, RunWithSeed is used instead of Run.
+func interviewRun(ctx context.Context, client llm.Client, model, initialPrompt, outputPath, seedContent string, in io.Reader, out, errOut io.Writer) error {
 	iv := interview.New(client, in, out, model)
-	spec, cost, err := iv.Run(ctx, initialPrompt)
+	var (
+		spec string
+		cost float64
+		err  error
+	)
+	if seedContent != "" {
+		spec, cost, err = iv.RunWithSeed(ctx, seedContent)
+	} else {
+		spec, cost, err = iv.Run(ctx, initialPrompt)
+	}
 	if err != nil {
 		return err
 	}

--- a/cmd/octog/main_test.go
+++ b/cmd/octog/main_test.go
@@ -1042,7 +1042,7 @@ func TestInterviewRun(t *testing.T) {
 			in := strings.NewReader(tt.userInput)
 			var out, errOut bytes.Buffer
 
-			err := interviewRun(context.Background(), client, "test-model", "What would you like to build?", outputPath, in, &out, &errOut)
+			err := interviewRun(context.Background(), client, "test-model", "What would you like to build?", outputPath, "", in, &out, &errOut)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")
@@ -1082,11 +1082,31 @@ func TestInterviewRun(t *testing.T) {
 		in := strings.NewReader("done\n")
 		var out, errOut bytes.Buffer
 
-		err := interviewRun(context.Background(), client, "model", "start", badPath, in, &out, &errOut)
+		err := interviewRun(context.Background(), client, "model", "start", badPath, "", in, &out, &errOut)
 		if err == nil {
 			t.Fatal("expected write error, got nil")
 		}
 	})
+}
+
+func TestInterviewSeedAndPromptConflict(t *testing.T) {
+	t.Parallel()
+	logger := testLogger()
+	ctx := context.Background()
+	err := interviewCmd(ctx, logger, []string{"--seed", "somefile.md", "--prompt", "hello"})
+	if !errors.Is(err, errSeedAndPromptConflict) {
+		t.Errorf("expected errSeedAndPromptConflict, got %v", err)
+	}
+}
+
+func TestInterviewSeedFileNotFound(t *testing.T) {
+	t.Parallel()
+	logger := testLogger()
+	ctx := context.Background()
+	err := interviewCmd(ctx, logger, []string{"--seed", "/nonexistent-spec-abc123.md"})
+	if err == nil {
+		t.Fatal("expected error for missing seed file, got nil")
+	}
 }
 
 func TestExtractCmdSourceDirNotExist(t *testing.T) {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -936,6 +936,30 @@ Four dimensions, each scored 0.0–1.0 (unweighted average):
 
 Returns per-scenario issues with dimension and actionable detail.
 
+## Conversational Spec-Drafting (`interview.Interviewer`)
+
+`interview.New(client llm.Client, in io.Reader, out io.Writer, model string) *Interviewer` — creates
+an interviewer that conducts a multi-turn conversation to produce a spec.
+
+```go
+func (i *Interviewer) Run(ctx context.Context, initialPrompt string) (string, float64, error)
+func (i *Interviewer) RunWithSeed(ctx context.Context, seedSpec string) (string, float64, error)
+```
+
+`Run` starts from scratch with an opening question (`initialPrompt`). `RunWithSeed` starts from an
+existing spec (`seedSpec`), injecting it into the first user message and switching to
+`seedSystemPrompt` — a variant that instructs the LLM to identify gaps and ambiguities rather than
+elicit requirements from scratch. Both methods share the same internal conversation loop (`run`),
+which accumulates messages, reads user replies from `in`, and terminates on `"done"` or EOF.
+
+Two system prompts live in `prompt.go`:
+
+- `systemPrompt` — standard spec-drafting persona
+- `seedSystemPrompt` — review/improvement persona; composed by prepending review instructions to
+  `systemPrompt` so the NLSpec dimension list stays in sync automatically
+
+`--seed` and `--prompt` are mutually exclusive (`errSeedAndPromptConflict`).
+
 ## Spec-Completeness Scoring (`interview.Scorer`)
 
 `interview.NewScorer(client llm.Client, model string) *Scorer` — scores a spec against five
@@ -993,7 +1017,7 @@ implement it). The service name is `octog`.
 ## CLI Interface
 
 ```text
-octog interview  [--output spec.md] [--model ...] [--provider anthropic|openai] [--prompt "What would you like to build?"]
+octog interview  [--output spec.md] [--model ...] [--provider anthropic|openai] [--prompt "What would you like to build?"] [--seed <existing-spec.md>]
 octog run        --spec <path> --scenarios <dir> [--model claude-sonnet-4-6] [--frugal-model ...] [--judge-model claude-haiku-4-5] [--budget 5.00] [--threshold 95] [--genes genes.json] [--language go] [--patch] [--block-on-regression] [--context-budget 0] [--otel-endpoint ...] [--skip-preflight] [--preflight-threshold 0.8] [-v 0|1|2] [--provider anthropic|openai]
 octog validate   --scenarios <dir> --target <url> [--grpc-target host:port] [--judge-model claude-haiku-4-5] [--threshold 0] [--format text|json] [-v 0|1|2] [--provider anthropic|openai]
 octog preflight  [--judge-model claude-haiku-4-5] [--threshold 0.8] [--verbose] [--scenarios <dir>] <spec-path>

--- a/internal/interview/interview.go
+++ b/internal/interview/interview.go
@@ -41,10 +41,21 @@ func New(client llm.Client, in io.Reader, out io.Writer, model string) *Intervie
 // Run conducts the interview starting with initialPrompt and returns the final
 // spec content and total LLM cost in USD.
 func (i *Interviewer) Run(ctx context.Context, initialPrompt string) (string, float64, error) {
-	messages := []llm.Message{{Role: "user", Content: initialPrompt}}
+	return i.run(ctx, systemPrompt, []llm.Message{{Role: "user", Content: initialPrompt}})
+}
 
+// RunWithSeed conducts the interview starting from an existing spec, asking
+// targeted questions to improve it. Returns the final spec and total LLM cost in USD.
+func (i *Interviewer) RunWithSeed(ctx context.Context, seedSpec string) (string, float64, error) {
+	userMsg := "Here is my current spec. Please review it for completeness and ask questions " +
+		"about anything that's missing or ambiguous:\n\n" + seedSpec
+	return i.run(ctx, seedSystemPrompt, []llm.Message{{Role: "user", Content: userMsg}})
+}
+
+// run is the shared conversation loop used by Run and RunWithSeed.
+func (i *Interviewer) run(ctx context.Context, sysPrompt string, messages []llm.Message) (string, float64, error) {
 	resp, err := i.client.Generate(ctx, llm.GenerateRequest{
-		SystemPrompt: systemPrompt,
+		SystemPrompt: sysPrompt,
 		Messages:     messages,
 		Model:        i.model,
 	})
@@ -76,13 +87,13 @@ func (i *Interviewer) Run(ctx context.Context, initialPrompt string) (string, fl
 			if round >= maxRounds {
 				fmt.Fprintln(i.out, "Maximum rounds reached. Generating spec now.") //nolint:errcheck
 			}
-			spec, cost, genErr := i.generateFinal(ctx, messages)
+			spec, cost, genErr := i.generateFinal(ctx, sysPrompt, messages)
 			return spec, totalCost + cost, genErr
 		}
 
 		messages = append(messages, llm.Message{Role: "user", Content: trimmed})
 		resp, err = i.client.Generate(ctx, llm.GenerateRequest{
-			SystemPrompt: systemPrompt,
+			SystemPrompt: sysPrompt,
 			Messages:     messages,
 			Model:        i.model,
 		})
@@ -101,16 +112,16 @@ func (i *Interviewer) Run(ctx context.Context, initialPrompt string) (string, fl
 	}
 
 	// EOF without "done" — treat as auto-generate.
-	spec, cost, err := i.generateFinal(ctx, messages)
+	spec, cost, err := i.generateFinal(ctx, sysPrompt, messages)
 	return spec, totalCost + cost, err
 }
 
-func (i *Interviewer) generateFinal(ctx context.Context, messages []llm.Message) (string, float64, error) {
+func (i *Interviewer) generateFinal(ctx context.Context, sysPrompt string, messages []llm.Message) (string, float64, error) {
 	msgs := make([]llm.Message, len(messages), len(messages)+1)
 	copy(msgs, messages)
 	msgs = append(msgs, llm.Message{Role: "user", Content: finalInstruction})
 	resp, err := i.client.Generate(ctx, llm.GenerateRequest{
-		SystemPrompt: systemPrompt,
+		SystemPrompt: sysPrompt,
 		Messages:     msgs,
 		Model:        i.model,
 	})

--- a/internal/interview/interview_test.go
+++ b/internal/interview/interview_test.go
@@ -258,3 +258,94 @@ func TestInterviewEOF(t *testing.T) {
 		t.Error("expected auto-generated spec on EOF")
 	}
 }
+
+func TestRunWithSeed(t *testing.T) {
+	t.Parallel()
+	const seedSpec = "## Purpose\nA todo app."
+	var capturedReqs []llm.GenerateRequest
+	calls := 0
+	responses := []llm.GenerateResponse{
+		{Content: "What persistence mechanism do you need?", CostUSD: 0.01},
+		{Content: "# Spec\n\n## Purpose\nAn improved todo app.", CostUSD: 0.02},
+	}
+
+	client := &mockClient{
+		generateFn: func(_ context.Context, req llm.GenerateRequest) (llm.GenerateResponse, error) {
+			capturedReqs = append(capturedReqs, req)
+			resp := responses[calls]
+			calls++
+			return resp, nil
+		},
+	}
+
+	in := strings.NewReader("done\n")
+	var out bytes.Buffer
+
+	iv := New(client, in, &out, "test-model")
+	spec, cost, err := iv.RunWithSeed(context.Background(), seedSpec)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if spec != "# Spec\n\n## Purpose\nAn improved todo app." {
+		t.Errorf("unexpected spec: %q", spec)
+	}
+
+	const wantCost = 0.01 + 0.02
+	if cost != wantCost {
+		t.Errorf("cost = %v, want %v", cost, wantCost)
+	}
+
+	// Verify system prompt is the seed variant.
+	if len(capturedReqs) == 0 {
+		t.Fatal("no generate calls captured")
+	}
+	if capturedReqs[0].SystemPrompt != seedSystemPrompt {
+		t.Errorf("expected seedSystemPrompt, got %q", capturedReqs[0].SystemPrompt)
+	}
+
+	// Verify first user message contains the seed spec content.
+	if len(capturedReqs[0].Messages) == 0 {
+		t.Fatal("no messages in first request")
+	}
+	if !strings.Contains(capturedReqs[0].Messages[0].Content, seedSpec) {
+		t.Errorf("first user message should contain seed spec, got %q", capturedReqs[0].Messages[0].Content)
+	}
+}
+
+func TestRunWithSeedPreservesConversationLoop(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	responses := []llm.GenerateResponse{
+		{Content: "What language?", CostUSD: 0.01},
+		{Content: "Any constraints?", CostUSD: 0.01},
+		{Content: "# Final Spec", CostUSD: 0.02},
+	}
+
+	client := &mockClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			resp := responses[calls]
+			calls++
+			return resp, nil
+		},
+	}
+
+	// Multi-round: answer one question then "done"
+	in := strings.NewReader("Go\ndone\n")
+	var out bytes.Buffer
+
+	iv := New(client, in, &out, "test-model")
+	spec, _, err := iv.RunWithSeed(context.Background(), "## Purpose\nA CLI tool.")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if spec != "# Final Spec" {
+		t.Errorf("unexpected spec: %q", spec)
+	}
+
+	// 3 calls: initial + answer to "Go" + final generation on "done"
+	if calls != 3 {
+		t.Errorf("expected 3 generate calls, got %d", calls)
+	}
+}

--- a/internal/interview/prompt.go
+++ b/internal/interview/prompt.go
@@ -21,3 +21,13 @@ Final spec format:
 - Use markdown with level-2 headings (##) for each NLSpec dimension.
 - Be precise and unambiguous. Avoid filler sentences.
 - Include only what is known; do not invent requirements.`
+
+// seedSystemPrompt is composed from systemPrompt with additional instructions for
+// reviewing an existing spec. Composed via concatenation so NLSpec dimension list
+// stays in sync with systemPrompt automatically.
+const seedSystemPrompt = "You are reviewing an existing software specification. " +
+	"Your role is to identify gaps, ambiguities, and missing NLSpec dimensions, " +
+	"then help the user improve it through targeted questions.\n\n" +
+	"Preserve what is already well-specified. " +
+	"Focus your questions on what is missing or unclear.\n\n" +
+	systemPrompt


### PR DESCRIPTION
Closes #207

## Changes
**1. `internal/interview/prompt.go`** -- Add seed system prompt

Add `seedSystemPrompt` composed from `systemPrompt` + seed-specific preamble. Structure: wrap `systemPrompt` content and prepend instructions about reviewing an existing spec, identifying gaps, preserving good parts. Use string concatenation to compose from `systemPrompt` so NLSpec dimensions stay in sync.

No separate `seedFinalInstruction` -- reuse the existing `finalInstruction`.

**2. `internal/interview/interview.go`** -- Add `RunWithSeed` + refactor

- Extract private method: `func (i *Interviewer) run(ctx context.Context, sysPrompt string, messages []llm.Message) (string, float64, error)` containing the current `Run` body (conversation loop + generateFinal call).
- Update `generateFinal` signature to accept `sysPrompt string` parameter instead of hardcoding `systemPrompt`.
- `Run(ctx, initialPrompt)` becomes: `return i.run(ctx, systemPrompt, []llm.Message{{Role: "user", Content: initialPrompt}})`
- Add `RunWithSeed(ctx context.Context, seedSpec string) (string, float64, error)`:
  - Constructs initial user message: `"Here is my current spec. Please review it for completeness and ask questions about anything that's missing or ambiguous:\n\n" + seedSpec`
  - Calls `i.run(ctx, seedSystemPrompt, []llm.Message{{Role: "user", Content: seedUserMsg}})`

**3. `cmd/octog/main.go`** -- Add `--seed` flag

In `interviewCmd`:
- Add `seed := fs.String("seed", "", "path to existing spec file to improve")`
- After parse, use `fs.Visit` to detect if `--prompt` was explicitly set
- If both `*seed != ""` and prompt was explicitly set, return `errSeedAndPromptConflict`
- When `*seed != ""`, read file with `os.ReadFile`, pass content to `interviewRun`
- Add sentinel: `var errSeedAndPromptConflict = errors.New("--seed and --prompt are mutually exclusive")`

In `interviewRun`:
- Add `seedContent string` parameter
- When `seedContent != ""`, call `iv.RunWithSeed(ctx, seedContent)` instead of `iv.Run(ctx, initialPrompt)`
- Update existing call site in `interviewCmd` to pass `""` for seedContent

## Review Findings
- Errors: 0
- Warnings: 0
- Nits: 4
- Assessment: **PASS**

Clean change. The refactor from `Run` → `run` with a shared loop is well-done — no code duplication, system prompt threaded correctly, mutual exclusivity of `--seed`/`--prompt` handled via `fs.Visit` (the idiomatic way to detect explicit flag usage). Test coverage is solid: conflict detection, missing file, seed conversation loop, multi-round preservation. Error wrapping follows project conventions.
