### PR TITLE
feat(interview): scenario generation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ Draft a spec interactively:
 # Conversational spec-drafting (outputs spec.md by default)
 octog interview --output my-spec.md
 
+# Also generate holdout scenario YAML files alongside the spec
+octog interview --output my-spec.md --scenarios
+
 # Improve an existing spec through targeted questions
 octog interview --seed my-spec.md --output my-spec.md
 ```

--- a/cmd/octog/main.go
+++ b/cmd/octog/main.go
@@ -1602,6 +1602,7 @@ func interviewCmd(ctx context.Context, logger *slog.Logger, args []string) error
 	provider := fs.String("provider", "", "LLM provider: anthropic or openai (auto-detected from env if omitted)")
 	prompt := fs.String("prompt", "What would you like to build?", "opening question to start the interview")
 	seed := fs.String("seed", "", "path to existing spec file to improve (mutually exclusive with --prompt)")
+	scenarios := fs.Bool("scenarios", false, "generate holdout scenario YAML files alongside the spec")
 
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: octog interview [flags]\n\nInteractively draft a spec through conversation.\n\nFlags:\n")
@@ -1640,13 +1641,15 @@ func interviewCmd(ctx context.Context, logger *slog.Logger, args []string) error
 	}
 	logger.Info("starting interview", "provider", clients.provider, "model", *model)
 
-	return interviewRun(ctx, clients.client, *model, *prompt, *output, seedContent, os.Stdin, os.Stdout, os.Stderr)
+	return interviewRun(ctx, clients.client, *model, *prompt, *output, seedContent, *scenarios, logger, os.Stdin, os.Stdout, os.Stderr)
 }
 
 // interviewRun runs the interview conversation and writes the resulting spec to
 // outputPath. Separated from interviewCmd for testability.
 // When seedContent is non-empty, RunWithSeed is used instead of Run.
-func interviewRun(ctx context.Context, client llm.Client, model, initialPrompt, outputPath, seedContent string, in io.Reader, out, errOut io.Writer) error {
+// When generateScenarios is true, scenario YAML files are generated and written
+// to a scenarios/ directory alongside the spec.
+func interviewRun(ctx context.Context, client llm.Client, model, initialPrompt, outputPath, seedContent string, generateScenarios bool, log *slog.Logger, in io.Reader, out, errOut io.Writer) error {
 	iv := interview.New(client, in, out, model)
 	var (
 		spec string
@@ -1666,12 +1669,51 @@ func interviewRun(ctx context.Context, client llm.Client, model, initialPrompt, 
 		return fmt.Errorf("write spec: %w", err)
 	}
 
-	costStr := fmt.Sprintf("$%.4f", cost)
+	specCostStr := fmt.Sprintf("$%.4f", cost)
 	if cost == 0 {
-		costStr = "free"
+		specCostStr = "free"
 	}
-	fmt.Fprintf(errOut, "Spec written to %s (cost: %s)\n", outputPath, costStr) //nolint:gosec,errcheck // G705 false positive: writing to stderr, not an HTTP response
+	fmt.Fprintf(errOut, "Spec written to %s (cost: %s)\n", outputPath, specCostStr) //nolint:gosec,errcheck // G705 false positive: writing to stderr, not an HTTP response
+
+	totalCost := cost
+	if generateScenarios {
+		scenarioCost, err := writeGeneratedScenarios(ctx, client, model, spec, outputPath, log, errOut)
+		if err != nil {
+			return err
+		}
+		totalCost += scenarioCost
+	}
+
+	if generateScenarios {
+		totalCostStr := fmt.Sprintf("$%.4f", totalCost)
+		fmt.Fprintf(errOut, "Total cost: %s\n", totalCostStr) //nolint:gosec,errcheck // G705 false positive: writing to errOut, not an HTTP response
+	}
 	return nil
+}
+
+// writeGeneratedScenarios generates scenario YAML files and writes them to a
+// scenarios/ directory alongside outputPath. Returns the LLM cost incurred.
+func writeGeneratedScenarios(ctx context.Context, client llm.Client, model, specContent, outputPath string, log *slog.Logger, errOut io.Writer) (float64, error) {
+	gen := interview.NewScenarioGenerator(client, model, log)
+	files, cost, err := gen.Generate(ctx, specContent)
+	if err != nil {
+		return cost, fmt.Errorf("generate scenarios: %w", err)
+	}
+
+	dir := filepath.Join(filepath.Dir(outputPath), "scenarios")
+	if err := os.MkdirAll(dir, 0o755); err != nil { //nolint:gosec // G301: scenarios/ is user-facing output directory
+		return cost, fmt.Errorf("create scenarios dir: %w", err)
+	}
+
+	for name, content := range files {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil { //nolint:gosec // G306: scenario files are user-facing documents
+			return cost, fmt.Errorf("write scenario %s: %w", name, err)
+		}
+	}
+
+	fmt.Fprintf(errOut, "Scenarios written to %s (%d file(s))\n", dir, len(files)) //nolint:gosec,errcheck // G705 false positive: writing to errOut (io.Writer), not an HTTP response
+	return cost, nil
 }
 
 func configureCmd(_ context.Context, _ *slog.Logger, args []string) error {

--- a/cmd/octog/main_test.go
+++ b/cmd/octog/main_test.go
@@ -1042,7 +1042,7 @@ func TestInterviewRun(t *testing.T) {
 			in := strings.NewReader(tt.userInput)
 			var out, errOut bytes.Buffer
 
-			err := interviewRun(context.Background(), client, "test-model", "What would you like to build?", outputPath, "", in, &out, &errOut)
+			err := interviewRun(context.Background(), client, "test-model", "What would you like to build?", outputPath, "", false, testLogger(), in, &out, &errOut)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")
@@ -1082,7 +1082,7 @@ func TestInterviewRun(t *testing.T) {
 		in := strings.NewReader("done\n")
 		var out, errOut bytes.Buffer
 
-		err := interviewRun(context.Background(), client, "model", "start", badPath, "", in, &out, &errOut)
+		err := interviewRun(context.Background(), client, "model", "start", badPath, "", false, testLogger(), in, &out, &errOut)
 		if err == nil {
 			t.Fatal("expected write error, got nil")
 		}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,8 +87,10 @@ cmd/octog
     │       ├── internal/llm
     │       ├── internal/spec
     │       └── internal/container
-    ├── internal/interview      (conversational spec-drafting, multi-turn LLM)
-    │       └── internal/llm
+    ├── internal/interview      (conversational spec-drafting, multi-turn LLM, scenario generation)
+    │       ├── internal/llm
+    │       ├── internal/attractor  (ParseFiles for scenario block extraction)
+    │       └── internal/scenario   (Load for scenario YAML validation)
     ├── internal/preflight      (spec clarity, scenario quality assessment)
     │       └── internal/llm
     ├── internal/gene           (scan, analyze, gene types)
@@ -119,7 +121,7 @@ content and failure feedback as strings. The validator (scenario runner + judge)
 | `spec` | Parse markdown specs, pyramid summarization | `parser.go`, `types.go`, `summary.go` | (none) |
 | `llm` | Model-agnostic LLM client, cost tracking, prompt templates | `client.go`, `anthropic.go`, `openai.go`, `models.go`, `json.go`, `prompt.go` | anthropic-sdk, openai-sdk |
 | `gene` | Scan exemplar codebases, LLM pattern extraction | `gene.go`, `scan.go`, `analyze.go` | `llm`, `spec` |
-| `interview` | Conversational spec-drafting and spec-completeness scoring | `interview.go`, `prompt.go`, `scoring.go`, `scoring_prompt.go` | `llm` |
+| `interview` | Conversational spec-drafting, spec-completeness scoring, holdout scenario generation | `interview.go`, `prompt.go`, `scoring.go`, `scoring_prompt.go`, `scenarios.go`, `scenarios_prompt.go` | `llm`, `attractor`, `scenario` |
 | `preflight` | Pre-run quality assessment of specs and scenarios | `preflight.go`, `scenario.go` | `llm` |
 | `lint` | Structural linting for specs and scenario YAML | `spec.go`, `scenario.go`, `diagnostic.go`, `varcheck.go` | (none) |
 | `observability` | OpenTelemetry tracing wrappers | `setup.go` | `llm`, `container`, otel SDK |
@@ -1003,6 +1005,37 @@ LLM is called with `Temperature=0`, `MaxTokens=4096`, and `CacheControl: ephemer
 prompt. Response must be a JSON object with exactly five named dimensions; scores are clamped to
 [0, 100]. Sentinel errors: `errEmptySpec`, `errMalformedResponse`, `errIncompleteDimensions`.
 
+## Holdout Scenario Generation (`interview.ScenarioGenerator`)
+
+`interview.NewScenarioGenerator(client llm.Client, model string, log *slog.Logger) *ScenarioGenerator`
+— generates holdout validation scenario YAML files from a spec using an LLM. Invoked by
+`octog interview --scenarios`.
+
+```go
+func (g *ScenarioGenerator) Generate(ctx context.Context, specContent string) (map[string]string, float64, error)
+```
+
+Returns a map of filename → YAML content, LLM cost in USD, and any error.
+
+Pipeline:
+
+1. LLM is called with `scenarioSystemPrompt` (system) + spec content (user message), `Temperature=0.7`,
+   `MaxTokens=8192`, `CacheControl: ephemeral`.
+2. Response is parsed with `attractor.ParseFiles` to extract `=== FILE: name === … === END FILE ===`
+   blocks. If no blocks are found, returns `errParseScenarioOutput`.
+3. Each filename is sanitized with `filepath.Base` (strips any directory prefix LLM may emit).
+   Filenames containing `..` or equal to `.` are dropped with a warning log.
+4. Each YAML block is validated with `scenario.Load`; invalid blocks are dropped with a warning log.
+5. Filename collisions (after base-name normalization) keep the first occurrence.
+6. If no valid scenarios survive, returns `errNoValidScenarios`.
+
+Sentinel errors: `errEmptySpec` (shared with `Scorer`), `errParseScenarioOutput`,
+`errNoValidScenarios`.
+
+`cmd/octog.writeGeneratedScenarios` wraps `ScenarioGenerator.Generate`, writes files to a
+`scenarios/` directory adjacent to the spec output path, and returns the LLM cost for
+aggregated cost reporting.
+
 ## Observability
 
 OpenTelemetry tracing is enabled via `--otel-endpoint` (or `OTEL_EXPORTER_OTLP_ENDPOINT` env var).
@@ -1017,7 +1050,7 @@ implement it). The service name is `octog`.
 ## CLI Interface
 
 ```text
-octog interview  [--output spec.md] [--model ...] [--provider anthropic|openai] [--prompt "What would you like to build?"] [--seed <existing-spec.md>]
+octog interview  [--output spec.md] [--model ...] [--provider anthropic|openai] [--prompt "What would you like to build?"] [--seed <existing-spec.md>] [--scenarios]
 octog run        --spec <path> --scenarios <dir> [--model claude-sonnet-4-6] [--frugal-model ...] [--judge-model claude-haiku-4-5] [--budget 5.00] [--threshold 95] [--genes genes.json] [--language go] [--patch] [--block-on-regression] [--context-budget 0] [--otel-endpoint ...] [--skip-preflight] [--preflight-threshold 0.8] [-v 0|1|2] [--provider anthropic|openai]
 octog validate   --scenarios <dir> --target <url> [--grpc-target host:port] [--judge-model claude-haiku-4-5] [--threshold 0] [--format text|json] [-v 0|1|2] [--provider anthropic|openai]
 octog preflight  [--judge-model claude-haiku-4-5] [--threshold 0.8] [--verbose] [--scenarios <dir>] <spec-path>

--- a/internal/interview/scenarios.go
+++ b/internal/interview/scenarios.go
@@ -1,0 +1,91 @@
+package interview
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"strings"
+
+	"github.com/foundatron/octopusgarden/internal/attractor"
+	"github.com/foundatron/octopusgarden/internal/llm"
+	"github.com/foundatron/octopusgarden/internal/scenario"
+)
+
+// scenarioMaxTokens is the maximum number of tokens to request when generating
+// scenario YAML from a spec.
+const scenarioMaxTokens = 8192
+
+var (
+	errNoValidScenarios    = errors.New("interview: no valid scenarios generated")
+	errParseScenarioOutput = errors.New("interview: failed to parse scenario output")
+)
+
+// ScenarioGenerator generates holdout validation scenarios from a spec using an LLM.
+type ScenarioGenerator struct {
+	client llm.Client
+	model  string
+	log    *slog.Logger
+}
+
+// NewScenarioGenerator creates a ScenarioGenerator that uses the given LLM client and model.
+func NewScenarioGenerator(client llm.Client, model string, log *slog.Logger) *ScenarioGenerator {
+	return &ScenarioGenerator{client: client, model: model, log: log}
+}
+
+// Generate generates scenario YAML files from specContent.
+// Returns a map of filename to YAML content, the LLM cost in USD, and any error.
+func (g *ScenarioGenerator) Generate(ctx context.Context, specContent string) (map[string]string, float64, error) {
+	if strings.TrimSpace(specContent) == "" {
+		return nil, 0, errEmptySpec
+	}
+
+	temp := 0.7
+	req := llm.GenerateRequest{
+		SystemPrompt: scenarioSystemPrompt,
+		Messages:     []llm.Message{{Role: "user", Content: specContent}},
+		Model:        g.model,
+		MaxTokens:    scenarioMaxTokens,
+		Temperature:  &temp,
+		CacheControl: &llm.CacheControl{Type: "ephemeral"},
+	}
+
+	resp, err := g.client.Generate(ctx, req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("scenario generator: %w", err)
+	}
+
+	raw, err := attractor.ParseFiles(resp.Content)
+	if err != nil {
+		return nil, resp.CostUSD, fmt.Errorf("%w: %w", errParseScenarioOutput, err)
+	}
+
+	valid := make(map[string]string, len(raw))
+	for name, content := range raw {
+		cleaned := filepath.Base(name)
+
+		if strings.Contains(cleaned, "..") || cleaned == "." {
+			g.log.Warn("generated scenario has unsafe filename, skipping", "file", name)
+			continue
+		}
+
+		if _, loadErr := scenario.Load(strings.NewReader(content)); loadErr != nil {
+			g.log.Warn("generated scenario failed validation, skipping", "file", name, "err", loadErr)
+			continue
+		}
+
+		if existing, collision := valid[cleaned]; collision {
+			g.log.Warn("generated scenario filename collision, keeping first",
+				"file", name, "cleaned", cleaned, "existing_length", len(existing))
+			continue
+		}
+		valid[cleaned] = content
+	}
+
+	if len(valid) == 0 {
+		return nil, resp.CostUSD, errNoValidScenarios
+	}
+
+	return valid, resp.CostUSD, nil
+}

--- a/internal/interview/scenarios_prompt.go
+++ b/internal/interview/scenarios_prompt.go
@@ -1,0 +1,154 @@
+package interview
+
+const scenarioSystemPrompt = `You are a scenario generator for OctopusGarden, an autonomous software factory.
+Given a software specification, generate a set of holdout validation scenarios in YAML format.
+
+## Scenario YAML Schema
+
+Each scenario file contains one scenario with the following structure:
+
+` + "```yaml" + `
+id: unique-kebab-case-identifier
+description: Human-readable description of what this scenario tests
+type: api
+weight: 1.0                    # optional, defaults to 1.0; higher = more important
+satisfaction_criteria: |
+  Describe in natural language what success looks like for a human judge.
+  Be specific about observable outcomes.
+
+setup:                         # optional; steps that run before judged steps (failures are fatal)
+  - description: Seed test data
+    exec:
+      command: "./seed.sh"
+    expect: Exit code 0, database seeded successfully
+
+steps:                         # required; the judged steps
+  - description: What this step tests
+    request:
+      method: GET
+      path: /api/resource
+      headers:
+        Authorization: "Bearer {{token}}"
+    expect: Returns 200 with the resource object
+    capture:
+      - name: resource_id
+        jsonpath: $.id
+
+  - description: Use a captured variable
+    request:
+      method: DELETE
+      path: /api/resource/{{resource_id}}
+    expect: Returns 204 No Content
+` + "```" + `
+
+## Step Types
+
+### HTTP Request (request)
+` + "```yaml" + `
+request:
+  method: POST
+  path: /api/items
+  headers:
+    Content-Type: application/json
+  body:
+    name: "test item"
+    value: 42
+` + "```" + `
+
+### CLI Command (exec)
+` + "```yaml" + `
+exec:
+  command: "myapp --flag value"
+  stdin: "optional stdin input"
+  timeout: "30s"
+` + "```" + `
+
+## Capture and Variable Substitution
+
+Capture values from responses for use in later steps:
+` + "```yaml" + `
+capture:
+  - name: item_id         # use as {{item_id}} in later steps
+    jsonpath: $.id        # dot-notation JSONPath into response body
+  - name: status_code
+    source: exitcode      # for exec steps: stdout, stderr, exitcode
+` + "```" + `
+
+## Output Format
+
+Output each scenario as a separate file block using EXACTLY this format.
+The === END FILE === terminator is REQUIRED — blocks without it are discarded.
+
+=== FILE: scenario-name.yaml ===
+id: scenario-name
+description: ...
+...
+=== END FILE ===
+
+Rules:
+- File names must be bare filenames only — no directory prefix (e.g., "happy-path.yaml" not "scenarios/happy-path.yaml")
+- Each file contains exactly one scenario
+- Use kebab-case for IDs and filenames (they should match)
+- Generate 3–5 scenarios that together provide good coverage
+
+## What Makes a Good Scenario Set
+
+- **Happy path**: The primary use case with valid inputs returns the expected result
+- **Error cases**: Invalid inputs, missing auth, not-found resources return appropriate errors
+- **Edge cases**: Boundary values, empty collections, concurrent operations
+- **Each scenario is independently runnable**: no hidden dependencies between scenarios
+- **Descriptive IDs**: "create-item-happy-path" not "test1"
+- **Specific satisfaction criteria**: describe observable outcomes, not implementation details
+
+## Example
+
+For a simple note-taking API:
+
+=== FILE: create-note-happy-path.yaml ===
+id: create-note-happy-path
+description: Creating a note with valid data returns the new note with an assigned ID
+type: api
+satisfaction_criteria: |
+  The API accepts a POST request with a title and body, persists the note,
+  and returns the created note with a non-empty id field and a 201 status code.
+steps:
+  - description: Create a note
+    request:
+      method: POST
+      path: /notes
+      headers:
+        Content-Type: application/json
+      body:
+        title: "Meeting notes"
+        body: "Discussed Q1 roadmap"
+    expect: Returns 201 with the created note including an id field
+    capture:
+      - name: note_id
+        jsonpath: $.id
+  - description: Retrieve the created note
+    request:
+      method: GET
+      path: /notes/{{note_id}}
+    expect: Returns 200 with the same title and body
+=== END FILE ===
+
+=== FILE: create-note-missing-title.yaml ===
+id: create-note-missing-title
+description: Creating a note without a title returns a validation error
+type: api
+satisfaction_criteria: |
+  The API rejects requests missing the required title field with a 400 status
+  and an error message indicating which field is missing.
+steps:
+  - description: Attempt to create a note without a title
+    request:
+      method: POST
+      path: /notes
+      headers:
+        Content-Type: application/json
+      body:
+        body: "No title here"
+    expect: Returns 400 with an error message mentioning the missing title field
+=== END FILE ===
+
+Now generate scenarios for the specification provided by the user.`

--- a/internal/interview/scenarios_test.go
+++ b/internal/interview/scenarios_test.go
@@ -1,0 +1,374 @@
+package interview
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"maps"
+	"slices"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/foundatron/octopusgarden/internal/llm"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// validScenarioBlock returns a well-formed scenario file block for use in tests.
+func validScenarioBlock(name, id string) string {
+	return "=== FILE: " + name + " ===\n" +
+		"id: " + id + "\n" +
+		"description: Test scenario " + id + "\n" +
+		"type: api\n" +
+		"satisfaction_criteria: |\n" +
+		"  Returns 200 with expected payload.\n" +
+		"steps:\n" +
+		"  - description: Call the endpoint\n" +
+		"    request:\n" +
+		"      method: GET\n" +
+		"      path: /items\n" +
+		"    expect: Returns 200 OK\n" +
+		"=== END FILE ===\n"
+}
+
+func TestGenerateHappyPath(t *testing.T) {
+	t.Parallel()
+	var capturedReq llm.GenerateRequest
+	body := validScenarioBlock("happy-path.yaml", "happy-path") +
+		validScenarioBlock("error-case.yaml", "error-case")
+
+	client := &mockClient{
+		generateFn: func(_ context.Context, req llm.GenerateRequest) (llm.GenerateResponse, error) {
+			capturedReq = req
+			return llm.GenerateResponse{Content: body, CostUSD: 0.03}, nil
+		},
+	}
+
+	gen := NewScenarioGenerator(client, "test-model", discardLogger())
+	files, cost, err := gen.Generate(context.Background(), "# My Spec\n\nSome content.")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(files) != 2 {
+		t.Errorf("expected 2 files, got %d", len(files))
+	}
+	if _, ok := files["happy-path.yaml"]; !ok {
+		t.Error("expected happy-path.yaml in result")
+	}
+	if _, ok := files["error-case.yaml"]; !ok {
+		t.Error("expected error-case.yaml in result")
+	}
+	if cost != 0.03 {
+		t.Errorf("CostUSD = %v, want 0.03", cost)
+	}
+
+	// Verify cache control and temperature were set.
+	if capturedReq.CacheControl == nil || capturedReq.CacheControl.Type != "ephemeral" {
+		t.Errorf("expected CacheControl ephemeral, got %+v", capturedReq.CacheControl)
+	}
+	if capturedReq.Temperature == nil || *capturedReq.Temperature != 0.7 {
+		t.Errorf("expected Temperature 0.7, got %v", capturedReq.Temperature)
+	}
+
+	// Each file must round-trip through scenario.Load (validated inside Generate already,
+	// but verify content is non-empty as a sanity check).
+	for name, content := range files {
+		if strings.TrimSpace(content) == "" {
+			t.Errorf("file %s has empty content", name)
+		}
+	}
+}
+
+func TestGeneratePartialInvalid(t *testing.T) {
+	t.Parallel()
+	// One valid scenario, one without an id (invalid).
+	validBlock := validScenarioBlock("good.yaml", "good-scenario")
+	invalidBlock := "=== FILE: bad.yaml ===\n" +
+		"description: Missing id field\n" +
+		"type: api\n" +
+		"=== END FILE ===\n"
+
+	client := &mockClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{Content: validBlock + invalidBlock, CostUSD: 0.01}, nil
+		},
+	}
+
+	gen := NewScenarioGenerator(client, "test-model", discardLogger())
+	files, _, err := gen.Generate(context.Background(), "# Spec")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(files) != 1 {
+		t.Errorf("expected 1 valid file, got %d", len(files))
+	}
+	if _, ok := files["good.yaml"]; !ok {
+		t.Error("expected good.yaml in result")
+	}
+	if _, ok := files["bad.yaml"]; ok {
+		t.Error("bad.yaml should have been excluded")
+	}
+}
+
+func TestGenerateLLMError(t *testing.T) {
+	t.Parallel()
+	errAPI := errors.New("api failure")
+	client := &mockClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{}, errAPI
+		},
+	}
+
+	gen := NewScenarioGenerator(client, "test-model", discardLogger())
+	_, _, err := gen.Generate(context.Background(), "# Spec")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, errAPI) {
+		t.Errorf("expected errAPI in chain, got %v", err)
+	}
+}
+
+func TestGenerateNoValidOutput(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		content string
+		wantErr error
+	}{
+		{
+			name:    "no blocks at all",
+			content: "Here are your scenarios: (none)",
+			wantErr: errParseScenarioOutput,
+		},
+		{
+			name: "all blocks missing END FILE",
+			content: "=== FILE: foo.yaml ===\n" +
+				"id: foo\n" +
+				"description: unclosed block\n",
+			wantErr: errParseScenarioOutput,
+		},
+		{
+			name: "blocks present but all invalid YAML",
+			content: "=== FILE: invalid.yaml ===\n" +
+				"description: no id field\n" +
+				"type: api\n" +
+				"=== END FILE ===\n",
+			wantErr: errNoValidScenarios,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			client := &mockClient{
+				generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+					return llm.GenerateResponse{Content: tt.content}, nil
+				},
+			}
+
+			gen := NewScenarioGenerator(client, "test-model", discardLogger())
+			_, _, err := gen.Generate(context.Background(), "# Spec")
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("expected %v, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestGenerateEmptySpec(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int32
+	client := &mockClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			calls.Add(1)
+			return llm.GenerateResponse{}, nil
+		},
+	}
+
+	gen := NewScenarioGenerator(client, "test-model", discardLogger())
+	tests := []struct {
+		name string
+		spec string
+	}{
+		{"empty string", ""},
+		{"whitespace only", "   \n\t  "},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, _, err := gen.Generate(context.Background(), tt.spec)
+			if !errors.Is(err, errEmptySpec) {
+				t.Errorf("expected errEmptySpec, got %v", err)
+			}
+		})
+	}
+
+	if c := calls.Load(); c != 0 {
+		t.Errorf("LLM should not be called for empty spec, got %d calls", c)
+	}
+}
+
+func TestGenerateStripsDirectoryPrefix(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		filename string
+		wantKey  string
+	}{
+		{
+			name:     "scenarios/ prefix",
+			filename: "scenarios/foo.yaml",
+			wantKey:  "foo.yaml",
+		},
+		{
+			name:     "./scenarios/ prefix",
+			filename: "./scenarios/foo.yaml",
+			wantKey:  "foo.yaml",
+		},
+		{
+			name:     "nested subdirectory",
+			filename: "scenarios/sub/bar.yaml",
+			wantKey:  "bar.yaml",
+		},
+		{
+			name:     "no prefix",
+			filename: "baz.yaml",
+			wantKey:  "baz.yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			body := validScenarioBlock(tt.filename, "test-id")
+			client := &mockClient{
+				generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+					return llm.GenerateResponse{Content: body, CostUSD: 0.01}, nil
+				},
+			}
+
+			gen := NewScenarioGenerator(client, "test-model", discardLogger())
+			files, _, err := gen.Generate(context.Background(), "# Spec")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if _, ok := files[tt.wantKey]; !ok {
+				t.Errorf("expected key %q, got keys: %v", tt.wantKey, slices.Collect(maps.Keys(files)))
+			}
+		})
+	}
+}
+
+func TestGenerateFilenameCollision(t *testing.T) {
+	t.Parallel()
+	// Two files that resolve to the same base name after stripping.
+	body := validScenarioBlock("scenarios/foo.yaml", "foo-1") +
+		validScenarioBlock("foo.yaml", "foo-2")
+
+	client := &mockClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{Content: body, CostUSD: 0.01}, nil
+		},
+	}
+
+	gen := NewScenarioGenerator(client, "test-model", discardLogger())
+	files, _, err := gen.Generate(context.Background(), "# Spec")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Only one should survive (first one wins).
+	if len(files) != 1 {
+		t.Errorf("expected 1 file after collision, got %d", len(files))
+	}
+	if _, ok := files["foo.yaml"]; !ok {
+		t.Errorf("expected key 'foo.yaml', got keys: %v", slices.Collect(maps.Keys(files)))
+	}
+}
+
+func TestGenerateUnsafeFilename(t *testing.T) {
+	t.Parallel()
+	// LLM returns a filename with path traversal -- attractor.ParseFiles rejects
+	// these before we even get to validation, so the error is errParseScenarioOutput.
+	unsafeBody := "=== FILE: ../../../etc/passwd ===\n" +
+		"id: evil\n" +
+		"description: Path traversal attempt\n" +
+		"type: api\n" +
+		"satisfaction_criteria: |\n" +
+		"  Returns 200.\n" +
+		"steps:\n" +
+		"  - description: Call endpoint\n" +
+		"    request:\n" +
+		"      method: GET\n" +
+		"      path: /foo\n" +
+		"    expect: Returns 200\n" +
+		"=== END FILE ===\n"
+
+	client := &mockClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{Content: unsafeBody, CostUSD: 0.01}, nil
+		},
+	}
+
+	gen := NewScenarioGenerator(client, "test-model", discardLogger())
+	_, _, err := gen.Generate(context.Background(), "# Spec")
+	if err == nil {
+		t.Fatal("expected error for unsafe filename, got nil")
+	}
+	if !errors.Is(err, errParseScenarioOutput) {
+		t.Errorf("expected errParseScenarioOutput for unsafe filename, got %v", err)
+	}
+}
+
+func TestGenerateContextCancellation(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately.
+
+	errCanceled := errors.New("context canceled")
+	client := &mockClient{
+		generateFn: func(ctx context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{}, errCanceled
+		},
+	}
+
+	gen := NewScenarioGenerator(client, "test-model", discardLogger())
+	_, _, err := gen.Generate(ctx, "# Spec")
+	if err == nil {
+		t.Fatal("expected error for canceled context, got nil")
+	}
+}
+
+func TestGenerateParseErrorDistinctFromNoValid(t *testing.T) {
+	t.Parallel()
+	// When ParseFiles returns an error (no blocks found), the error should be
+	// errParseScenarioOutput, not errNoValidScenarios.
+	client := &mockClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{Content: "no file blocks here"}, nil
+		},
+	}
+
+	gen := NewScenarioGenerator(client, "test-model", discardLogger())
+	_, _, err := gen.Generate(context.Background(), "# Spec")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, errParseScenarioOutput) {
+		t.Errorf("expected errParseScenarioOutput, got %v", err)
+	}
+	if errors.Is(err, errNoValidScenarios) {
+		t.Error("parse failure should not wrap errNoValidScenarios")
+	}
+}


### PR DESCRIPTION
Closes #208

## Changes
**1. Create `internal/interview/scenarios.go`**
- Define `ScenarioGenerator` struct (fields: `client llm.Client`, `model string`) with constructor `NewScenarioGenerator(client, model)` — consistent with `Scorer` pattern
- `func (g *ScenarioGenerator) Generate(ctx context.Context, specContent string) (map[string]string, float64, error)`
- Validate `specContent` is non-empty (reuse `errEmptySpec` or define `errEmptySpecContent`)
- Build `llm.GenerateRequest` with:
  - `SystemPrompt`: scenario format instructions (from `scenarios_prompt.go`)
  - `Messages`: `[{Role: "user", Content: specContent}]`
  - `MaxTokens`: 8192 (scenarios are verbose)
  - `Temperature`: pointer to 0.7
  - `CacheControl`: `&llm.CacheControl{Type: "ephemeral"}` on system prompt
- Call `client.Generate(ctx, req)`
- Parse response with `attractor.ParseFiles(resp.Content)`
- For each file: strip leading `scenarios/` prefix from key if present; validate with `scenario.Load(strings.NewReader(content))`; keep valid ones, `slog.Warn` for invalid ones
- `var errNoValidScenarios = errors.New("interview: no valid scenarios generated")` — return this if zero valid scenarios after filtering
- Return `map[string]string`, `resp.CostUSD`, `nil`

**2. Create `internal/interview/scenarios_prompt.go`**
- `scenarioSystemPrompt` constant with:
  - Scenario YAML schema covering: `id`, `description`, `type`, `weight`, `satisfaction_criteria`, `setup` steps, `steps`
  - Step types: `request` (HTTP) and `exec` (CLI) — these are the most common and the LLM will be most reliable with
  - Capture/variable substitution syntax
  - **Output format: `=== FILE: name.yaml ===` header AND `=== END FILE ===` terminator** (critical for `ParseFiles`)
  - At least one complete example scenario in the prompt
  - Guidelines: cover happy paths, error cases, edge cases; each scenario independently runnable; use descriptive IDs; bare filenames only (no directory prefix)

**3. Modify `cmd/octog/main.go`**
- Add `--scenarios` bool flag to `interviewCmd`'s FlagSet
- Pass flag value through to `interviewRun` (add `scenarios bool` parameter)
- In `interviewRun`: after writing spec, if `scenarios` is true:
  - `gen := interview.NewScenarioGenerator(client, model)`
  - `files, cost, err := gen.Generate(ctx, spec)`
  - Compute output dir: `filepath.Join(filepath.Dir(outputPath), "scenarios")`
  - `os.MkdirAll(dir, 0o755)`
  - Write each file with `os.WriteFile(filepath.Join(dir, name), ..., 0o644)`
  - Print summary to `errOut`: count of files, directory path, cost
  - Add scenario cost to total cost display
- Update existing callers of `interviewRun` (in tests) to pass the new `scenarios` parameter as `false`

## Review Findings
- Errors: 0
- Warnings: 4
- Nits: 5
- Assessment: **NEEDS CHANGES**

The path traversal concern (#7) and the map collision issue (#4) are the most impactful. The `slog.Warn` (#1) breaks the established logging pattern. The sentinel conflation (#2) will make debugging harder in production. None are catastrophic, but collectively they warrant a revision pass.
