### PR TITLE
feat(gene): create Go HTTP REST reference exemplar for gene extraction

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -73,10 +73,12 @@ octopusgarden/
 │   ├── store/                    # SQLite run history (db.go, types.go)
 │   ├── testutil/                 # Test helpers
 │   └── e2e/                      # End-to-end integration tests
-├── examples/                     # Example specs and scenarios
-│   └── <name>/
-│       ├── spec.md               # Spec file
-│       └── scenarios/            # Scenario YAML files
+├── examples/                     # Example specs, scenarios, and reference implementations
+│   ├── <name>/
+│   │   ├── spec.md               # Spec file
+│   │   └── scenarios/            # Scenario YAML files
+│   └── exemplars/                # Reference implementations for gene extraction
+│       └── go-rest/              # Go stdlib REST API (CRUD, pagination, in-memory store)
 └── docs/architecture.md          # This file
 ```
 

--- a/docs/gene-transfusion.md
+++ b/docs/gene-transfusion.md
@@ -6,8 +6,11 @@ attractor loop, bootstrapping code generation with proven architectural decision
 ## Quick Start
 
 ```bash
-# 1. Extract patterns from your best project
+# 1. Extract patterns from your best project (or use the bundled go-rest exemplar)
 octog extract --source-dir /path/to/exemplar --output genes.json
+
+# Bundled Go REST exemplar — good starting point for Go HTTP services
+octog extract --source-dir examples/exemplars/go-rest --output genes.json
 
 # 2. Run the factory with extracted genes
 octog run \
@@ -283,7 +286,8 @@ assets (`.exe`, `.png`, `.woff`).
 ## Best Practices
 
 - **Extract from your best project.** The gene captures patterns from the source directory -- pick a
-  well-structured exemplar that represents the conventions you want.
+  well-structured exemplar that represents the conventions you want. The bundled
+  `examples/exemplars/go-rest` exemplar is a ready-made starting point for Go HTTP services.
 - **Re-extract after major refactors.** Gene files are snapshots. If the exemplar's architecture
   evolves, re-run `octog extract` to update the gene.
 - **Commit gene files.** They're small JSON files (~2-5 KB) that encode team conventions. Version

--- a/examples/exemplars/go-rest/.gitignore
+++ b/examples/exemplars/go-rest/.gitignore
@@ -1,0 +1,2 @@
+go-rest
+server

--- a/examples/exemplars/go-rest/Dockerfile
+++ b/examples/exemplars/go-rest/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.24-alpine AS builder
+WORKDIR /app
+COPY . .
+RUN CGO_ENABLED=0 go build -o server .
+
+FROM scratch
+COPY --from=builder /app/server /server
+EXPOSE 8080
+CMD ["/server"]

--- a/examples/exemplars/go-rest/go.mod
+++ b/examples/exemplars/go-rest/go.mod
@@ -1,0 +1,3 @@
+module go-rest
+
+go 1.24

--- a/examples/exemplars/go-rest/handlers.go
+++ b/examples/exemplars/go-rest/handlers.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+)
+
+// writeJSON encodes v as JSON and writes it with the given status code.
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// writeError writes an ErrorResponse with the given status and message.
+func writeError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, ErrorResponse{Error: msg})
+}
+
+// registerRoutes wires all routes onto mux.
+func registerRoutes(mux *http.ServeMux, store *Store) {
+	mux.HandleFunc("GET /health", handleHealth)
+	mux.HandleFunc("POST /items", handleCreateItem(store))
+	mux.HandleFunc("GET /items", handleListItems(store))
+	mux.HandleFunc("GET /items/{id}", handleGetItem(store))
+	mux.HandleFunc("PUT /items/{id}", handleUpdateItem(store))
+	mux.HandleFunc("DELETE /items/{id}", handleDeleteItem(store))
+}
+
+func handleHealth(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func handleCreateItem(store *Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req CreateItemRequest
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // 1 MiB
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid JSON")
+			return
+		}
+		if req.Name == "" {
+			writeError(w, http.StatusBadRequest, "name is required")
+			return
+		}
+		item, err := store.Create(req)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to create item")
+			return
+		}
+		w.Header().Set("Location", "/items/"+item.ID)
+		writeJSON(w, http.StatusCreated, item)
+	}
+}
+
+func handleListItems(store *Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		limit := 20
+		offset := 0
+		if v := r.URL.Query().Get("limit"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				limit = n
+			}
+		}
+		if v := r.URL.Query().Get("offset"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+				offset = n
+			}
+		}
+		items, total := store.List(limit, offset)
+		writeJSON(w, http.StatusOK, ListResponse{
+			Items:  items,
+			Total:  total,
+			Limit:  limit,
+			Offset: offset,
+		})
+	}
+}
+
+func handleGetItem(store *Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := r.PathValue("id")
+		item, err := store.Get(id)
+		if errors.Is(err, errNotFound) {
+			writeError(w, http.StatusNotFound, "item not found")
+			return
+		}
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to get item")
+			return
+		}
+		writeJSON(w, http.StatusOK, item)
+	}
+}
+
+func handleUpdateItem(store *Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := r.PathValue("id")
+		var req UpdateItemRequest
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // 1 MiB
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid JSON")
+			return
+		}
+		if req.Name == "" {
+			writeError(w, http.StatusBadRequest, "name is required")
+			return
+		}
+		item, err := store.Update(id, req)
+		if errors.Is(err, errNotFound) {
+			writeError(w, http.StatusNotFound, "item not found")
+			return
+		}
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to update item")
+			return
+		}
+		writeJSON(w, http.StatusOK, item)
+	}
+}
+
+func handleDeleteItem(store *Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := r.PathValue("id")
+		err := store.Delete(id)
+		if errors.Is(err, errNotFound) {
+			writeError(w, http.StatusNotFound, "item not found")
+			return
+		}
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to delete item")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}

--- a/examples/exemplars/go-rest/handlers_test.go
+++ b/examples/exemplars/go-rest/handlers_test.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	registerRoutes(mux, NewStore())
+	return httptest.NewServer(mux)
+}
+
+func TestHandleHealth(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/health")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+}
+
+func TestHandleCreateItem(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		wantStatus int
+	}{
+		{
+			name:       "valid",
+			body:       `{"name":"widget","description":"a widget"}`,
+			wantStatus: http.StatusCreated,
+		},
+		{
+			name:       "missing name",
+			body:       `{"description":"no name"}`,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "invalid JSON",
+			body:       `not json`,
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newTestServer(t)
+			defer srv.Close()
+
+			resp, err := http.Post(srv.URL+"/items", "application/json", strings.NewReader(tc.body))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != tc.wantStatus {
+				t.Errorf("status = %d, want %d", resp.StatusCode, tc.wantStatus)
+			}
+		})
+	}
+}
+
+func TestHandleGetItem(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	// Create an item first.
+	body := `{"name":"thing","description":"a thing"}`
+	resp, err := http.Post(srv.URL+"/items", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	var created Item
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name       string
+		id         string
+		wantStatus int
+	}{
+		{"found", created.ID, http.StatusOK},
+		{"not found", "00000000-0000-0000-0000-000000000000", http.StatusNotFound},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := http.Get(srv.URL + "/items/" + tc.id)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != tc.wantStatus {
+				t.Errorf("status = %d, want %d", resp.StatusCode, tc.wantStatus)
+			}
+		})
+	}
+}
+
+func TestHandleListItems(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	for i := range 3 {
+		body, _ := json.Marshal(CreateItemRequest{Name: "item", Description: string(rune('A' + i))})
+		resp, err := http.Post(srv.URL+"/items", "application/json", bytes.NewReader(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+	}
+
+	resp, err := http.Get(srv.URL + "/items?limit=2&offset=0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	var list ListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&list); err != nil {
+		t.Fatal(err)
+	}
+	if list.Total != 3 {
+		t.Errorf("Total = %d, want 3", list.Total)
+	}
+	if len(list.Items) != 2 {
+		t.Errorf("len(Items) = %d, want 2", len(list.Items))
+	}
+}
+
+func TestHandleUpdateItem(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	// Create an item.
+	resp, err := http.Post(srv.URL+"/items", "application/json", strings.NewReader(`{"name":"old"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	var created Item
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name       string
+		id         string
+		body       string
+		wantStatus int
+	}{
+		{"update existing", created.ID, `{"name":"new"}`, http.StatusOK},
+		{"not found", "00000000-0000-0000-0000-000000000000", `{"name":"x"}`, http.StatusNotFound},
+		{"missing name", created.ID, `{"description":"no name"}`, http.StatusBadRequest},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req, _ := http.NewRequest(http.MethodPut, srv.URL+"/items/"+tc.id, strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != tc.wantStatus {
+				t.Errorf("status = %d, want %d", resp.StatusCode, tc.wantStatus)
+			}
+		})
+	}
+}
+
+func TestHandleDeleteItem(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	// Create an item.
+	resp, err := http.Post(srv.URL+"/items", "application/json", strings.NewReader(`{"name":"todelete"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	var created Item
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name       string
+		id         string
+		wantStatus int
+	}{
+		{"delete existing", created.ID, http.StatusNoContent},
+		{"already deleted", created.ID, http.StatusNotFound},
+		{"not found", "00000000-0000-0000-0000-000000000000", http.StatusNotFound},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/items/"+tc.id, nil)
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != tc.wantStatus {
+				t.Errorf("status = %d, want %d", resp.StatusCode, tc.wantStatus)
+			}
+		})
+	}
+}

--- a/examples/exemplars/go-rest/main.go
+++ b/examples/exemplars/go-rest/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"os/signal"
+	"syscall"
+)
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	store := NewStore()
+	mux := http.NewServeMux()
+	registerRoutes(mux, store)
+
+	srv := &http.Server{
+		Addr:    ":8080",
+		Handler: mux,
+	}
+
+	go func() {
+		<-ctx.Done()
+		_ = srv.Shutdown(context.Background()) //nolint:contextcheck
+	}()
+
+	slog.Info("server listening", "addr", srv.Addr)
+	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		slog.Error("server error", "err", err)
+	}
+}

--- a/examples/exemplars/go-rest/store.go
+++ b/examples/exemplars/go-rest/store.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+var errNotFound = errors.New("item not found")
+
+// Store is an in-memory item store with ordered iteration and O(1) lookup.
+type Store struct {
+	mu    sync.RWMutex
+	items map[string]*Item
+	order []string // insertion-order IDs
+}
+
+// NewStore creates a new empty Store.
+func NewStore() *Store {
+	return &Store{
+		items: make(map[string]*Item),
+		order: make([]string, 0),
+	}
+}
+
+// newID generates a UUID v4-style ID.
+func newID() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate id: %w", err)
+	}
+	// Set version (4) and variant bits.
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+	encoded := hex.EncodeToString(b)
+	return encoded[:8] + "-" + encoded[8:12] + "-" + encoded[12:16] + "-" + encoded[16:20] + "-" + encoded[20:], nil
+}
+
+// Create adds a new item to the store.
+func (s *Store) Create(req CreateItemRequest) (Item, error) {
+	id, err := newID()
+	if err != nil {
+		return Item{}, err
+	}
+	item := &Item{
+		ID:          id,
+		Name:        req.Name,
+		Description: req.Description,
+		CreatedAt:   time.Now().UTC(),
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.items[id] = item
+	s.order = append(s.order, id)
+	return *item, nil
+}
+
+// Get returns the item with the given ID, or errNotFound.
+func (s *Store) Get(id string) (Item, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	item, ok := s.items[id]
+	if !ok {
+		return Item{}, errNotFound
+	}
+	return *item, nil
+}
+
+// List returns a paginated slice of items in insertion order and the total count,
+// both read under a single lock to avoid TOCTOU inconsistency.
+func (s *Store) List(limit, offset int) ([]Item, int) {
+	if limit <= 0 {
+		limit = 20
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	total := len(s.order)
+	if offset >= total {
+		return []Item{}, total
+	}
+	end := min(offset+limit, total)
+	result := make([]Item, 0, end-offset)
+	for _, id := range s.order[offset:end] {
+		result = append(result, *s.items[id])
+	}
+	return result, total
+}
+
+// Update modifies an existing item, or returns errNotFound.
+func (s *Store) Update(id string, req UpdateItemRequest) (Item, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	item, ok := s.items[id]
+	if !ok {
+		return Item{}, errNotFound
+	}
+	item.Name = req.Name
+	item.Description = req.Description
+	return *item, nil
+}
+
+// Delete removes an item from the store, or returns errNotFound.
+func (s *Store) Delete(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.items[id]; !ok {
+		return errNotFound
+	}
+	delete(s.items, id)
+	for i, oid := range s.order {
+		if oid == id {
+			s.order = append(s.order[:i], s.order[i+1:]...)
+			break
+		}
+	}
+	return nil
+}

--- a/examples/exemplars/go-rest/types.go
+++ b/examples/exemplars/go-rest/types.go
@@ -1,0 +1,36 @@
+package main
+
+import "time"
+
+// Item represents a resource in the store.
+type Item struct {
+	ID          string    `json:"id"`
+	Name        string    `json:"name"`
+	Description string    `json:"description"`
+	CreatedAt   time.Time `json:"created_at"`
+}
+
+// CreateItemRequest is the request body for creating an item.
+type CreateItemRequest struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+// UpdateItemRequest is the request body for updating an item.
+type UpdateItemRequest struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+// ErrorResponse is returned for all error responses.
+type ErrorResponse struct {
+	Error string `json:"error"`
+}
+
+// ListResponse wraps a paginated list of items.
+type ListResponse struct {
+	Items  []Item `json:"items"`
+	Total  int    `json:"total"`
+	Limit  int    `json:"limit"`
+	Offset int    `json:"offset"`
+}


### PR DESCRIPTION
Closes #185

## Changes
**New files under `examples/exemplars/go-rest/`:**

1. **`go.mod`** -- `module go-rest`, `go 1.24`. Zero external dependencies.

2. **`types.go`** -- `Item` (ID, Name, Description, CreatedAt), `CreateItemRequest` (Name, Description required), `UpdateItemRequest` (Name, Description), `ErrorResponse` (Error string), `ListResponse` (Items, Total, Limit, Offset). JSON struct tags on all exported fields.

3. **`store.go`** -- In-memory store: `sync.Mutex`, map for lookups, slice for ordered iteration. Methods: Create, Get, List (limit/offset with bounds checking), Update, Delete. UUID via `crypto/rand` (16 bytes → hex-with-dashes format). No name-uniqueness constraint, no 409.

4. **`handlers.go`** -- HTTP handlers using Go 1.22+ `http.ServeMux` patterns:
   - `GET /health` → 200 `{"status":"ok"}`
   - `POST /items` → 201 + Location header + created item (400 on bad JSON or missing Name)
   - `GET /items` → 200 with pagination (limit/offset query params, defaults 20/0)
   - `GET /items/{id}` → 200 with item (404 if not found)
   - `PUT /items/{id}` → 200 with updated item (404 if not found, 400 on bad JSON or missing Name)
   - `DELETE /items/{id}` → 204 no body (404 if not found)
   - All errors as JSON `ErrorResponse` with appropriate status codes
   - Use `http.PathValue("id")` for wildcard extraction

5. **`main.go`** -- Create store, wire routes on `http.ServeMux`, `log/slog` structured logging (log listen address on startup), listen `:8080`, graceful shutdown via `signal.NotifyContext`.

6. **`Dockerfile`** -- Multi-stage: `golang:1.24-alpine` builder (`CGO_ENABLED=0 go build -o server .`) → `scratch` final stage (EXPOSE 8080, CMD ["/server"]). Use `scratch` not `alpine` -- no shell needed, smaller image, better gene signal for minimal containers.

**No modifications to existing files.**

## Review Findings
- Errors: 1
- Warnings: 3
- Nits: 2
- Assessment: **NEEDS CHANGES**

The data race (finding 1) is the critical issue — returning mutable pointers from a locked store and reading them after unlock is unsound. The simplest fix is to return value copies:

```go
func (s *Store) Get(id string) (Item, error) {
    s.mu.Lock()
    defer s.mu.Unlock()
    item, ok := s.items[id]
    if !ok {
        return Item{}, errNotFound
    }
    return *item, nil  // return a copy
}
```
