### PR TITLE
feat(gene): add Component struct for modular decomposition

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -184,8 +184,8 @@ content and failure feedback as strings. The validator (scenario runner + judge)
 
 - **Status**: Implemented
 - **Files**: `gene/scan.go`, `gene/analyze.go`, `gene/gene.go`, `attractor/prompts.go`
-- **Method**: Scan exemplar codebase for high-signal files within 20K token budget. LLM extracts structured pattern guide. Injected into system prompt.
-- **Limitations**: Single exemplar only. No multi-repo synthesis. No incremental update as generated code evolves. Patterns are extracted once, not refined based on generation outcomes.
+- **Method**: Scan exemplar codebase for high-signal files within 20K token budget. LLM extracts structured pattern guide including optional named `Component` entries (interface, patterns, dependency graph). `parseComponents` scans the guide for `**COMPONENT: <name>**` headers; `validateComponents` enforces non-empty unique names, declared dependencies exist, and no cycles (DFS). Guide and components stored in `Gene` JSON. Injected into system prompt.
+- **Limitations**: Single exemplar only. No multi-repo synthesis. No incremental update as generated code evolves. Patterns are extracted once, not refined based on generation outcomes. Component graph is validated but not yet used to order generation or scope prompts.
 
 ### Regression Tracking
 
@@ -1041,17 +1041,35 @@ pipeline: `gene.Scan` selects high-signal files (markers, README, Dockerfile, en
 models) within a ~20K token budget → `gene.Analyze` sends them to an LLM to produce a structured
 guide → the guide is stored as a `Gene` JSON file.
 
+When the LLM response includes `**COMPONENT: <name>**` headers, `parseComponents` extracts each
+component's `Interface`, `Patterns`, and `DependsOn` fields into `Component` structs stored on the
+`Gene`. `Validate` (via `validateComponents` + `detectComponentCycles`) enforces non-empty unique
+names, all declared dependencies exist, and the dependency graph is acyclic (DFS gray/black coloring).
+
+[embedmd]:# (../internal/gene/gene.go go /^\/\/ Component represents/ /^}/)
+```go
+// Component represents a named architectural component within a Gene,
+// with its interface description, patterns, and declared dependencies.
+type Component struct {
+	Name      string   `json:"name"`
+	Interface string   `json:"interface"`
+	Patterns  string   `json:"patterns"`
+	DependsOn []string `json:"depends_on,omitempty"`
+}
+```
+
 [embedmd]:# (../internal/gene/gene.go go /^\/\/ Gene represents/ /^}/)
 ```go
 // Gene represents an extracted coding guide for a specific language,
 // derived from a source repository's patterns and conventions.
 type Gene struct {
-	Version     int       `json:"version"`
-	Source      string    `json:"source"`
-	Language    string    `json:"language"`
-	ExtractedAt time.Time `json:"extracted_at"`
-	Guide       string    `json:"guide"`
-	TokenCount  int       `json:"token_count"`
+	Version     int         `json:"version"`
+	Source      string      `json:"source"`
+	Language    string      `json:"language"`
+	ExtractedAt time.Time   `json:"extracted_at"`
+	Guide       string      `json:"guide"`
+	TokenCount  int         `json:"token_count"`
+	Components  []Component `json:"components,omitempty"`
 }
 ```
 

--- a/internal/gene/analyze.go
+++ b/internal/gene/analyze.go
@@ -27,6 +27,12 @@ Respond with a concise guide covering these sections:
 **STRUCTURE** — Directory layout and what goes where.
 **BOOT** — How the application starts: entry point, config loading, dependency wiring, server listen.
 **BUILD** — Build tool, Dockerfile strategy, CI commands, and how to run locally.
+**COMPONENTS** — When the codebase has clear module boundaries (distinct service layers, adapters, or domain objects), identify each as a named component using the format below. Omit this section entirely for simple single-package applications.
+
+**COMPONENT: <name>**
+Interface: <what this component exposes to callers>
+Patterns: <key implementation patterns>
+DependsOn: <comma-separated component names, or none>
 
 Keep the guide under 800 words. Be specific — cite actual file paths, function names, and patterns from the source files provided. Do not include generic advice.`
 
@@ -57,6 +63,7 @@ func Analyze(ctx context.Context, logger *slog.Logger, client llm.Client, model 
 		ExtractedAt: time.Now(),
 		Guide:       guide,
 		TokenCount:  spec.EstimateTokens(guide),
+		Components:  parseComponents(guide),
 	}
 
 	logger.Info("gene extraction",
@@ -68,6 +75,103 @@ func Analyze(ctx context.Context, logger *slog.Logger, client llm.Client, model 
 	)
 
 	return g, nil
+}
+
+// parseComponents scans a gene guide for **COMPONENT: <name>** headers and extracts
+// each component's Interface, Patterns, and DependsOn fields. Returns nil when no
+// component headers are found. Component text is left in the guide (intentional; no
+// downstream consumer of Components requires stripping it yet).
+func parseComponents(guide string) []Component {
+	var components []Component
+	var current *Component
+	inPatterns := false
+
+	for _, line := range strings.Split(guide, "\n") {
+		trimmed := strings.TrimRight(line, " \t")
+
+		if name, ok := parseComponentHeader(trimmed); ok {
+			if current != nil {
+				components = append(components, *current)
+			}
+			current = &Component{Name: name}
+			inPatterns = false
+			continue
+		}
+
+		if current == nil {
+			continue
+		}
+
+		if nowInPatterns, matched := applyComponentField(current, trimmed); matched {
+			inPatterns = nowInPatterns
+			continue
+		}
+
+		if inPatterns && trimmed != "" {
+			// A bold header (e.g. **BUILD**) signals end of the components section;
+			// stop accumulating to prevent non-component guide text leaking into Patterns.
+			if strings.HasPrefix(trimmed, "**") {
+				inPatterns = false
+			} else {
+				current.Patterns += "\n" + trimmed
+			}
+		}
+	}
+
+	if current != nil {
+		components = append(components, *current)
+	}
+
+	if len(components) == 0 {
+		return nil
+	}
+	return components
+}
+
+// parseComponentHeader returns the component name if line matches **COMPONENT: <name>**.
+func parseComponentHeader(line string) (name string, ok bool) {
+	after, found := strings.CutPrefix(line, "**COMPONENT:")
+	if !found {
+		return "", false
+	}
+	return strings.TrimSpace(strings.TrimSuffix(after, "**")), true
+}
+
+// applyComponentField updates c when line matches a known field prefix.
+// Returns (true, true) when the Patterns field is matched (caller should accumulate
+// subsequent lines), (false, true) for any other matched field, (false, false) otherwise.
+func applyComponentField(c *Component, line string) (inPatterns bool, matched bool) {
+	if after, found := strings.CutPrefix(line, "Interface:"); found {
+		c.Interface = strings.TrimSpace(after)
+		return false, true
+	}
+	if after, found := strings.CutPrefix(line, "Patterns:"); found {
+		c.Patterns = strings.TrimSpace(after)
+		return true, true
+	}
+	if after, found := strings.CutPrefix(line, "DependsOn:"); found {
+		c.DependsOn = parseDependsOn(strings.TrimSpace(after))
+		return false, true
+	}
+	return false, false
+}
+
+// parseDependsOn splits a comma-separated dependency list; returns nil for empty or "none".
+func parseDependsOn(val string) []string {
+	if val == "" || strings.EqualFold(val, "none") {
+		return nil
+	}
+	parts := strings.Split(val, ",")
+	deps := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if dep := strings.TrimSpace(p); dep != "" {
+			deps = append(deps, dep)
+		}
+	}
+	if len(deps) == 0 {
+		return nil
+	}
+	return deps
 }
 
 func buildAnalyzeUserMessage(sourceDir string, scan ScanResult) string {

--- a/internal/gene/analyze_test.go
+++ b/internal/gene/analyze_test.go
@@ -155,6 +155,128 @@ func TestAnalyzeSetsTokenCount(t *testing.T) {
 	}
 }
 
+const cannedGuideWithComponents = `**PATTERN** — Layered HTTP server.
+**INVARIANTS** — Errors wrapped with fmt.Errorf.
+**EDGE CASES** — Timeouts via context.
+**STACK** — Go 1.24, net/http.
+**STRUCTURE** — cmd/ for entrypoints.
+**BOOT** — main.go creates server.
+**BUILD** — go build ./cmd/...
+**COMPONENT: Handler**
+Interface: Accepts HTTP requests
+Patterns: Uses net/http ServeHTTP
+DependsOn: Service
+**COMPONENT: Service**
+Interface: Business logic layer
+Patterns: Pure functions, no global state
+DependsOn: none`
+
+func TestParseComponents(t *testing.T) {
+	tests := []struct {
+		name  string
+		guide string
+		want  []Component
+	}{
+		{
+			name:  "no_components",
+			guide: cannedGuide,
+			want:  nil,
+		},
+		{
+			name:  "multiple_components",
+			guide: cannedGuideWithComponents,
+			want: []Component{
+				{Name: "Handler", Interface: "Accepts HTTP requests", Patterns: "Uses net/http ServeHTTP", DependsOn: []string{"Service"}},
+				{Name: "Service", Interface: "Business logic layer", Patterns: "Pure functions, no global state", DependsOn: nil},
+			},
+		},
+		{
+			name:  "depends_on_comma_separated",
+			guide: "**COMPONENT: C**\nInterface: foo\nPatterns: bar\nDependsOn: A, B",
+			want:  []Component{{Name: "C", Interface: "foo", Patterns: "bar", DependsOn: []string{"A", "B"}}},
+		},
+		{
+			name:  "depends_on_none",
+			guide: "**COMPONENT: D**\nInterface: foo\nPatterns: bar\nDependsOn: none",
+			want:  []Component{{Name: "D", Interface: "foo", Patterns: "bar", DependsOn: nil}},
+		},
+		{
+			name:  "multiline_patterns",
+			guide: "**COMPONENT: E**\nInterface: foo\nPatterns: first line\nsecond line\nthird line\nDependsOn: none",
+			want:  []Component{{Name: "E", Interface: "foo", Patterns: "first line\nsecond line\nthird line", DependsOn: nil}},
+		},
+		{
+			name:  "trailing_bold_header_does_not_leak_into_patterns",
+			guide: "**COMPONENT: F**\nInterface: foo\nPatterns: pattern one\n**BUILD** — go build ./cmd/...",
+			want:  []Component{{Name: "F", Interface: "foo", Patterns: "pattern one"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseComponents(tt.guide)
+			if len(got) != len(tt.want) {
+				t.Fatalf("parseComponents() len = %d, want %d: %+v", len(got), len(tt.want), got)
+			}
+			for i, c := range got {
+				w := tt.want[i]
+				if c.Name != w.Name {
+					t.Errorf("[%d] Name = %q, want %q", i, c.Name, w.Name)
+				}
+				if c.Interface != w.Interface {
+					t.Errorf("[%d] Interface = %q, want %q", i, c.Interface, w.Interface)
+				}
+				if c.Patterns != w.Patterns {
+					t.Errorf("[%d] Patterns = %q, want %q", i, c.Patterns, w.Patterns)
+				}
+				if len(c.DependsOn) != len(w.DependsOn) {
+					t.Errorf("[%d] DependsOn len = %d, want %d", i, len(c.DependsOn), len(w.DependsOn))
+				} else {
+					for j, dep := range c.DependsOn {
+						if dep != w.DependsOn[j] {
+							t.Errorf("[%d] DependsOn[%d] = %q, want %q", i, j, dep, w.DependsOn[j])
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestAnalyzeWithComponents(t *testing.T) {
+	mock := &mockClient{resp: llm.GenerateResponse{Content: cannedGuideWithComponents}}
+	g, err := Analyze(context.Background(), testAnalyzeLogger(), mock, "claude-haiku-4-5", "/src", testScanResult())
+	if err != nil {
+		t.Fatalf("Analyze() error = %v", err)
+	}
+	if len(g.Components) != 2 {
+		t.Fatalf("Components len = %d, want 2", len(g.Components))
+	}
+	if g.Components[0].Name != "Handler" {
+		t.Errorf("Components[0].Name = %q, want %q", g.Components[0].Name, "Handler")
+	}
+	if g.Components[1].Name != "Service" {
+		t.Errorf("Components[1].Name = %q, want %q", g.Components[1].Name, "Service")
+	}
+}
+
+func TestAnalyzeWithoutComponents(t *testing.T) {
+	mock := &mockClient{resp: llm.GenerateResponse{Content: cannedGuide}}
+	g, err := Analyze(context.Background(), testAnalyzeLogger(), mock, "claude-haiku-4-5", "/src", testScanResult())
+	if err != nil {
+		t.Fatalf("Analyze() error = %v", err)
+	}
+	if g.Components != nil {
+		t.Errorf("Components = %v, want nil", g.Components)
+	}
+}
+
+func TestExtractionPromptContainsComponentSection(t *testing.T) {
+	if !strings.Contains(extractionPrompt, "COMPONENT") {
+		t.Error("extractionPrompt missing COMPONENT section")
+	}
+}
+
 var errTestLLM = errors.New("test LLM error")
 
 func TestAnalyzeLLMError(t *testing.T) {

--- a/internal/gene/gene.go
+++ b/internal/gene/gene.go
@@ -5,13 +5,18 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 )
 
 var (
-	errInvalidVersion  = errors.New("version must be greater than zero")
-	errEmptyGuide      = errors.New("guide must not be empty")
-	errUnknownLanguage = errors.New("unknown language")
+	errInvalidVersion     = errors.New("version must be greater than zero")
+	errEmptyGuide         = errors.New("guide must not be empty")
+	errUnknownLanguage    = errors.New("unknown language")
+	errEmptyComponentName = errors.New("component name must not be empty")
+	errDuplicateComponent = errors.New("duplicate component name")
+	errMissingDependency  = errors.New("component dependency not found")
+	errDependencyCycle    = errors.New("dependency cycle detected")
 )
 
 var validLanguages = map[string]bool{
@@ -21,15 +26,25 @@ var validLanguages = map[string]bool{
 	"rust":   true,
 }
 
+// Component represents a named architectural component within a Gene,
+// with its interface description, patterns, and declared dependencies.
+type Component struct {
+	Name      string   `json:"name"`
+	Interface string   `json:"interface"`
+	Patterns  string   `json:"patterns"`
+	DependsOn []string `json:"depends_on,omitempty"`
+}
+
 // Gene represents an extracted coding guide for a specific language,
 // derived from a source repository's patterns and conventions.
 type Gene struct {
-	Version     int       `json:"version"`
-	Source      string    `json:"source"`
-	Language    string    `json:"language"`
-	ExtractedAt time.Time `json:"extracted_at"`
-	Guide       string    `json:"guide"`
-	TokenCount  int       `json:"token_count"`
+	Version     int         `json:"version"`
+	Source      string      `json:"source"`
+	Language    string      `json:"language"`
+	ExtractedAt time.Time   `json:"extracted_at"`
+	Guide       string      `json:"guide"`
+	TokenCount  int         `json:"token_count"`
+	Components  []Component `json:"components,omitempty"`
 }
 
 // Validate checks that the gene has valid field values.
@@ -43,6 +58,72 @@ func Validate(g Gene) error {
 	if !validLanguages[g.Language] {
 		return errUnknownLanguage
 	}
+	if len(g.Components) > 0 {
+		if err := validateComponents(g.Components); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateComponents checks for empty/duplicate names, missing dependencies, and dependency cycles.
+func validateComponents(components []Component) error {
+	names := make(map[string]bool, len(components))
+	for _, c := range components {
+		if c.Name == "" {
+			return errEmptyComponentName
+		}
+		if names[c.Name] {
+			return fmt.Errorf("component %q: %w", c.Name, errDuplicateComponent)
+		}
+		names[c.Name] = true
+	}
+
+	for _, c := range components {
+		for _, dep := range c.DependsOn {
+			if !names[dep] {
+				return fmt.Errorf("component %q depends on %q: %w", c.Name, dep, errMissingDependency)
+			}
+		}
+	}
+
+	return detectComponentCycles(components)
+}
+
+// detectComponentCycles runs a DFS over the component dependency graph and returns
+// errDependencyCycle (wrapped) if any cycle is found.
+func detectComponentCycles(components []Component) error {
+	adj := make(map[string][]string, len(components))
+	for _, c := range components {
+		adj[c.Name] = c.DependsOn
+	}
+	visited := make(map[string]bool, len(components))
+	inStack := make(map[string]bool, len(components))
+	for _, c := range components {
+		if err := dfsComponentCycle(c.Name, nil, adj, visited, inStack); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// dfsComponentCycle performs a single DFS step for cycle detection using gray/black coloring.
+func dfsComponentCycle(name string, path []string, adj map[string][]string, visited, inStack map[string]bool) error {
+	if inStack[name] {
+		return fmt.Errorf("dependency cycle %s: %w", strings.Join(append(path, name), " -> "), errDependencyCycle)
+	}
+	if visited[name] {
+		return nil
+	}
+	inStack[name] = true
+	newPath := append(path[:len(path):len(path)], name) // cap-limit forces fresh alloc on append
+	for _, dep := range adj[name] {
+		if err := dfsComponentCycle(dep, newPath, adj, visited, inStack); err != nil {
+			return err
+		}
+	}
+	inStack[name] = false
+	visited[name] = true
 	return nil
 }
 

--- a/internal/gene/gene_test.go
+++ b/internal/gene/gene_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -230,5 +231,152 @@ func TestSaveValidationFailure(t *testing.T) {
 
 	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
 		t.Error("Save() should not create file on validation failure")
+	}
+}
+
+func TestValidateComponents(t *testing.T) {
+	tests := []struct {
+		name       string
+		components []Component
+		wantErr    error
+	}{
+		{
+			name: "valid",
+			components: []Component{
+				{Name: "A", Interface: "Foo", Patterns: "bar", DependsOn: []string{"B"}},
+				{Name: "B", Interface: "Baz", Patterns: "qux"},
+			},
+			wantErr: nil,
+		},
+		{
+			name:       "empty_name",
+			components: []Component{{Name: ""}},
+			wantErr:    errEmptyComponentName,
+		},
+		{
+			name:       "duplicate_name",
+			components: []Component{{Name: "A"}, {Name: "A"}},
+			wantErr:    errDuplicateComponent,
+		},
+		{
+			name:       "missing_dependency",
+			components: []Component{{Name: "A", DependsOn: []string{"X"}}},
+			wantErr:    errMissingDependency,
+		},
+		{
+			name: "cycle_simple",
+			components: []Component{
+				{Name: "A", DependsOn: []string{"B"}},
+				{Name: "B", DependsOn: []string{"A"}},
+			},
+			wantErr: errDependencyCycle,
+		},
+		{
+			name: "cycle_longer",
+			components: []Component{
+				{Name: "A", DependsOn: []string{"B"}},
+				{Name: "B", DependsOn: []string{"C"}},
+				{Name: "C", DependsOn: []string{"A"}},
+			},
+			wantErr: errDependencyCycle,
+		},
+		{
+			name:       "self_cycle",
+			components: []Component{{Name: "A", DependsOn: []string{"A"}}},
+			wantErr:    errDependencyCycle,
+		},
+		{
+			name:       "no_dependencies",
+			components: []Component{{Name: "A"}, {Name: "B"}},
+			wantErr:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := validGene()
+			g.Components = tt.components
+			err := Validate(g)
+			if tt.wantErr == nil {
+				if err != nil {
+					t.Errorf("Validate() = %v, want nil", err)
+				}
+				return
+			}
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("Validate() = %v, want errors.Is(%v)", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestGeneRoundTripWithComponents(t *testing.T) {
+	t.Run("with_components", func(t *testing.T) {
+		original := validGene()
+		original.Components = []Component{
+			{Name: "A", Interface: "foo", Patterns: "bar", DependsOn: []string{"B"}},
+			{Name: "B", Interface: "baz", Patterns: "qux"},
+		}
+		data, err := json.Marshal(original)
+		if err != nil {
+			t.Fatalf("Marshal() error = %v", err)
+		}
+		var decoded Gene
+		if err := json.Unmarshal(data, &decoded); err != nil {
+			t.Fatalf("Unmarshal() error = %v", err)
+		}
+		if len(decoded.Components) != 2 {
+			t.Fatalf("Components len = %d, want 2", len(decoded.Components))
+		}
+		if decoded.Components[0].Name != "A" {
+			t.Errorf("Components[0].Name = %q, want %q", decoded.Components[0].Name, "A")
+		}
+		if decoded.Components[1].Name != "B" {
+			t.Errorf("Components[1].Name = %q, want %q", decoded.Components[1].Name, "B")
+		}
+	})
+
+	t.Run("omitempty_nil", func(t *testing.T) {
+		original := validGene() // Components is nil
+		data, err := json.Marshal(original)
+		if err != nil {
+			t.Fatalf("Marshal() error = %v", err)
+		}
+		if strings.Contains(string(data), `"components"`) {
+			t.Error(`JSON should not contain "components" key when Components is nil`)
+		}
+	})
+}
+
+func TestSaveLoadWithComponents(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gene-components.json")
+
+	original := validGene()
+	original.Components = []Component{
+		{Name: "Handler", Interface: "HTTP handler", Patterns: "net/http", DependsOn: []string{"Service"}},
+		{Name: "Service", Interface: "Business logic", Patterns: "pure functions"},
+	}
+
+	if err := Save(path, original); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if len(loaded.Components) != 2 {
+		t.Fatalf("Components len = %d, want 2", len(loaded.Components))
+	}
+	if loaded.Components[0].Name != "Handler" {
+		t.Errorf("Components[0].Name = %q, want %q", loaded.Components[0].Name, "Handler")
+	}
+	if loaded.Components[1].Name != "Service" {
+		t.Errorf("Components[1].Name = %q, want %q", loaded.Components[1].Name, "Service")
+	}
+	if len(loaded.Components[0].DependsOn) != 1 || loaded.Components[0].DependsOn[0] != "Service" {
+		t.Errorf("Components[0].DependsOn = %v, want [Service]", loaded.Components[0].DependsOn)
 	}
 }


### PR DESCRIPTION
Closes #183

## Changes
**1. `internal/gene/gene.go`**
- Add `Component` struct: `Name string`, `Interface string`, `Patterns string`, `DependsOn []string` (all JSON-tagged)
- Add `Components []Component` to `Gene` with `json:"components,omitempty"`
- Add sentinel errors: `errDuplicateComponent`, `errMissingDependency`, `errDependencyCycle`
- Add `validateComponents(components []Component) error` helper called from `Validate()` when `len(g.Components) > 0`:
  - Duplicate name check via `map[string]bool`
  - Missing dependency check (DependsOn references must exist in name set)
  - DFS cycle detection with `visited` + `inStack` coloring (handles disconnected subgraphs)
  - All errors wrapped with `fmt.Errorf("...: %w", sentinel)` so `errors.Is` works

**2. `internal/gene/analyze.go`**
- Extend `extractionPrompt`: add `**COMPONENTS**` section (keep under 100 words) instructing the LLM to identify component boundaries when clear module separation exists, using the `**COMPONENT: <name>**` / `Interface:` / `Patterns:` / `DependsOn:` format. Instruct omission for simple single-package apps.
- Add `parseComponents(guide string) []Component`: line-by-line state machine scanning for `**COMPONENT:` headers, extracting fields until next header or end-of-string. Returns `nil` when no headers found.
- In `Analyze()`, after `guide` is set, call `parseComponents(guide)` and assign to `g.Components`. Note: component text remains in `Guide` (no stripping); this is intentional since no downstream consumer of `Components` exists yet.

## Review Findings
- Errors: 0
- Warnings: 1
- Nits: 5
- Assessment: **NEEDS CHANGES**

The warning about pattern continuation leaking non-component text is the only actionable item. A simple fix: stop accumulating into `currentField` when hitting a line that starts with `**` (a markdown bold header), which would signal the end of the components section.
