### PR TITLE
feat(attractor): per-component convergence using structured genes

### DIFF
--- a/cmd/octog/main.go
+++ b/cmd/octog/main.go
@@ -198,7 +198,7 @@ func runCmd(ctx context.Context, logger *slog.Logger, args []string) error {
 	}
 
 	// Load genes if provided and optionally override language.
-	genesGuide, genesLanguage, langForOpts, err := loadGenes(*genesFlag, langForOpts, isFlagSet(fs, "language"), logger)
+	genesGuide, genesLanguage, langForOpts, geneComponents, err := loadGenes(*genesFlag, langForOpts, isFlagSet(fs, "language"), logger)
 	if err != nil {
 		return err
 	}
@@ -251,20 +251,21 @@ func runCmd(ctx context.Context, logger *slog.Logger, args []string) error {
 		MaxTokens:         *maxTokensFlag,
 		Agentic:           *agenticFlag,
 		AgentMaxTurns:     *agentMaxTurnsFlag,
+		GeneComponents:    geneComponents,
 	})
 }
 
 // loadGenes loads a genes file if path is non-empty, returning the guide text,
-// gene language, and the resolved target language. If the language flag was not
-// explicitly set, the gene's language overrides langForOpts.
-func loadGenes(path, langForOpts string, languageExplicit bool, logger *slog.Logger) (guide, geneLang, resolvedLang string, err error) {
+// gene language, the resolved target language, and any structured components.
+// If the language flag was not explicitly set, the gene's language overrides langForOpts.
+func loadGenes(path, langForOpts string, languageExplicit bool, logger *slog.Logger) (guide, geneLang, resolvedLang string, components []gene.Component, err error) {
 	resolvedLang = langForOpts
 	if path == "" {
-		return "", "", resolvedLang, nil
+		return "", "", resolvedLang, nil, nil
 	}
 	g, err := gene.Load(path)
 	if err != nil {
-		return "", "", "", fmt.Errorf("load genes: %w", err)
+		return "", "", "", nil, fmt.Errorf("load genes: %w", err)
 	}
 	logger.Info("loaded genes", "source", g.Source, "language", g.Language, "tokens", g.TokenCount)
 
@@ -272,7 +273,10 @@ func loadGenes(path, langForOpts string, languageExplicit bool, logger *slog.Log
 		resolvedLang = g.Language
 		logger.Info("auto-detected language from genes (override with --language)", "language", resolvedLang)
 	}
-	return g.Guide, g.Language, resolvedLang, nil
+	if len(g.Components) > 0 {
+		logger.Info("loaded gene components for composed convergence", "count", len(g.Components))
+	}
+	return g.Guide, g.Language, resolvedLang, g.Components, nil
 }
 
 // isFlagSet reports whether the named flag was explicitly provided on the command line.
@@ -307,6 +311,7 @@ type runLoopParams struct {
 	MaxTokens         int
 	Agentic           bool
 	AgentMaxTurns     int
+	GeneComponents    []gene.Component
 }
 
 func runAttractorLoop(ctx context.Context, logger *slog.Logger, llmClient llm.Client, p runLoopParams) error {
@@ -373,25 +378,38 @@ func runAttractorLoop(ctx context.Context, logger *slog.Logger, llmClient llm.Cl
 	}, grpcTargetGetter)
 	instrumentedValidate := observability.WrapValidateFn(validateFn, tp)
 
+	// Build component validators when gene components are available.
+	var componentValidators map[string]attractor.ValidateFn
+	if len(p.GeneComponents) > 0 {
+		componentValidators = buildComponentValidators(scenarios, instrumentedLLM, p.JudgeModel, executorOpts{
+			logger:        logger,
+			sessionGetter: sessionGetter,
+			needsBrowser:  caps.NeedsBrowser,
+			needsWS:       caps.NeedsWS,
+		}, grpcTargetGetter)
+	}
+
 	att := attractor.New(instrumentedLLM, instrumentedContainer, logger, tp)
 	opts := attractor.RunOptions{
-		Model:             p.Model,
-		FrugalModel:       p.FrugalModel,
-		JudgeModel:        p.JudgeModel,
-		BudgetUSD:         p.Budget,
-		Threshold:         p.Threshold,
-		PatchMode:         p.PatchMode,
-		BlockOnRegression: p.BlockOnRegression,
-		ContextBudget:     p.ContextBudget,
-		Language:          p.Language,
-		Progress:          progressFn(ctx, logger, st, os.Stderr, p.Verbosity),
-		Capabilities:      caps,
-		Genes:             p.GenesGuide,
-		GeneLanguage:      p.GeneLanguage,
-		TestCommand:       parsedSpec.TestCommand,
-		MaxTokens:         p.MaxTokens,
-		Agentic:           p.Agentic,
-		AgentMaxTurns:     p.AgentMaxTurns,
+		Model:               p.Model,
+		FrugalModel:         p.FrugalModel,
+		JudgeModel:          p.JudgeModel,
+		BudgetUSD:           p.Budget,
+		Threshold:           p.Threshold,
+		PatchMode:           p.PatchMode,
+		BlockOnRegression:   p.BlockOnRegression,
+		ContextBudget:       p.ContextBudget,
+		Language:            p.Language,
+		Progress:            progressFn(ctx, logger, st, os.Stderr, p.Verbosity),
+		Capabilities:        caps,
+		Genes:               p.GenesGuide,
+		GeneLanguage:        p.GeneLanguage,
+		TestCommand:         parsedSpec.TestCommand,
+		MaxTokens:           p.MaxTokens,
+		Agentic:             p.Agentic,
+		AgentMaxTurns:       p.AgentMaxTurns,
+		GeneComponents:      p.GeneComponents,
+		ComponentValidators: componentValidators,
 	}
 
 	startedAt := time.Now()
@@ -1323,6 +1341,23 @@ func runAndScoreParallel(ctx context.Context, scenarios []scenario.Scenario, opt
 	}
 
 	return scenario.Aggregate(results), nil
+}
+
+// buildComponentValidators creates a map of per-component ValidateFn closures.
+// Scenarios are grouped by their Component field in a single pass.
+// The "" key maps to scenarios with empty Component (integration scenarios).
+func buildComponentValidators(scenarios []scenario.Scenario, llmClient llm.Client, judgeModel string, baseOpts executorOpts, grpcTargetGetter func() string) map[string]attractor.ValidateFn {
+	// Group scenarios by component in a single pass.
+	grouped := make(map[string][]scenario.Scenario)
+	for _, sc := range scenarios {
+		grouped[sc.Component] = append(grouped[sc.Component], sc)
+	}
+
+	validators := make(map[string]attractor.ValidateFn, len(grouped))
+	for name, group := range grouped {
+		validators[name] = buildValidateFn(group, llmClient, judgeModel, baseOpts, grpcTargetGetter)
+	}
+	return validators
 }
 
 func buildValidateFn(scenarios []scenario.Scenario, llmClient llm.Client, judgeModel string, baseOpts executorOpts, grpcTargetGetter func() string) attractor.ValidateFn {

--- a/cmd/octog/main_test.go
+++ b/cmd/octog/main_test.go
@@ -1295,7 +1295,7 @@ func TestLoadGenesAutoLanguage(t *testing.T) {
 	genesPath := writeTestGenes(t, "python")
 	logger := testLogger()
 
-	guide, geneLang, resolvedLang, err := loadGenes(genesPath, "go", false, logger)
+	guide, geneLang, resolvedLang, _, err := loadGenes(genesPath, "go", false, logger)
 	if err != nil {
 		t.Fatalf("loadGenes: %v", err)
 	}
@@ -1314,7 +1314,7 @@ func TestLoadGenesExplicitLanguageWins(t *testing.T) {
 	genesPath := writeTestGenes(t, "python")
 	logger := testLogger()
 
-	guide, geneLang, resolvedLang, err := loadGenes(genesPath, "go", true, logger)
+	guide, geneLang, resolvedLang, _, err := loadGenes(genesPath, "go", true, logger)
 	if err != nil {
 		t.Fatalf("loadGenes: %v", err)
 	}
@@ -1332,7 +1332,7 @@ func TestLoadGenesExplicitLanguageWins(t *testing.T) {
 func TestLoadGenesEmptyPath(t *testing.T) {
 	logger := testLogger()
 
-	guide, geneLang, resolvedLang, err := loadGenes("", "go", false, logger)
+	guide, geneLang, resolvedLang, _, err := loadGenes("", "go", false, logger)
 	if err != nil {
 		t.Fatalf("loadGenes: %v", err)
 	}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,15 +42,16 @@ octopusgarden/
 │   │   ├── jsonpath.go           # Dot-notation JSONPath evaluator ($.field.sub)
 │   │   └── grpc.go              # gRPC step executor (reflection-based, streaming)
 │   ├── attractor/                # Convergence loop
-│   │   ├── attractor.go          # Core loop, types, options
+│   │   ├── attractor.go          # Core loop, types, options, composed convergence
 │   │   ├── convergence.go        # Trend detection
 │   │   ├── diagnosis.go          # Wonder/reflect two-phase stall recovery
 │   │   ├── escalation.go         # Model tier escalation (frugal ↔ primary)
 │   │   ├── fileparse.go          # Parse LLM output into files, merge for patch mode
 │   │   ├── languages.go          # Per-language templates (Go, Python, Node, Rust)
 │   │   ├── oscillation.go        # A→B→A→B oscillation detection (SHA-256 hashing)
-│   │   ├── prompts.go            # System prompt, feedback fidelity, steering text
+│   │   ├── prompts.go            # System prompt, feedback fidelity, steering text, component prompts
 │   │   ├── regression.go         # Per-scenario regression tracking
+│   │   ├── toposort.go           # Kahn's algorithm topological sort for component dependency graph
 │   │   └── triage.go             # LLM-based file triage: filter bestFiles to failure-relevant subset
 │   ├── container/docker.go       # Build and run Docker containers
 │   ├── llm/                      # LLM client abstraction
@@ -115,7 +116,7 @@ content and failure feedback as strings. The validator (scenario runner + judge)
 
 | Package | Purpose | Key Files | Dependencies |
 | ------- | ------- | --------- | ------------ |
-| `attractor` | Convergence loop: generate code, build, validate, iterate | `attractor.go`, `convergence.go`, `diagnosis.go`, `escalation.go`, `oscillation.go`, `regression.go`, `prompts.go`, `fileparse.go`, `languages.go`, `triage.go` | `llm`, `spec`, `container` |
+| `attractor` | Convergence loop: generate code, build, validate, iterate | `attractor.go`, `convergence.go`, `diagnosis.go`, `escalation.go`, `oscillation.go`, `regression.go`, `prompts.go`, `fileparse.go`, `languages.go`, `triage.go`, `toposort.go` | `llm`, `spec`, `container`, `gene` |
 | `container` | Docker image build, container run, health check, exec sessions | `docker.go` | docker SDK |
 | `scenario` | Load YAML scenarios, execute steps, LLM-judge scoring | `types.go`, `loader.go`, `runner.go`, `judge.go`, `result.go`, `jsonpath.go`, `grpc.go` | `llm` |
 | `spec` | Parse markdown specs, pyramid summarization | `parser.go`, `types.go`, `summary.go` | (none) |
@@ -186,8 +187,22 @@ content and failure feedback as strings. The validator (scenario runner + judge)
 
 - **Status**: Implemented
 - **Files**: `gene/scan.go`, `gene/analyze.go`, `gene/gene.go`, `attractor/prompts.go`
-- **Method**: Scan exemplar codebase for high-signal files within 20K token budget. LLM extracts structured pattern guide including optional named `Component` entries (interface, patterns, dependency graph). `parseComponents` scans the guide for `**COMPONENT: <name>**` headers; `validateComponents` enforces non-empty unique names, declared dependencies exist, and no cycles (DFS). Guide and components stored in `Gene` JSON. Injected into system prompt.
-- **Limitations**: Single exemplar only. No multi-repo synthesis. No incremental update as generated code evolves. Patterns are extracted once, not refined based on generation outcomes. Component graph is validated but not yet used to order generation or scope prompts.
+- **Method**: Scan exemplar codebase for high-signal files within 20K token budget. LLM extracts structured pattern guide including optional named `Component` entries (interface, patterns, dependency graph). `parseComponents` scans the guide for `**COMPONENT: <name>**` headers; `validateComponents` enforces non-empty unique names, declared dependencies exist, and no cycles (DFS). Guide and components stored in `Gene` JSON. Injected into system prompt. When components are present, `cmd/octog` also constructs per-component `ValidateFn` closures (grouped by `Scenario.Component`) and passes them to the attractor via `RunOptions.ComponentValidators` — enabling composed convergence (see below).
+- **Limitations**: Single exemplar only. No multi-repo synthesis. No incremental update as generated code evolves. Patterns are extracted once, not refined based on generation outcomes.
+
+### Composed Convergence
+
+- **Status**: Implemented
+- **Files**: `attractor/attractor.go`, `attractor/toposort.go`, `attractor/prompts.go`
+- **Method**: When `RunOptions.GeneComponents` and `RunOptions.ComponentValidators` are both set (and `Agentic` is false), the attractor attempts composed convergence before falling back to the monolithic loop. Steps:
+  1. **Topological sort** (`topoSort`): order components dependency-first using Kahn's BFS algorithm. Returns error on cycles or unknown dependencies.
+  2. **Per-component mini-loops**: for each component in topo order, run up to `componentMiniLoopMaxIter` (5) iterations. Each iteration generates files scoped to the component using `buildComponentPrompt` (spec + `COMPONENT CONTRACT` + `COMPONENT PATTERNS` + `DEPENDENCY INTERFACES` for declared deps only). Only the component's own `ValidateFn` scores it. Files from converged dependencies are included as a base file set.
+  3. **File merge**: after all components converge, `mergeComponentFiles` merges all component file sets in topo order (later components win on path conflicts).
+  4. **Integration validation**: the merged files are built and validated with the `""` key validator (scenarios with empty `Component` field). If integration satisfaction >= threshold, the run converges. Otherwise, falls back to the monolithic loop.
+  5. **Fallback**: any component stall, build failure, or integration failure triggers a fallback to the standard monolithic loop. Costs accumulated during the composed attempt are carried forward so budget accounting remains accurate.
+- **Prompt structure**: `buildComponentPrompt` places the spec first (cacheable prefix) followed by component-specific content — `COMPONENT CONTRACT`, optional `COMPONENT PATTERNS`, and `DEPENDENCY INTERFACES` filtered to declared dependencies only (alphabetical order).
+- **Scenario grouping**: `buildComponentValidators` groups scenarios by `Scenario.Component` in a single pass. The `""` key collects integration scenarios (empty `Component`).
+- **Limitations**: Not supported in agentic mode. No partial-merge retry (integration failure falls back entirely to monolithic). Component mini-loop stall limit (2) and max iterations (5) are compile-time constants. No cost-aware per-component budget allocation. File-level conflicts resolved by topo order, not semantic merging.
 
 ### Regression Tracking
 
@@ -359,8 +374,9 @@ type StepOutput struct {
 type Scenario struct {
 	ID                   string   `yaml:"id"`
 	Description          string   `yaml:"description"`
-	Type                 string   `yaml:"type"`   // "api" only for MVP
-	Weight               *float64 `yaml:"weight"` // nil means not set, defaults to 1.0
+	Type                 string   `yaml:"type"`      // "api" only for MVP
+	Weight               *float64 `yaml:"weight"`    // nil means not set, defaults to 1.0
+	Component            string   `yaml:"component"` // component name for composed convergence; empty = integration scenario
 	Setup                []Step   `yaml:"setup"`
 	Steps                []Step   `yaml:"steps"`
 	SatisfactionCriteria string   `yaml:"satisfaction_criteria"`
@@ -671,27 +687,29 @@ type ValidateFn func(ctx context.Context, url string, restart RestartFunc) (sati
 ```go
 // RunOptions configures the attractor loop.
 type RunOptions struct {
-	Model             string
-	FrugalModel       string               // optional cheaper model to start with; escalates to Model after consecutive failures
-	JudgeModel        string               // model used for the wonder phase diagnosis; falls back to Model when empty
-	Language          string               // language hint: "go", "python", "node", "rust", or "" (auto)
-	BudgetUSD         float64              // 0 = unlimited
-	Threshold         float64              // default 95
-	MaxIterations     int                  // default 10
-	StallLimit        int                  // default 3
-	WorkspaceDir      string               // default "./workspace"
-	HealthTimeout     time.Duration        // default 30s
-	Progress          ProgressFunc         // optional per-iteration callback
-	PatchMode         bool                 // if true, iteration 2+ sends prev best files + failures
-	BlockOnRegression bool                 // if true, convergence is blocked when per-scenario regressions are detected
-	ContextBudget     int                  // max estimated tokens for spec in system prompt; 0 = unlimited
-	Capabilities      ScenarioCapabilities // detected from loaded scenarios
-	Genes             string               // extracted pattern guide to inject into system prompt (empty = no genes)
-	GeneLanguage      string               // source language of the gene exemplar (for cross-language note)
-	TestCommand       string               // optional shell command run inside HTTP container after health check; non-zero exit = test_fail
-	MaxTokens         int                  // max output tokens for generation; 0 = auto-scale per model
-	Agentic           bool                 // if true, use AgentLoop for code generation (tool-use mode)
-	AgentMaxTurns     int                  // max turns per AgentLoop call; 0 = default (50 when Agentic is true)
+	Model               string
+	FrugalModel         string                // optional cheaper model to start with; escalates to Model after consecutive failures
+	JudgeModel          string                // model used for the wonder phase diagnosis; falls back to Model when empty
+	Language            string                // language hint: "go", "python", "node", "rust", or "" (auto)
+	BudgetUSD           float64               // 0 = unlimited
+	Threshold           float64               // default 95
+	MaxIterations       int                   // default 10
+	StallLimit          int                   // default 3
+	WorkspaceDir        string                // default "./workspace"
+	HealthTimeout       time.Duration         // default 30s
+	Progress            ProgressFunc          // optional per-iteration callback
+	PatchMode           bool                  // if true, iteration 2+ sends prev best files + failures
+	BlockOnRegression   bool                  // if true, convergence is blocked when per-scenario regressions are detected
+	ContextBudget       int                   // max estimated tokens for spec in system prompt; 0 = unlimited
+	Capabilities        ScenarioCapabilities  // detected from loaded scenarios
+	Genes               string                // extracted pattern guide to inject into system prompt (empty = no genes)
+	GeneLanguage        string                // source language of the gene exemplar (for cross-language note)
+	TestCommand         string                // optional shell command run inside HTTP container after health check; non-zero exit = test_fail
+	MaxTokens           int                   // max output tokens for generation; 0 = auto-scale per model
+	Agentic             bool                  // if true, use AgentLoop for code generation (tool-use mode)
+	AgentMaxTurns       int                   // max turns per AgentLoop call; 0 = default (50 when Agentic is true)
+	GeneComponents      []gene.Component      // structured component decomposition from gene extraction
+	ComponentValidators map[string]ValidateFn // per-component validators; "" key = integration validator
 }
 ```
 
@@ -712,9 +730,19 @@ type RunResult struct {
 
 ```text
 0. Preflight: run spec clarity check (unless --skip-preflight); abort if below threshold
-1. If FrugalModel is set, init escalation state (start at frugal tier)
-2. If ContextBudget > 0 and spec exceeds budget, summarize spec (pyramid summaries)
-3. For iter = 1 to MaxIterations:
+1. If GeneComponents + ComponentValidators are set (and not Agentic): attempt composed convergence
+   a. topoSort components (Kahn's BFS); error on cycles/unknown deps
+   b. For each component in topo order: run mini-loop (max 5 iters, stall limit 2)
+      - buildComponentPrompt: spec + COMPONENT CONTRACT + DEPENDENCY INTERFACES (declared only)
+      - validate with per-component ValidateFn; carry dep files as base file set
+      - stall/build fail → fall back to monolithic; budget exceeded → fall back
+   c. mergeComponentFiles: merge all component file sets (later topo order wins conflicts)
+   d. Build composed dir; validate with integration ValidateFn ("" key)
+   e. satisfaction >= threshold → return "converged"; else fall back to monolithic
+   f. Costs from composed attempt carried forward into monolithic budget accounting
+2. If FrugalModel is set, init escalation state (start at frugal tier)
+3. If ContextBudget > 0 and spec exceeds budget, summarize spec (pyramid summaries)
+4. For iter = 1 to MaxIterations:
    a. Check budget
    b. Check escalation: upgrade frugal→primary after 2 non-improving, downgrade after 5 improving
    c. Select spec content (full or summarized with failure-relevant sections expanded)
@@ -740,7 +768,7 @@ type RunResult struct {
    q. Determine feedback fidelity: compact (iter 1-2) → standard (3-4) → full (5+)
    r. Track improvement/stalls; patch mode: disable after 2 consecutive regressions
    s. If stall count >= stall limit → return "stalled"
-4. Return "max_iterations"
+5. Return "max_iterations"
 ```
 
 ### Progress Reporting

--- a/internal/attractor/attractor.go
+++ b/internal/attractor/attractor.go
@@ -18,6 +18,7 @@ import (
 	"go.opentelemetry.io/otel/trace/noop"
 
 	"github.com/foundatron/octopusgarden/internal/container"
+	"github.com/foundatron/octopusgarden/internal/gene"
 	"github.com/foundatron/octopusgarden/internal/llm"
 	specpkg "github.com/foundatron/octopusgarden/internal/spec"
 )
@@ -27,6 +28,13 @@ var (
 	errUnsupportedLanguage  = errors.New("attractor: unsupported language")
 	errMinimalismNoMessages = errors.New("attractor: minimalism suffix: no messages to append to")
 	errAgentClientRequired  = errors.New("attractor: agentic mode requires AgentClient implementation")
+	errComponentFallback    = errors.New("attractor: component convergence failed, falling back to monolithic")
+	errComponentStalled     = errors.New("attractor: component stalled")
+	errComponentBudget      = errors.New("attractor: budget exceeded during component convergence")
+	errComponentBuildFail   = errors.New("attractor: component build failed")
+	errComponentSessionFail = errors.New("attractor: component session start failed")
+	errComponentStartFail   = errors.New("attractor: component container start failed")
+	errUnknownDependency    = errors.New("attractor: component depends on unknown component")
 
 	_ ContainerManager = (*container.Manager)(nil)
 )
@@ -128,27 +136,29 @@ type Attractor struct {
 
 // RunOptions configures the attractor loop.
 type RunOptions struct {
-	Model             string
-	FrugalModel       string               // optional cheaper model to start with; escalates to Model after consecutive failures
-	JudgeModel        string               // model used for the wonder phase diagnosis; falls back to Model when empty
-	Language          string               // language hint: "go", "python", "node", "rust", or "" (auto)
-	BudgetUSD         float64              // 0 = unlimited
-	Threshold         float64              // default 95
-	MaxIterations     int                  // default 10
-	StallLimit        int                  // default 3
-	WorkspaceDir      string               // default "./workspace"
-	HealthTimeout     time.Duration        // default 30s
-	Progress          ProgressFunc         // optional per-iteration callback
-	PatchMode         bool                 // if true, iteration 2+ sends prev best files + failures
-	BlockOnRegression bool                 // if true, convergence is blocked when per-scenario regressions are detected
-	ContextBudget     int                  // max estimated tokens for spec in system prompt; 0 = unlimited
-	Capabilities      ScenarioCapabilities // detected from loaded scenarios
-	Genes             string               // extracted pattern guide to inject into system prompt (empty = no genes)
-	GeneLanguage      string               // source language of the gene exemplar (for cross-language note)
-	TestCommand       string               // optional shell command run inside HTTP container after health check; non-zero exit = test_fail
-	MaxTokens         int                  // max output tokens for generation; 0 = auto-scale per model
-	Agentic           bool                 // if true, use AgentLoop for code generation (tool-use mode)
-	AgentMaxTurns     int                  // max turns per AgentLoop call; 0 = default (50 when Agentic is true)
+	Model               string
+	FrugalModel         string                // optional cheaper model to start with; escalates to Model after consecutive failures
+	JudgeModel          string                // model used for the wonder phase diagnosis; falls back to Model when empty
+	Language            string                // language hint: "go", "python", "node", "rust", or "" (auto)
+	BudgetUSD           float64               // 0 = unlimited
+	Threshold           float64               // default 95
+	MaxIterations       int                   // default 10
+	StallLimit          int                   // default 3
+	WorkspaceDir        string                // default "./workspace"
+	HealthTimeout       time.Duration         // default 30s
+	Progress            ProgressFunc          // optional per-iteration callback
+	PatchMode           bool                  // if true, iteration 2+ sends prev best files + failures
+	BlockOnRegression   bool                  // if true, convergence is blocked when per-scenario regressions are detected
+	ContextBudget       int                   // max estimated tokens for spec in system prompt; 0 = unlimited
+	Capabilities        ScenarioCapabilities  // detected from loaded scenarios
+	Genes               string                // extracted pattern guide to inject into system prompt (empty = no genes)
+	GeneLanguage        string                // source language of the gene exemplar (for cross-language note)
+	TestCommand         string                // optional shell command run inside HTTP container after health check; non-zero exit = test_fail
+	MaxTokens           int                   // max output tokens for generation; 0 = auto-scale per model
+	Agentic             bool                  // if true, use AgentLoop for code generation (tool-use mode)
+	AgentMaxTurns       int                   // max turns per AgentLoop call; 0 = default (50 when Agentic is true)
+	GeneComponents      []gene.Component      // structured component decomposition from gene extraction
+	ComponentValidators map[string]ValidateFn // per-component validators; "" key = integration validator
 }
 
 // RunResult holds the outcome of an attractor run.
@@ -281,13 +291,8 @@ func New(client llm.Client, containerMgr ContainerManager, logger *slog.Logger, 
 // grpcTargetProvider is an optional callback called before validation to set the gRPC target.
 // Returns a RunResult for normal termination, or an error for unrecoverable failures.
 func (a *Attractor) Run(ctx context.Context, rawSpec string, opts RunOptions, validate ValidateFn, sessionProvider SessionProviderFn, grpcTargetProvider GRPCTargetProviderFn) (*RunResult, error) {
-	if strings.TrimSpace(rawSpec) == "" {
-		return nil, errEmptySpec
-	}
-	if opts.Language != "" {
-		if _, ok := LookupLanguage(opts.Language); !ok {
-			return nil, fmt.Errorf("%w: %q (supported: %v)", errUnsupportedLanguage, opts.Language, SupportedLanguages())
-		}
+	if err := validateRunInputs(rawSpec, opts); err != nil {
+		return nil, err
 	}
 
 	if sessionProvider == nil {
@@ -298,6 +303,18 @@ func (a *Attractor) Run(ctx context.Context, rawSpec string, opts RunOptions, va
 	}
 
 	opts = withDefaults(opts)
+
+	// Try composed convergence when gene components and component validators are available.
+	// composedCost carries costs from the composed attempt even on fallback, so the
+	// monolithic loop starts with an accurate budget accounting.
+	composedResult, composedCost, err := a.tryComposed(ctx, rawSpec, opts, sessionProvider, grpcTargetProvider)
+	if err != nil {
+		return nil, err
+	}
+	if composedResult != nil {
+		return composedResult, nil
+	}
+
 	s := &runState{
 		runID:              generateRunID(),
 		opts:               opts,
@@ -306,6 +323,7 @@ func (a *Attractor) Run(ctx context.Context, rawSpec string, opts RunOptions, va
 		sessionProvider:    sessionProvider,
 		grpcTargetProvider: grpcTargetProvider,
 		escalation:         newEscalationState(opts.FrugalModel, opts.Model, a.logger),
+		totalCost:          composedCost,
 	}
 	s.baseDir = filepath.Join(opts.WorkspaceDir, s.runID)
 	s.bestDir = filepath.Join(s.baseDir, "best")
@@ -383,6 +401,396 @@ func (a *Attractor) setRunSpanAttrs(span trace.Span, result *RunResult) {
 		attribute.Float64("satisfaction", result.Satisfaction),
 		attribute.Float64("cost_usd", result.CostUSD),
 	)
+}
+
+// validateRunInputs validates inputs to Run before the loop starts.
+func validateRunInputs(rawSpec string, opts RunOptions) error {
+	if strings.TrimSpace(rawSpec) == "" {
+		return errEmptySpec
+	}
+	if opts.Language != "" {
+		if _, ok := LookupLanguage(opts.Language); !ok {
+			return fmt.Errorf("%w: %q (supported: %v)", errUnsupportedLanguage, opts.Language, SupportedLanguages())
+		}
+	}
+	return nil
+}
+
+// tryComposed attempts composed convergence if gene components and validators are available.
+// Returns (nil, 0, nil) to fall through to the monolithic loop.
+// The returned cost reflects LLM and validation spend during the composed attempt,
+// even when falling back, so callers can seed the monolithic budget correctly.
+func (a *Attractor) tryComposed(ctx context.Context, rawSpec string, opts RunOptions, sessionProvider SessionProviderFn, grpcTargetProvider GRPCTargetProviderFn) (*RunResult, float64, error) {
+	if len(opts.GeneComponents) == 0 || len(opts.ComponentValidators) == 0 {
+		return nil, 0, nil
+	}
+	if opts.Agentic {
+		a.logger.Warn("composed convergence skipped: not supported in agentic mode, falling back to monolithic")
+		return nil, 0, nil
+	}
+	result, cost, err := a.runComposed(ctx, rawSpec, opts, sessionProvider, grpcTargetProvider)
+	if err != nil && !errors.Is(err, errComponentFallback) {
+		return nil, cost, err
+	}
+	if result != nil {
+		return result, cost, nil
+	}
+	a.logger.Info("composed convergence failed, falling back to monolithic loop")
+	return nil, cost, nil
+}
+
+// Component mini-loop tuning constants.
+const (
+	// componentMiniLoopMaxIter is the maximum iterations for a per-component convergence mini-loop.
+	componentMiniLoopMaxIter = 5
+	// componentMiniLoopStallLimit is the stall limit for per-component mini-loops.
+	componentMiniLoopStallLimit = 2
+)
+
+// runComposed attempts composed convergence: converge each component independently
+// in topological order, then validate the composed result with integration scenarios.
+// Returns the accumulated cost even on fallback so callers can track total spend.
+func (a *Attractor) runComposed(ctx context.Context, rawSpec string, opts RunOptions, sessionProvider SessionProviderFn, grpcTargetProvider GRPCTargetProviderFn) (*RunResult, float64, error) {
+	sorted, err := topoSort(opts.GeneComponents)
+	if err != nil {
+		return nil, 0, fmt.Errorf("attractor: composed convergence: %w", err)
+	}
+
+	s := &runState{
+		runID:              generateRunID(),
+		opts:               opts,
+		startTime:          time.Now(),
+		sessionProvider:    sessionProvider,
+		grpcTargetProvider: grpcTargetProvider,
+	}
+	s.baseDir = filepath.Join(opts.WorkspaceDir, s.runID)
+	s.bestDir = filepath.Join(s.baseDir, "best")
+
+	ctx, composedSpan := a.tracer.Start(ctx, "attractor.composed.run", trace.WithAttributes(
+		attribute.String("run_id", s.runID),
+		attribute.Int("components", len(sorted)),
+	))
+	defer composedSpan.End()
+
+	componentFiles := make(map[string]map[string]string, len(sorted))
+	depInterfaces := make(map[string]string, len(sorted))
+
+	for _, comp := range sorted {
+		if s.budgetExceeded() {
+			composedSpan.SetStatus(codes.Error, "budget exceeded")
+			return nil, s.totalCost, errComponentFallback
+		}
+
+		compFiles, compErr := a.convergeComponent(ctx, rawSpec, comp, depInterfaces, componentFiles, s)
+		if compErr != nil {
+			a.logger.Warn("component convergence failed, falling back to monolithic",
+				"component", comp.Name, "error", compErr)
+			composedSpan.RecordError(compErr)
+			composedSpan.SetStatus(codes.Error, compErr.Error())
+			return nil, s.totalCost, errComponentFallback
+		}
+		componentFiles[comp.Name] = compFiles
+		depInterfaces[comp.Name] = comp.Interface
+	}
+
+	// Merge all component files into composed output (later topo order wins on overlap).
+	composedFiles := mergeComponentFiles(sorted, componentFiles, a.logger)
+
+	result, err := a.validateComposed(ctx, composedFiles, s)
+	if err != nil {
+		composedSpan.RecordError(err)
+		if !errors.Is(err, errComponentFallback) {
+			composedSpan.SetStatus(codes.Error, err.Error())
+		}
+		return nil, s.totalCost, err
+	}
+	composedSpan.SetAttributes(attribute.Float64("cost_usd", s.totalCost))
+	return result, s.totalCost, nil
+}
+
+// mergeComponentFiles merges files from all components in topo order. Later components
+// win on file path conflicts. Overlaps are logged.
+func mergeComponentFiles(sorted []gene.Component, componentFiles map[string]map[string]string, logger *slog.Logger) map[string]string {
+	composed := make(map[string]string)
+	for _, comp := range sorted {
+		for path, content := range componentFiles[comp.Name] {
+			if _, exists := composed[path]; exists {
+				logger.Debug("file overlap in composed merge, later component wins",
+					"path", path, "component", comp.Name)
+			}
+			composed[path] = content
+		}
+	}
+	return composed
+}
+
+// validateComposed writes composed files, builds, runs, and validates with integration scenarios.
+func (a *Attractor) validateComposed(ctx context.Context, composedFiles map[string]string, s *runState) (*RunResult, error) {
+	ctx, span := a.tracer.Start(ctx, "attractor.composed.validate", trace.WithAttributes(
+		attribute.String("run_id", s.runID),
+	))
+	defer span.End()
+
+	integrationDir := filepath.Join(s.baseDir, "composed")
+	if err := writeFiles(integrationDir, composedFiles); err != nil {
+		return nil, fmt.Errorf("attractor: write composed files: %w", err)
+	}
+
+	integrationValidate := s.opts.ComponentValidators[""]
+	if integrationValidate == nil {
+		// No integration scenarios: composed result is accepted.
+		s.bestSatisfaction = 100
+		s.bestFiles = maps.Clone(composedFiles)
+		if err := writeFiles(s.bestDir, composedFiles); err != nil {
+			return nil, fmt.Errorf("attractor: write best composed: %w", err)
+		}
+		span.SetAttributes(attribute.String("outcome", "accepted_no_integration"))
+		return s.result(0, StatusConverged), nil
+	}
+
+	tag := fmt.Sprintf("og-%s-composed", s.runID)
+	if err := a.containerMgr.Build(ctx, integrationDir, tag); err != nil {
+		a.logger.Warn("composed build failed", "error", err)
+		return nil, errComponentFallback
+	}
+
+	caps := s.opts.Capabilities
+
+	if caps.NeedsExec {
+		session, stopSession, err := a.containerMgr.StartSession(ctx, tag)
+		if err != nil {
+			return nil, errComponentFallback
+		}
+		defer stopSession()
+		s.sessionProvider(session)
+		defer s.sessionProvider(nil)
+	}
+
+	url, stop, err := a.startComposedContainer(ctx, tag, caps, s)
+	if err != nil {
+		return nil, err
+	}
+	if stop != nil {
+		defer stop()
+	}
+
+	satisfaction, failures, valCost, err := integrationValidate(ctx, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("attractor: integration validate: %w", err)
+	}
+	s.totalCost += valCost
+
+	span.SetAttributes(
+		attribute.Float64("satisfaction", satisfaction),
+		attribute.Float64("cost_usd", valCost),
+	)
+
+	if satisfaction >= s.opts.Threshold {
+		s.bestSatisfaction = satisfaction
+		s.bestFiles = maps.Clone(composedFiles)
+		if wErr := writeFiles(s.bestDir, composedFiles); wErr != nil {
+			return nil, fmt.Errorf("attractor: write best composed: %w", wErr)
+		}
+		return s.result(0, StatusConverged), nil
+	}
+
+	a.logger.Info("integration validation failed", "satisfaction", satisfaction, "failures_count", len(failures))
+	span.SetStatus(codes.Error, "integration validation failed")
+	return nil, errComponentFallback
+}
+
+// startComposedContainer starts the appropriate container type for integration validation.
+func (a *Attractor) startComposedContainer(ctx context.Context, tag string, caps ScenarioCapabilities, s *runState) (url string, stop func(), err error) {
+	switch {
+	case caps.NeedsGRPC:
+		res, gErr := a.startGRPCContainer(ctx, 0, tag, caps, s)
+		if gErr != nil {
+			return "", nil, errComponentFallback
+		}
+		if res.stop == nil {
+			return "", nil, errComponentFallback
+		}
+		s.grpcTargetProvider(res.grpcTarget)
+		return res.url, func() { res.stop(); s.grpcTargetProvider("") }, nil
+	case caps.NeedsHTTP || caps.NeedsBrowser || !caps.NeedsExec:
+		res, hErr := a.startHTTPContainer(ctx, 0, tag, s.opts.HealthTimeout, s)
+		if hErr != nil {
+			return "", nil, errComponentFallback
+		}
+		if res.stop == nil {
+			return "", nil, errComponentFallback
+		}
+		return res.url, res.stop, nil
+	default:
+		return "", nil, nil
+	}
+}
+
+// componentLoopState holds local mutable state for a component mini-loop.
+// Isolated from the shared runState to prevent corruption (only totalCost is shared).
+type componentLoopState struct {
+	history    []iterationFeedback
+	stallCount int
+	bestScore  float64
+	bestFiles  map[string]string
+}
+
+// convergeComponent runs a mini convergence loop for a single component.
+// Uses local state for history/stallCount/etc. Only totalCost accumulates into s.
+func (a *Attractor) convergeComponent(ctx context.Context, rawSpec string, comp gene.Component, depInterfaces map[string]string, componentFiles map[string]map[string]string, s *runState) (map[string]string, error) {
+	ctx, span := a.tracer.Start(ctx, "attractor.composed.component", trace.WithAttributes(
+		attribute.String("component", comp.Name),
+		attribute.String("run_id", s.runID),
+	))
+	defer span.End()
+
+	validate := s.opts.ComponentValidators[comp.Name]
+	baseFiles := buildDepFileSet(comp, componentFiles)
+	cs := &componentLoopState{}
+
+	a.logger.Info("converging component", "component", comp.Name, "max_iterations", componentMiniLoopMaxIter)
+
+	for iter := 1; iter <= componentMiniLoopMaxIter; iter++ {
+		if s.budgetExceeded() {
+			return nil, fmt.Errorf("%w: component %q", errComponentBudget, comp.Name)
+		}
+		files, err := a.componentIteration(ctx, rawSpec, comp, depInterfaces, baseFiles, validate, iter, cs, s)
+		if err != nil {
+			return nil, err
+		}
+		if files != nil {
+			return files, nil
+		}
+		if cs.stallCount >= componentMiniLoopStallLimit {
+			return nil, fmt.Errorf("%w: component %q", errComponentStalled, comp.Name)
+		}
+	}
+
+	if cs.bestFiles != nil {
+		a.logger.Info("component exhausted iterations, using best", "component", comp.Name, "best_score", cs.bestScore)
+		return cs.bestFiles, nil
+	}
+	return nil, fmt.Errorf("%w: component %q", errComponentStalled, comp.Name)
+}
+
+// componentIteration runs one iteration of the component mini-loop.
+// Returns (files, nil) on convergence, (nil, nil) to continue, or (nil, err) on hard error.
+func (a *Attractor) componentIteration(ctx context.Context, rawSpec string, comp gene.Component, depInterfaces map[string]string, baseFiles map[string]string, validate ValidateFn, iter int, cs *componentLoopState, s *runState) (map[string]string, error) {
+	systemPrompt := buildComponentPrompt(rawSpec, comp, depInterfaces, s.opts.Capabilities, s.opts.Language)
+	genResp, err := a.llm.Generate(ctx, llm.GenerateRequest{
+		SystemPrompt: systemPrompt,
+		Messages:     buildMessages(iter, cs.history),
+		MaxTokens:    s.opts.MaxTokens,
+		Model:        s.opts.Model,
+		CacheControl: &llm.CacheControl{Type: "ephemeral"},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("attractor: generate component %q iteration %d: %w", comp.Name, iter, err)
+	}
+	s.totalCost += genResp.CostUSD
+
+	files, parseErr := ParseFiles(genResp.Content)
+	if parseErr != nil {
+		cs.stallCount++
+		cs.history = append(cs.history, iterationFeedback{
+			iteration: iter, kind: feedbackParseError,
+			message: fmt.Sprintf("Failed to parse generated files: %s", parseErr),
+		})
+		return nil, nil
+	}
+
+	buildContext := MergeFiles(files, baseFiles)
+	iterDir := filepath.Join(s.baseDir, fmt.Sprintf("comp_%s_iter_%d", comp.Name, iter))
+	if err := writeFiles(iterDir, buildContext); err != nil {
+		return nil, fmt.Errorf("attractor: write component %q files: %w", comp.Name, err)
+	}
+
+	if validate == nil {
+		a.logger.Info("component converged (no validator)", "component", comp.Name, "iteration", iter)
+		return files, nil
+	}
+
+	return a.evaluateComponent(ctx, iterDir, comp.Name, iter, files, validate, cs, s)
+}
+
+// evaluateComponent builds, validates, and records results for one component iteration.
+func (a *Attractor) evaluateComponent(ctx context.Context, iterDir, compName string, iter int, files map[string]string, validate ValidateFn, cs *componentLoopState, s *runState) (map[string]string, error) {
+	satisfaction, failures, err := a.buildAndValidateComponent(ctx, iterDir, compName, iter, validate, s)
+	if err != nil {
+		cs.stallCount++
+		cs.history = append(cs.history, iterationFeedback{
+			iteration: iter, kind: feedbackBuildError, message: err.Error(),
+		})
+		return nil, nil
+	}
+
+	if satisfaction >= s.opts.Threshold {
+		a.logger.Info("component converged", "component", compName, "iteration", iter, "satisfaction", satisfaction)
+		return files, nil
+	}
+
+	if satisfaction > cs.bestScore {
+		cs.bestScore = satisfaction
+		cs.bestFiles = maps.Clone(files)
+		cs.stallCount = 0
+	} else {
+		cs.stallCount++
+	}
+
+	fidelity := determineFidelity(iter, cs.stallCount)
+	cs.history = append(cs.history, iterationFeedback{
+		iteration:       iter,
+		kind:            feedbackValidation,
+		message:         formatValidationFeedback(satisfaction, failures, fidelity),
+		fidelity:        fidelity,
+		failedScenarios: parseFailedScenarios(failures),
+	})
+	return nil, nil
+}
+
+// buildDepFileSet merges files from all converged dependencies into a base file set.
+func buildDepFileSet(comp gene.Component, componentFiles map[string]map[string]string) map[string]string {
+	base := make(map[string]string)
+	for _, dep := range comp.DependsOn {
+		if depFiles, ok := componentFiles[dep]; ok {
+			maps.Copy(base, depFiles)
+		}
+	}
+	return base
+}
+
+// buildAndValidateComponent builds a container and runs validation for a component.
+// Returns satisfaction, failures, and error (error for build/run/health failures).
+func (a *Attractor) buildAndValidateComponent(ctx context.Context, iterDir, compName string, iter int, validate ValidateFn, s *runState) (float64, []string, error) {
+	tag := fmt.Sprintf("og-%s-comp-%s-%d", s.runID, compName, iter)
+	if err := a.containerMgr.Build(ctx, iterDir, tag); err != nil {
+		return 0, nil, fmt.Errorf("%w: %w", errComponentBuildFail, err)
+	}
+
+	if s.opts.Capabilities.NeedsExec {
+		session, stopSession, err := a.containerMgr.StartSession(ctx, tag)
+		if err != nil {
+			return 0, nil, fmt.Errorf("%w: %w", errComponentSessionFail, err)
+		}
+		defer stopSession()
+		s.sessionProvider(session)
+		defer s.sessionProvider(nil)
+	}
+
+	url, stop, err := a.startComposedContainer(ctx, tag, s.opts.Capabilities, s)
+	if err != nil {
+		return 0, nil, fmt.Errorf("%w: %w", errComponentStartFail, err)
+	}
+	if stop != nil {
+		defer stop()
+	}
+
+	satisfaction, failures, valCost, valErr := validate(ctx, url, nil)
+	if valErr != nil {
+		return 0, nil, fmt.Errorf("attractor: validate component %q: %w", compName, valErr)
+	}
+	s.totalCost += valCost
+	return satisfaction, failures, nil
 }
 
 // generateContent produces the LLM output for one iteration.

--- a/internal/attractor/attractor_test.go
+++ b/internal/attractor/attractor_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/foundatron/octopusgarden/internal/container"
+	"github.com/foundatron/octopusgarden/internal/gene"
 	"github.com/foundatron/octopusgarden/internal/llm"
 )
 
@@ -2658,5 +2659,217 @@ func TestTruncationWithParsableOutput(t *testing.T) {
 	}
 	if result.Status != StatusConverged {
 		t.Errorf("expected status %q, got %q (truncated but parsable output should proceed)", StatusConverged, result.Status)
+	}
+}
+
+func TestComposedConvergence_BothComponentsConverge(t *testing.T) {
+	client := &mockLLMClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
+		},
+	}
+	componentValidate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+		return 100, nil, 0.005, nil
+	}
+	integrationValidate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+		return 100, nil, 0.005, nil
+	}
+
+	opts := defaultOpts(t)
+	opts.GeneComponents = []gene.Component{
+		{Name: "models", Interface: "Data model types"},
+		{Name: "routes", Interface: "HTTP handlers", DependsOn: []string{"models"}},
+	}
+	opts.ComponentValidators = map[string]ValidateFn{
+		"models": componentValidate,
+		"routes": componentValidate,
+		"":       integrationValidate,
+	}
+
+	a := New(client, &mockContainerMgr{}, testLogger(), nil)
+	result, err := a.Run(context.Background(), "Build an app", opts, componentValidate, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != StatusConverged {
+		t.Errorf("expected status %q, got %q", StatusConverged, result.Status)
+	}
+}
+
+func TestComposedConvergence_FallbackToMonolithic(t *testing.T) {
+	client := &mockLLMClient{
+		generateFn: func(_ context.Context, req llm.GenerateRequest) (llm.GenerateResponse, error) {
+			// Component prompts contain "COMPONENT CONTRACT"; monolithic prompts do not.
+			if strings.Contains(req.SystemPrompt, "COMPONENT CONTRACT") {
+				return llm.GenerateResponse{Content: "no files here", CostUSD: 0.01}, nil
+			}
+			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
+		},
+	}
+	monolithicValidate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+		return 100, nil, 0.005, nil
+	}
+
+	opts := defaultOpts(t)
+	opts.GeneComponents = []gene.Component{
+		{Name: "models", Interface: "Data model types"},
+	}
+	opts.ComponentValidators = map[string]ValidateFn{
+		"models": monolithicValidate,
+	}
+
+	a := New(client, &mockContainerMgr{}, testLogger(), nil)
+	result, err := a.Run(context.Background(), "Build an app", opts, monolithicValidate, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != StatusConverged {
+		t.Errorf("expected status %q, got %q (should fall back to monolithic)", StatusConverged, result.Status)
+	}
+}
+
+func TestComposedConvergence_NoComponents(t *testing.T) {
+	client := &mockLLMClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
+		},
+	}
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+		return 100, nil, 0.005, nil
+	}
+
+	// No GeneComponents set — should behave exactly like the monolithic path.
+	a := New(client, &mockContainerMgr{}, testLogger(), nil)
+	result, err := a.Run(context.Background(), "Build an app", defaultOpts(t), validate, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != StatusConverged {
+		t.Errorf("expected status %q, got %q", StatusConverged, result.Status)
+	}
+}
+
+func TestComposedConvergence_FileMergeOverlap(t *testing.T) {
+	sorted := []gene.Component{
+		{Name: "A"},
+		{Name: "B"},
+	}
+	componentFiles := map[string]map[string]string{
+		"A": {"shared.go": "package a", "a.go": "package a"},
+		"B": {"shared.go": "package b", "b.go": "package b"},
+	}
+	merged := mergeComponentFiles(sorted, componentFiles, testLogger())
+	// Later topo order (B) wins on overlap.
+	if merged["shared.go"] != "package b" {
+		t.Errorf("expected later component to win overlap, got %q", merged["shared.go"])
+	}
+	if merged["a.go"] != "package a" {
+		t.Error("non-overlapping file from A should be preserved")
+	}
+	if merged["b.go"] != "package b" {
+		t.Error("non-overlapping file from B should be preserved")
+	}
+}
+
+func TestComposedConvergence_BudgetExhausted(t *testing.T) {
+	client := &mockLLMClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.50}, nil
+		},
+	}
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+		return 50, []string{"not done"}, 0.01, nil
+	}
+
+	opts := defaultOpts(t)
+	opts.BudgetUSD = 0.10
+	opts.GeneComponents = []gene.Component{
+		{Name: "models", Interface: "types"},
+	}
+	opts.ComponentValidators = map[string]ValidateFn{
+		"models": validate,
+	}
+
+	a := New(client, &mockContainerMgr{}, testLogger(), nil)
+	// Budget exceeded during component iteration should fall back to monolithic,
+	// then monolithic should also detect budget exceeded.
+	result, err := a.Run(context.Background(), "Build an app", opts, validate, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != StatusBudgetExceeded {
+		t.Errorf("expected status %q, got %q", StatusBudgetExceeded, result.Status)
+	}
+}
+
+func TestComposedConvergence_AgenticSkip(t *testing.T) {
+	// Use mockAgentClient so that Agentic = true works in the monolithic fallback.
+	// This exercises the real skip path: tryComposed returns (nil, 0, nil) when
+	// opts.Agentic is true, then the monolithic agentic loop converges.
+	client := &mockAgentClient{
+		agentLoopFn: func(ctx context.Context, _ llm.AgentRequest, handler llm.ToolHandler) (llm.AgentResponse, error) {
+			if err := agentWritesFiles(ctx, handler); err != nil {
+				return llm.AgentResponse{}, err
+			}
+			return llm.AgentResponse{Turns: 1, TotalCost: 0.01}, nil
+		},
+	}
+	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+		return 100, nil, 0.005, nil
+	}
+
+	opts := agenticOpts(t)
+	opts.GeneComponents = []gene.Component{
+		{Name: "models", Interface: "types"},
+	}
+	opts.ComponentValidators = map[string]ValidateFn{
+		"models": validate,
+	}
+
+	// Agentic + components: composed is skipped (tryComposed returns nil,0,nil),
+	// monolithic agentic loop runs and converges.
+	a := New(client, &mockContainerMgr{}, testLogger(), nil)
+	result, err := a.Run(context.Background(), "Build an app", opts, validate, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != StatusConverged {
+		t.Errorf("expected status %q, got %q", StatusConverged, result.Status)
+	}
+}
+
+func TestComposedConvergence_IntegrationFail(t *testing.T) {
+	client := &mockLLMClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
+		},
+	}
+	componentValidate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+		return 100, nil, 0.005, nil
+	}
+	integrationValidate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+		return 40, []string{"integration broken"}, 0.005, nil
+	}
+	monolithicValidate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+		return 100, nil, 0.005, nil
+	}
+
+	opts := defaultOpts(t)
+	opts.GeneComponents = []gene.Component{
+		{Name: "models", Interface: "types"},
+	}
+	opts.ComponentValidators = map[string]ValidateFn{
+		"models": componentValidate,
+		"":       integrationValidate,
+	}
+
+	a := New(client, &mockContainerMgr{}, testLogger(), nil)
+	// Integration fails -> fallback to monolithic -> converges.
+	result, err := a.Run(context.Background(), "Build an app", opts, monolithicValidate, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != StatusConverged {
+		t.Errorf("expected status %q, got %q", StatusConverged, result.Status)
 	}
 }

--- a/internal/attractor/prompts.go
+++ b/internal/attractor/prompts.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"github.com/foundatron/octopusgarden/internal/gene"
 	"github.com/foundatron/octopusgarden/internal/llm"
 )
 
@@ -337,6 +338,42 @@ message Item { string id = 1; string name = 2; }
 === END FILE ===
 `)
 	fmt.Fprintf(&b, "=== FILE: Dockerfile ===\nFROM %s\n%s\nWORKDIR /app\nCOPY . .\nRUN <compile .proto files to generate stubs>\nRUN <install dependencies and build the application>\nCMD [\"./server\"]\n=== END FILE ===\n", tmpl.BaseImage, tmpl.GRPCSetup)
+	return b.String()
+}
+
+// buildComponentPrompt creates the system prompt for component-scoped generation.
+// The spec is placed first (with cache_control: ephemeral on the system message) so that
+// the shared prefix is cacheable across components. Component-specific content follows.
+func buildComponentPrompt(spec string, component gene.Component, depInterfaces map[string]string, caps ScenarioCapabilities, language string) string {
+	var b strings.Builder
+	b.WriteString(systemPromptPrefix)
+	b.WriteString(spec)
+
+	b.WriteString("\n\nCOMPONENT CONTRACT:\n")
+	b.WriteString(component.Interface)
+
+	if component.Patterns != "" {
+		b.WriteString("\n\nCOMPONENT PATTERNS:\n")
+		b.WriteString(component.Patterns)
+	}
+
+	// Only include interfaces for declared dependencies, not all accumulated interfaces.
+	if len(component.DependsOn) > 0 && len(depInterfaces) > 0 {
+		var depSection strings.Builder
+		depNames := slices.Sorted(slices.Values(component.DependsOn))
+		for _, name := range depNames {
+			if iface, ok := depInterfaces[name]; ok {
+				fmt.Fprintf(&depSection, "\n--- %s ---\n%s\n", name, iface)
+			}
+		}
+		if depSection.Len() > 0 {
+			b.WriteString("\n\nDEPENDENCY INTERFACES:\n")
+			b.WriteString(depSection.String())
+		}
+	}
+
+	b.WriteString(buildCapabilitySuffix(caps, language))
+	b.WriteString(buildDepRules(language))
 	return b.String()
 }
 

--- a/internal/attractor/prompts_test.go
+++ b/internal/attractor/prompts_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 	"unicode/utf8"
+
+	"github.com/foundatron/octopusgarden/internal/gene"
 )
 
 func TestBuildSystemPromptContainsSpec(t *testing.T) {
@@ -1394,5 +1396,94 @@ func TestBuildPatchMessagesZeroOmitted(t *testing.T) {
 	content := msgs[0].Content
 	if strings.Contains(content, "other files not relevant") {
 		t.Errorf("should not contain omitted-files notice when omittedCount=0, got:\n%s", content)
+	}
+}
+
+func TestBuildComponentPrompt_IncludesContractAndPatterns(t *testing.T) {
+	comp := gene.Component{
+		Name:      "routes",
+		Interface: "HTTP handler interface for /api routes",
+		Patterns:  "Use chi router with middleware chain",
+	}
+	prompt := buildComponentPrompt("my spec", comp, nil, ScenarioCapabilities{}, "go")
+	if !strings.Contains(prompt, "COMPONENT CONTRACT:") {
+		t.Error("prompt should contain COMPONENT CONTRACT section")
+	}
+	if !strings.Contains(prompt, comp.Interface) {
+		t.Error("prompt should contain component interface text")
+	}
+	if !strings.Contains(prompt, "COMPONENT PATTERNS:") {
+		t.Error("prompt should contain COMPONENT PATTERNS section")
+	}
+	if !strings.Contains(prompt, comp.Patterns) {
+		t.Error("prompt should contain component patterns text")
+	}
+}
+
+func TestBuildComponentPrompt_IncludesDependencyInterfaces(t *testing.T) {
+	comp := gene.Component{
+		Name:      "routes",
+		Interface: "HTTP handler interface",
+		DependsOn: []string{"models"},
+	}
+	depInterfaces := map[string]string{
+		"models": "type User struct { ID int; Name string }",
+	}
+	prompt := buildComponentPrompt("my spec", comp, depInterfaces, ScenarioCapabilities{}, "")
+	if !strings.Contains(prompt, "DEPENDENCY INTERFACES:") {
+		t.Error("prompt should contain DEPENDENCY INTERFACES section")
+	}
+	if !strings.Contains(prompt, "--- models ---") {
+		t.Error("prompt should contain models dependency header")
+	}
+	if !strings.Contains(prompt, depInterfaces["models"]) {
+		t.Error("prompt should contain dependency interface text")
+	}
+}
+
+func TestBuildComponentPrompt_NoDependencies(t *testing.T) {
+	comp := gene.Component{
+		Name:      "models",
+		Interface: "Data models",
+	}
+	prompt := buildComponentPrompt("my spec", comp, nil, ScenarioCapabilities{}, "")
+	if strings.Contains(prompt, "DEPENDENCY INTERFACES:") {
+		t.Error("prompt should not contain DEPENDENCY INTERFACES when there are no deps")
+	}
+}
+
+func TestBuildComponentPrompt_FiltersToOnlyDeclaredDeps(t *testing.T) {
+	comp := gene.Component{
+		Name:      "routes",
+		Interface: "HTTP handler interface",
+		DependsOn: []string{"models"},
+	}
+	depInterfaces := map[string]string{
+		"models": "type User struct { ID int; Name string }",
+		"auth":   "type AuthService interface { Verify(token string) bool }",
+	}
+	prompt := buildComponentPrompt("my spec", comp, depInterfaces, ScenarioCapabilities{}, "")
+	if !strings.Contains(prompt, "--- models ---") {
+		t.Error("prompt should contain declared dependency models")
+	}
+	if strings.Contains(prompt, "--- auth ---") {
+		t.Error("prompt should not contain undeclared dependency auth")
+	}
+}
+
+func TestBuildComponentPrompt_SpecFirst(t *testing.T) {
+	spec := "Build a REST API"
+	comp := gene.Component{
+		Name:      "routes",
+		Interface: "HTTP handlers",
+	}
+	prompt := buildComponentPrompt(spec, comp, nil, ScenarioCapabilities{}, "")
+	specIdx := strings.Index(prompt, spec)
+	contractIdx := strings.Index(prompt, "COMPONENT CONTRACT:")
+	if specIdx < 0 || contractIdx < 0 {
+		t.Fatal("prompt missing spec or contract section")
+	}
+	if specIdx >= contractIdx {
+		t.Error("spec should appear before component contract (caching correctness)")
 	}
 }

--- a/internal/attractor/toposort.go
+++ b/internal/attractor/toposort.go
@@ -1,0 +1,75 @@
+package attractor
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/foundatron/octopusgarden/internal/gene"
+)
+
+var errTopoSortCycle = errors.New("attractor: dependency cycle detected")
+
+// topoSort returns components in dependency-first order (leaves first) using Kahn's algorithm.
+// Returns an error if the dependency graph contains a cycle or references an unknown component.
+func topoSort(components []gene.Component) ([]gene.Component, error) {
+	byName, inDegree, err := buildTopoGraph(components)
+	if err != nil {
+		return nil, err
+	}
+	return kahnSort(components, byName, inDegree)
+}
+
+// buildTopoGraph validates dependencies and computes in-degrees.
+func buildTopoGraph(components []gene.Component) (map[string]gene.Component, map[string]int, error) {
+	byName := make(map[string]gene.Component, len(components))
+	inDegree := make(map[string]int, len(components))
+	for _, c := range components {
+		byName[c.Name] = c
+		inDegree[c.Name] = 0
+	}
+	for _, c := range components {
+		for _, dep := range c.DependsOn {
+			if _, ok := byName[dep]; !ok {
+				return nil, nil, fmt.Errorf("%w: %q depends on %q", errUnknownDependency, c.Name, dep)
+			}
+			inDegree[c.Name]++
+		}
+	}
+	return byName, inDegree, nil
+}
+
+// kahnSort performs Kahn's BFS topological sort using precomputed in-degrees.
+func kahnSort(components []gene.Component, byName map[string]gene.Component, inDegree map[string]int) ([]gene.Component, error) {
+	// Build reverse adjacency: dep -> list of dependents.
+	dependents := make(map[string][]string, len(components))
+	for _, c := range components {
+		for _, dep := range c.DependsOn {
+			dependents[dep] = append(dependents[dep], c.Name)
+		}
+	}
+
+	queue := make([]string, 0, len(components))
+	for _, c := range components {
+		if inDegree[c.Name] == 0 {
+			queue = append(queue, c.Name)
+		}
+	}
+
+	sorted := make([]gene.Component, 0, len(components))
+	for len(queue) > 0 {
+		name := queue[0]
+		queue = queue[1:]
+		sorted = append(sorted, byName[name])
+		for _, dependent := range dependents[name] {
+			inDegree[dependent]--
+			if inDegree[dependent] == 0 {
+				queue = append(queue, dependent)
+			}
+		}
+	}
+
+	if len(sorted) != len(components) {
+		return nil, errTopoSortCycle
+	}
+	return sorted, nil
+}

--- a/internal/attractor/toposort_test.go
+++ b/internal/attractor/toposort_test.go
@@ -1,0 +1,113 @@
+package attractor
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/foundatron/octopusgarden/internal/gene"
+)
+
+func TestTopoSort(t *testing.T) {
+	tests := []struct {
+		name       string
+		components []gene.Component
+		wantOrder  []string // expected name order (dependency-first)
+		wantErr    error
+	}{
+		{
+			name: "linear_chain",
+			components: []gene.Component{
+				{Name: "A", DependsOn: []string{"B"}},
+				{Name: "B", DependsOn: []string{"C"}},
+				{Name: "C"},
+			},
+			wantOrder: []string{"C", "B", "A"},
+		},
+		{
+			name: "diamond",
+			components: []gene.Component{
+				{Name: "A", DependsOn: []string{"B", "C"}},
+				{Name: "B", DependsOn: []string{"D"}},
+				{Name: "C", DependsOn: []string{"D"}},
+				{Name: "D"},
+			},
+			// D must come first; B and C before A; D before B and C.
+			wantOrder: nil, // check constraints instead
+		},
+		{
+			name: "no_dependencies",
+			components: []gene.Component{
+				{Name: "X"},
+				{Name: "Y"},
+				{Name: "Z"},
+			},
+			wantOrder: nil, // just check count
+		},
+		{
+			name: "single_component",
+			components: []gene.Component{
+				{Name: "solo"},
+			},
+			wantOrder: []string{"solo"},
+		},
+		{
+			name: "cycle_detection",
+			components: []gene.Component{
+				{Name: "A", DependsOn: []string{"B"}},
+				{Name: "B", DependsOn: []string{"A"}},
+			},
+			wantErr: errTopoSortCycle,
+		},
+		{
+			name: "unknown_dependency",
+			components: []gene.Component{
+				{Name: "A", DependsOn: []string{"missing"}},
+			},
+			wantErr: errUnknownDependency,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sorted, err := topoSort(tt.components)
+			if tt.wantErr != nil {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !errors.Is(err, tt.wantErr) && err.Error() != tt.wantErr.Error() {
+					t.Fatalf("expected error %q, got %q", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(sorted) != len(tt.components) {
+				t.Fatalf("expected %d components, got %d", len(tt.components), len(sorted))
+			}
+
+			if tt.wantOrder != nil {
+				for i, want := range tt.wantOrder {
+					if sorted[i].Name != want {
+						t.Errorf("position %d: want %q, got %q", i, want, sorted[i].Name)
+					}
+				}
+				return
+			}
+
+			// For non-deterministic orders, verify topological constraint:
+			// every component appears after all its dependencies.
+			pos := make(map[string]int, len(sorted))
+			for i, c := range sorted {
+				pos[c.Name] = i
+			}
+			for _, c := range sorted {
+				for _, dep := range c.DependsOn {
+					if pos[dep] >= pos[c.Name] {
+						t.Errorf("component %q (pos %d) appears before dependency %q (pos %d)", c.Name, pos[c.Name], dep, pos[dep])
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/scenario/loader_test.go
+++ b/internal/scenario/loader_test.go
@@ -212,3 +212,43 @@ func TestLoad_requestFields(t *testing.T) {
 		t.Error("Body is nil, expected parsed YAML value")
 	}
 }
+
+func TestComponentFieldRoundTrip(t *testing.T) {
+	const yaml = `
+id: models-crud
+description: "test component field"
+component: models
+steps:
+  - description: "check something"
+    request:
+      method: GET
+      path: /items
+    expect: "works"
+`
+	sc, err := Load(strings.NewReader(yaml))
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if sc.Component != "models" {
+		t.Errorf("Component = %q, want %q", sc.Component, "models")
+	}
+
+	// Empty component should also work.
+	const yamlNoComponent = `
+id: integration-test
+description: "no component"
+steps:
+  - description: "check"
+    request:
+      method: GET
+      path: /
+    expect: "ok"
+`
+	sc2, err := Load(strings.NewReader(yamlNoComponent))
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if sc2.Component != "" {
+		t.Errorf("Component = %q, want empty", sc2.Component)
+	}
+}

--- a/internal/scenario/types.go
+++ b/internal/scenario/types.go
@@ -57,8 +57,9 @@ type StepOutput struct {
 type Scenario struct {
 	ID                   string   `yaml:"id"`
 	Description          string   `yaml:"description"`
-	Type                 string   `yaml:"type"`   // "api" only for MVP
-	Weight               *float64 `yaml:"weight"` // nil means not set, defaults to 1.0
+	Type                 string   `yaml:"type"`      // "api" only for MVP
+	Weight               *float64 `yaml:"weight"`    // nil means not set, defaults to 1.0
+	Component            string   `yaml:"component"` // component name for composed convergence; empty = integration scenario
 	Setup                []Step   `yaml:"setup"`
 	Steps                []Step   `yaml:"steps"`
 	SatisfactionCriteria string   `yaml:"satisfaction_criteria"`

--- a/schemas/scenario.json
+++ b/schemas/scenario.json
@@ -26,6 +26,10 @@
       "exclusiveMinimum": 0,
       "description": "Relative weight for aggregate satisfaction scoring. Defaults to 1.0."
     },
+    "component": {
+      "type": "string",
+      "description": "Component name for composed convergence. Empty or omitted means integration scenario (validated against composed app)."
+    },
     "satisfaction_criteria": {
       "type": "string",
       "description": "Overall criteria the LLM judge uses to evaluate this scenario."


### PR DESCRIPTION
Closes #184

## Changes
**1. `internal/scenario/types.go`** -- Add `Component` field to `Scenario`
- Add `Component string \`yaml:"component"\`` after `Weight`
- Empty string = integration scenario (validated against composed app)

**2. `schemas/scenario.json`** -- Add `component` property
- Add `"component": { "type": "string" }` to the scenario schema object

**3. `internal/attractor/attractor.go`** -- Core composed convergence logic
- Import `gene` package
- Add to `RunOptions`:
  ```go
  GeneComponents      []gene.Component       // structured component decomposition
  ComponentValidators map[string]ValidateFn  // per-component validators; "" key = integration
  ```
- Add sentinel: `var errComponentFallback = errors.New("attractor: component convergence failed, falling back to monolithic")`
- In `Run()`, after `withDefaults(opts)`: if `len(opts.GeneComponents) > 0 && len(opts.ComponentValidators) > 0`, check agentic mode (log warning + skip to monolithic if `opts.Agentic`), otherwise call `a.runComposed(ctx, rawSpec, s)`. If result is non-nil, return it. If error is `errComponentFallback`, log and continue to monolithic loop. Otherwise return error.
- New method `runComposed(ctx context.Context, rawSpec string, s *runState) (*RunResult, error)`:
  1. `topoSort(s.opts.GeneComponents)` -- error on cycle
  2. Build `componentFiles map[string]map[string]string` and `depInterfaces map[string]string`
  3. For each component in topo order:
     - Merge dependency files into a base file set for the build context
     - Run `a.convergeComponent(ctx, rawSpec, comp, depInterfaces, componentFiles, s)`
     - On failure, return `nil, errComponentFallback`
     - Cache result in `componentFiles[comp.Name]`; record `depInterfaces[comp.Name] = comp.Interface`
  4. Merge all component files into `composedFiles` (later topo order wins, log on overlap)
  5. Write composed files, build, run, validate with `s.opts.ComponentValidators[""]` (integration)
  6. On integration failure, return `nil, errComponentFallback`
- New method `convergeComponent(...)`:
  - Local state: history, stallCount, bestScore, bestFiles, codeHashes (not shared with `s`)
  - Accumulate cost into `s.totalCost`
  - Mini-loop: max 5 iterations, stall limit 2
  - Each iteration: generate with `buildComponentPrompt()`, parse files, merge with dep files for build context, build container, validate with `s.opts.ComponentValidators[comp.Name]`
  - On satisfaction >= threshold, return files
  - On exhaustion, return `nil, errComponentFallback`
  - Check `s.budgetExceeded()` before each LLM call

**4. `internal/attractor/toposort.go`** (new file)
- `func topoSort(components []gene.Component) ([]gene.Component, error)` -- Kahn's algorithm
- `var errTopoSortCycle = errors.New("attractor: dependency cycle detected")`
- Returns dependency-first order (leaves first)

**5. `internal/attractor/prompts.go`** -- Component-scoped prompt
- Add `buildComponentPrompt(spec string, component gene.Component, depInterfaces map[string]string, caps ScenarioCapabilities, language string) string`:
  - `systemPromptPrefix` + spec (cacheable prefix)
  - `\n\nCOMPONENT CONTRACT:\n` + `component.Interface`
  - `\n\nCOMPONENT PATTERNS:\n` + `component.Patterns`
  - If deps present: `\n\nDEPENDENCY INTERFACES:\n` with each dep's interface text
  - Capability suffix + dep rules (reuse existing helpers)
  - No gene guide text (component data replaces it)

**6. `cmd/octog/main.go`** -- CLI wiring
- In `runCmd`, after `loadGenes()`: if genes path was provided, call `gene.Load(genesPath)` to get the full `Gene` struct, extract `Components`
- Add `GeneComponents []gene.Component` to `runLoopParams`
- In `runAttractorLoop()`:
  - Set `opts.GeneComponents` from params
  - When components are present, build `opts.ComponentValidators`:
    - For each unique component name, build a `ValidateFn` that filters scenarios to `sc.Component == name` before calling `runAndScore`
    - Key `""` filters to `sc.Component == ""`
  - Pass through to `opts.ComponentValidators`

---

## Review Findings
- Errors: 1
- Warnings: 5
- Nits: 3
- Assessment: **NEEDS CHANGES**

The cost leak (#1) is the critical issue -- it breaks the budget invariant and misreports spend. The double gene load (#2) and silent error swallowing (#3) are straightforward fixes. The missing tracing (#6) should be addressed before this ships to avoid operational blind spots.
