### PR TITLE
feat(scenario): add difficulty tier to scenarios

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -377,6 +377,7 @@ type Scenario struct {
 	Type                 string   `yaml:"type"`      // "api" only for MVP
 	Weight               *float64 `yaml:"weight"`    // nil means not set, defaults to 1.0
 	Component            string   `yaml:"component"` // component name for composed convergence; empty = integration scenario
+	Tier                 int      `yaml:"tier"`      // difficulty tier (1=simple, 2=moderate, 3=complex); auto-inferred when 0
 	Setup                []Step   `yaml:"setup"`
 	Steps                []Step   `yaml:"steps"`
 	SatisfactionCriteria string   `yaml:"satisfaction_criteria"`
@@ -530,6 +531,11 @@ steps:
 satisfaction_criteria: |
   All CRUD operations work correctly with appropriate status codes.
 ```
+
+`weight` defaults to 1.0 in aggregate scoring when not set. `tier` is auto-inferred by `inferTier`
+in `loader.go` when not set (zero): >6 judged steps or ≥3 steps with captures → 3 (complex); >3
+judged steps or ≥1 step with captures → 2 (moderate); else → 1 (simple). The `octog lint` checker
+warns if `tier` is explicitly set outside the 1–3 range.
 
 #### gRPC Step
 

--- a/internal/lint/scenario.go
+++ b/internal/lint/scenario.go
@@ -139,6 +139,9 @@ func lintScenarioContent(path string, data []byte) []Diagnostic {
 	// Check weight.
 	diags = append(diags, checkWeight(path, fields)...)
 
+	// Check tier.
+	diags = append(diags, checkTier(path, fields)...)
+
 	// Check steps.
 	stepsNode, stepsLine := getFieldNode(fields, "steps")
 	if stepsNode == nil {
@@ -255,6 +258,31 @@ func checkWeight(path string, fields map[string]*fieldEntry) []Diagnostic {
 			Line:    fe.value.Line,
 			Level:   Warning,
 			Message: "weight must be positive",
+		}}
+	}
+	return nil
+}
+
+func checkTier(path string, fields map[string]*fieldEntry) []Diagnostic {
+	fe, ok := fields["tier"]
+	if !ok {
+		return nil
+	}
+	var t int
+	if err := fe.value.Decode(&t); err != nil {
+		return []Diagnostic{{
+			File:    path,
+			Line:    fe.value.Line,
+			Level:   Warning,
+			Message: fmt.Sprintf("tier must be a number: %s", err),
+		}}
+	}
+	if t < 1 || t > 3 {
+		return []Diagnostic{{
+			File:    path,
+			Line:    fe.value.Line,
+			Level:   Warning,
+			Message: "tier must be between 1 and 3",
 		}}
 	}
 	return nil

--- a/internal/lint/scenario_test.go
+++ b/internal/lint/scenario_test.go
@@ -993,6 +993,50 @@ steps:
 			wantErrors: 1,
 			wantMsg:    "exec files must be a mapping",
 		},
+		{
+			name: "tier 0 is invalid",
+			yaml: `id: test
+tier: 0
+steps:
+  - description: A step
+    request:
+      method: GET
+      path: /items
+    expect: "ok"
+`,
+			wantErrors: 0,
+			wantWarns:  1,
+			wantMsg:    "tier must be between 1 and 3",
+		},
+		{
+			name: "tier 4 is invalid",
+			yaml: `id: test
+tier: 4
+steps:
+  - description: A step
+    request:
+      method: GET
+      path: /items
+    expect: "ok"
+`,
+			wantErrors: 0,
+			wantWarns:  1,
+			wantMsg:    "tier must be between 1 and 3",
+		},
+		{
+			name: "tier 2 is valid",
+			yaml: `id: test
+tier: 2
+steps:
+  - description: A step
+    request:
+      method: GET
+      path: /items
+    expect: "ok"
+`,
+			wantErrors: 0,
+			wantWarns:  0,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/scenario/loader.go
+++ b/internal/scenario/loader.go
@@ -92,5 +92,30 @@ func parseScenario(data []byte) (Scenario, error) {
 		s.Weight = &w
 	}
 
+	if s.Tier == 0 {
+		s.Tier = inferTier(s)
+	}
+
 	return s, nil
+}
+
+// inferTier assigns a difficulty tier based on step count and capture usage.
+// Tier 3: more than 6 judged steps, or 3+ steps with captures.
+// Tier 2: more than 3 judged steps, or at least 1 step with captures.
+// Tier 1: everything else.
+func inferTier(s Scenario) int {
+	stepsWithCaptures := 0
+	for _, step := range s.Steps {
+		if len(step.Capture) > 0 {
+			stepsWithCaptures++
+		}
+	}
+	switch {
+	case len(s.Steps) > 6 || stepsWithCaptures >= 3:
+		return 3
+	case len(s.Steps) > 3 || stepsWithCaptures >= 1:
+		return 2
+	default:
+		return 1
+	}
 }

--- a/internal/scenario/loader_test.go
+++ b/internal/scenario/loader_test.go
@@ -213,6 +213,87 @@ func TestLoad_requestFields(t *testing.T) {
 	}
 }
 
+func TestTierInference(t *testing.T) {
+	makeSteps := func(n int) []Step {
+		steps := make([]Step, n)
+		for i := range steps {
+			steps[i] = Step{Request: &Request{Method: "GET", Path: "/items"}}
+		}
+		return steps
+	}
+	makeStepsWithCaptures := func(n, withCap int) []Step {
+		steps := makeSteps(n)
+		for i := range withCap {
+			steps[i].Capture = []Capture{{Name: "x", JSONPath: "$.id"}}
+		}
+		return steps
+	}
+
+	// Explicit tier round-trips through YAML without inference.
+	t.Run("explicit tier round-trips", func(t *testing.T) {
+		input := "id: t\ntier: 2\nsteps:\n  - request:\n      method: GET\n      path: /items\n    expect: ok\n"
+		s, err := Load(strings.NewReader(input))
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if s.Tier != 2 {
+			t.Errorf("Tier = %d, want 2", s.Tier)
+		}
+	})
+
+	tests := []struct {
+		name     string
+		scenario Scenario
+		wantTier int
+	}{
+		{
+			name:     "2 steps no captures -> tier 1",
+			scenario: Scenario{ID: "t", Steps: makeSteps(2)},
+			wantTier: 1,
+		},
+		{
+			name:     "4 steps no captures -> tier 2",
+			scenario: Scenario{ID: "t", Steps: makeSteps(4)},
+			wantTier: 2,
+		},
+		{
+			name:     "3 steps 1 capture -> tier 2",
+			scenario: Scenario{ID: "t", Steps: makeStepsWithCaptures(3, 1)},
+			wantTier: 2,
+		},
+		{
+			name:     "8 steps no captures -> tier 3",
+			scenario: Scenario{ID: "t", Steps: makeSteps(8)},
+			wantTier: 3,
+		},
+		{
+			name:     "3 steps 3 captures -> tier 3",
+			scenario: Scenario{ID: "t", Steps: makeStepsWithCaptures(3, 3)},
+			wantTier: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := inferTier(tt.scenario)
+			if got != tt.wantTier {
+				t.Errorf("inferTier() = %d, want %d", got, tt.wantTier)
+			}
+		})
+	}
+
+	// sampleYAML: 2 judged steps, setup-only capture -> tier 1
+	t.Run("sampleYAML infers tier 1", func(t *testing.T) {
+		s, err := Load(strings.NewReader(sampleYAML))
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if s.Tier != 1 {
+			t.Errorf("Tier = %d, want 1", s.Tier)
+		}
+	})
+}
+
 func TestComponentFieldRoundTrip(t *testing.T) {
 	const yaml = `
 id: models-crud

--- a/internal/scenario/types.go
+++ b/internal/scenario/types.go
@@ -60,6 +60,7 @@ type Scenario struct {
 	Type                 string   `yaml:"type"`      // "api" only for MVP
 	Weight               *float64 `yaml:"weight"`    // nil means not set, defaults to 1.0
 	Component            string   `yaml:"component"` // component name for composed convergence; empty = integration scenario
+	Tier                 int      `yaml:"tier"`      // difficulty tier (1=simple, 2=moderate, 3=complex); auto-inferred when 0
 	Setup                []Step   `yaml:"setup"`
 	Steps                []Step   `yaml:"steps"`
 	SatisfactionCriteria string   `yaml:"satisfaction_criteria"`

--- a/schemas/scenario.json
+++ b/schemas/scenario.json
@@ -26,6 +26,12 @@
       "exclusiveMinimum": 0,
       "description": "Relative weight for aggregate satisfaction scoring. Defaults to 1.0."
     },
+    "tier": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 3,
+      "description": "Difficulty tier (1=simple, 2=moderate, 3=complex). Auto-inferred from step count and capture usage when omitted."
+    },
     "component": {
       "type": "string",
       "description": "Component name for composed convergence. Empty or omitted means integration scenario (validated against composed app)."


### PR DESCRIPTION
Closes #181

## Changes
1. **`internal/scenario/types.go`** -- Add `Tier int` field to `Scenario` struct with yaml tag `"tier"`, placed after `Component`, before `Setup`.

2. **`internal/scenario/loader.go`** -- Two additions:
   - After weight defaulting (line 93), add: `if s.Tier == 0 { s.Tier = inferTier(s) }`
   - Add `inferTier(s Scenario) int` function (value receiver, pure):
     - Count judged steps: `len(s.Steps)`
     - Count steps with captures: iterate `s.Steps`, check `len(step.Capture) > 0`
     - Tier 3: `len(s.Steps) > 6 || stepsWithCaptures >= 3`
     - Tier 2: `len(s.Steps) > 3 || stepsWithCaptures >= 1`
     - Tier 1: everything else

3. **`internal/lint/scenario.go`** -- Add `checkTier(path string, fields map[string]*fieldEntry) []Diagnostic`:
   - Absent -> return nil
   - Decode as int; fail -> Warning
   - Value < 1 or > 3 -> Warning: `"tier must be between 1 and 3"`
   - Call from `lintScenarioContent` after `checkWeight` (line 140)

4. **`schemas/scenario.json`** -- Add `"tier"` property after `"weight"`:
   ```json
   "tier": {
     "type": "integer",
     "minimum": 1,
     "maximum": 3,
     "description": "Difficulty tier (1=simple, 2=moderate, 3=complex). Auto-inferred from step count and capture usage when omitted."
   }
   ```

## Review Findings
- Errors: 0
- Warnings: 0
- Nits: 3
- Assessment: **PASS**

Clean, well-scoped change. The inference heuristic is simple and appropriate, the lint integration follows the existing `checkWeight` pattern exactly, tests cover the meaningful boundaries (tier 1/2/3 thresholds, explicit round-trip, edge counts), and the JSON schema, types, and docs are all updated consistently. Using `int` zero-value as "unset" is idiomatic Go and the linter correctly warns if someone explicitly writes `tier: 0`.
