### PR TITLE
feat(gene): create Python HTTP REST reference exemplar for gene extraction

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,7 +78,8 @@ octopusgarden/
 │   │   ├── spec.md               # Spec file
 │   │   └── scenarios/            # Scenario YAML files
 │   └── exemplars/                # Reference implementations for gene extraction
-│       └── go-rest/              # Go stdlib REST API (CRUD, pagination, in-memory store)
+│       ├── go-rest/              # Go stdlib REST API (CRUD, pagination, in-memory store)
+│       └── python-rest/          # Python stdlib REST API (CRUD, pagination, in-memory store)
 └── docs/architecture.md          # This file
 ```
 

--- a/docs/gene-transfusion.md
+++ b/docs/gene-transfusion.md
@@ -6,11 +6,14 @@ attractor loop, bootstrapping code generation with proven architectural decision
 ## Quick Start
 
 ```bash
-# 1. Extract patterns from your best project (or use the bundled go-rest exemplar)
+# 1. Extract patterns from your best project (or use a bundled exemplar)
 octog extract --source-dir /path/to/exemplar --output genes.json
 
 # Bundled Go REST exemplar — good starting point for Go HTTP services
 octog extract --source-dir examples/exemplars/go-rest --output genes.json
+
+# Bundled Python REST exemplar — good starting point for Python HTTP services
+octog extract --source-dir examples/exemplars/python-rest --output genes.json
 
 # 2. Run the factory with extracted genes
 octog run \
@@ -287,7 +290,8 @@ assets (`.exe`, `.png`, `.woff`).
 
 - **Extract from your best project.** The gene captures patterns from the source directory -- pick a
   well-structured exemplar that represents the conventions you want. The bundled
-  `examples/exemplars/go-rest` exemplar is a ready-made starting point for Go HTTP services.
+  `examples/exemplars/go-rest` exemplar is a ready-made starting point for Go HTTP services;
+  `examples/exemplars/python-rest` covers Python stdlib HTTP services.
 - **Re-extract after major refactors.** Gene files are snapshots. If the exemplar's architecture
   evolves, re-run `octog extract` to update the gene.
 - **Commit gene files.** They're small JSON files (~2-5 KB) that encode team conventions. Version

--- a/examples/exemplars/python-rest/Dockerfile
+++ b/examples/exemplars/python-rest/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+COPY . .
+
+EXPOSE 8080
+
+CMD ["python3", "app.py"]

--- a/examples/exemplars/python-rest/app.py
+++ b/examples/exemplars/python-rest/app.py
@@ -1,0 +1,88 @@
+"""Python REST exemplar: items CRUD API using stdlib only."""
+
+import re
+import signal
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from socketserver import ThreadingMixIn
+
+from handlers import (
+    handle_create_item,
+    handle_delete_item,
+    handle_get_item,
+    handle_health,
+    handle_list_items,
+    handle_update_item,
+    write_error,
+)
+from store import Store
+
+_ITEM_ID_RE = re.compile(r"^/items/([^/]+)$")
+
+
+class ThreadingHTTPServer(ThreadingMixIn, HTTPServer):
+    daemon_threads = True
+
+
+class ItemHandler(BaseHTTPRequestHandler):
+    store: Store
+
+    def log_message(self, fmt, *args):  # noqa: D102
+        pass  # suppress default access log; structured logging preferred
+
+    def do_GET(self):
+        path = self.path.split("?")[0]
+        if path == "/health":
+            handle_health(self, self.store)
+        elif path == "/items":
+            handle_list_items(self, self.store)
+        else:
+            m = _ITEM_ID_RE.match(path)
+            if m:
+                handle_get_item(self, self.store, m.group(1))
+            else:
+                self._not_found()
+
+    def do_POST(self):
+        if self.path.split("?")[0] == "/items":
+            handle_create_item(self, self.store)
+        else:
+            self._not_found()
+
+    def do_PUT(self):
+        m = _ITEM_ID_RE.match(self.path.split("?")[0])
+        if m:
+            handle_update_item(self, self.store, m.group(1))
+        else:
+            self._not_found()
+
+    def do_DELETE(self):
+        m = _ITEM_ID_RE.match(self.path.split("?")[0])
+        if m:
+            handle_delete_item(self, self.store, m.group(1))
+        else:
+            self._not_found()
+
+    def _not_found(self):
+        write_error(self, 404, "not found")
+
+
+def main():
+    store = Store()
+    server = ThreadingHTTPServer(("0.0.0.0", 8080), ItemHandler)
+    # Inject store via class attribute — stdlib pattern for sharing state with handlers.
+    server.RequestHandlerClass.store = store
+
+    def shutdown(signum, frame):
+        server.shutdown()
+        sys.exit(0)
+
+    signal.signal(signal.SIGINT, shutdown)
+    signal.signal(signal.SIGTERM, shutdown)
+
+    print("server listening on :8080", flush=True)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/exemplars/python-rest/handlers.py
+++ b/examples/exemplars/python-rest/handlers.py
@@ -1,0 +1,130 @@
+"""HTTP handler functions for the items REST API."""
+
+import dataclasses
+import json
+from urllib.parse import parse_qs, urlparse
+
+from store import NotFoundError, Store
+
+
+def write_json(handler, status: int, data) -> None:
+    body = json.dumps(data).encode()
+    handler.send_response(status)
+    handler.send_header("Content-Type", "application/json")
+    handler.send_header("Content-Length", str(len(body)))
+    handler.end_headers()
+    handler.wfile.write(body)
+
+
+def write_error(handler, status: int, msg: str) -> None:
+    write_json(handler, status, {"error": msg})
+
+
+def handle_health(handler, store: Store) -> None:
+    write_json(handler, 200, {"status": "ok"})
+
+
+def handle_create_item(handler, store: Store) -> None:
+    try:
+        length = int(handler.headers.get("Content-Length", 0))
+    except ValueError:
+        length = 0
+    if length > 1 << 20:
+        write_error(handler, 400, "request body too large")
+        return
+    try:
+        body = json.loads(handler.rfile.read(length))
+    except (json.JSONDecodeError, ValueError):
+        write_error(handler, 400, "invalid JSON")
+        return
+    name = body.get("name", "").strip()
+    if not name:
+        write_error(handler, 400, "name is required")
+        return
+    description = body.get("description", "")
+    item = store.create(name, description)
+    handler.send_response(201)
+    handler.send_header("Content-Type", "application/json")
+    handler.send_header("Location", f"/items/{item.id}")
+    body_bytes = json.dumps(dataclasses.asdict(item)).encode()
+    handler.send_header("Content-Length", str(len(body_bytes)))
+    handler.end_headers()
+    handler.wfile.write(body_bytes)
+
+
+def handle_list_items(handler, store: Store) -> None:
+    parsed = urlparse(handler.path)
+    params = parse_qs(parsed.query)
+    limit = 20
+    offset = 0
+    try:
+        if "limit" in params:
+            v = int(params["limit"][0])
+            if v > 0:
+                limit = v
+    except ValueError:
+        pass
+    try:
+        if "offset" in params:
+            v = int(params["offset"][0])
+            if v >= 0:
+                offset = v
+    except ValueError:
+        pass
+    items, total = store.list(limit, offset)
+    write_json(
+        handler,
+        200,
+        {
+            "items": [dataclasses.asdict(i) for i in items],
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+        },
+    )
+
+
+def handle_get_item(handler, store: Store, item_id: str) -> None:
+    try:
+        item = store.get(item_id)
+    except NotFoundError:
+        write_error(handler, 404, "item not found")
+        return
+    write_json(handler, 200, dataclasses.asdict(item))
+
+
+def handle_update_item(handler, store: Store, item_id: str) -> None:
+    try:
+        length = int(handler.headers.get("Content-Length", 0))
+    except ValueError:
+        length = 0
+    if length > 1 << 20:
+        write_error(handler, 400, "request body too large")
+        return
+    try:
+        body = json.loads(handler.rfile.read(length))
+    except (json.JSONDecodeError, ValueError):
+        write_error(handler, 400, "invalid JSON")
+        return
+    name = body.get("name", "").strip()
+    if not name:
+        write_error(handler, 400, "name is required")
+        return
+    description = body.get("description", "")
+    try:
+        item = store.update(item_id, name, description)
+    except NotFoundError:
+        write_error(handler, 404, "item not found")
+        return
+    write_json(handler, 200, dataclasses.asdict(item))
+
+
+def handle_delete_item(handler, store: Store, item_id: str) -> None:
+    try:
+        store.delete(item_id)
+    except NotFoundError:
+        write_error(handler, 404, "item not found")
+        return
+    handler.send_response(204)
+    handler.send_header("Content-Length", "0")
+    handler.end_headers()

--- a/examples/exemplars/python-rest/requirements.txt
+++ b/examples/exemplars/python-rest/requirements.txt
@@ -1,0 +1,1 @@
+# stdlib only — no dependencies

--- a/examples/exemplars/python-rest/store.py
+++ b/examples/exemplars/python-rest/store.py
@@ -1,0 +1,77 @@
+"""In-memory item store with thread-safe access and insertion-order iteration."""
+
+import dataclasses
+import threading
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+
+class NotFoundError(Exception):
+    """Raised when an item is not found in the store."""
+
+
+@dataclass
+class Item:
+    id: str
+    name: str
+    description: str
+    created_at: str
+
+
+class Store:
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._items: dict[str, Item] = {}
+        self._order: list[str] = []
+
+    def create(self, name: str, description: str) -> Item:
+        item_id = str(uuid.uuid4())
+        created_at = (
+            datetime.now(timezone.utc)
+            .isoformat(timespec="milliseconds")
+            .replace("+00:00", "Z")
+        )
+        item = Item(
+            id=item_id, name=name, description=description, created_at=created_at
+        )
+        with self._lock:
+            self._items[item_id] = item
+            self._order.append(item_id)
+        return item
+
+    def get(self, item_id: str) -> Item:
+        with self._lock:
+            item = self._items.get(item_id)
+            if item is None:
+                raise NotFoundError(item_id)
+            return dataclasses.replace(item)
+
+    def list(self, limit: int = 20, offset: int = 0) -> tuple[list[Item], int]:
+        if limit <= 0:
+            limit = 20
+        if offset < 0:
+            offset = 0
+        with self._lock:
+            total = len(self._order)
+            if offset >= total:
+                return [], total
+            end = min(offset + limit, total)
+            items = [self._items[i] for i in self._order[offset:end]]
+        return items, total
+
+    def update(self, item_id: str, name: str, description: str) -> Item:
+        with self._lock:
+            item = self._items.get(item_id)
+            if item is None:
+                raise NotFoundError(item_id)
+            item.name = name
+            item.description = description
+            return dataclasses.replace(item)
+
+    def delete(self, item_id: str) -> None:
+        with self._lock:
+            if item_id not in self._items:
+                raise NotFoundError(item_id)
+            del self._items[item_id]
+            self._order.remove(item_id)

--- a/examples/exemplars/python-rest/test_store.py
+++ b/examples/exemplars/python-rest/test_store.py
@@ -1,0 +1,84 @@
+"""Smoke tests for the in-memory Store: create/get/list/update/delete round-trip."""
+
+import unittest
+
+from store import NotFoundError, Store
+
+
+class TestStore(unittest.TestCase):
+    def setUp(self):
+        self.store = Store()
+
+    def test_create_and_get(self):
+        item = self.store.create("widget", "a small widget")
+        self.assertEqual(item.name, "widget")
+        self.assertEqual(item.description, "a small widget")
+        self.assertTrue(item.id)
+        self.assertTrue(item.created_at.endswith("Z"))
+
+        fetched = self.store.get(item.id)
+        self.assertEqual(fetched.id, item.id)
+        self.assertEqual(fetched.name, item.name)
+
+    def test_get_returns_copy(self):
+        item = self.store.create("original", "")
+        copy = self.store.get(item.id)
+        copy.name = "mutated"
+        # Mutation of the returned copy must not affect the stored item.
+        self.assertEqual(self.store.get(item.id).name, "original")
+
+    def test_get_not_found(self):
+        with self.assertRaises(NotFoundError):
+            self.store.get("does-not-exist")
+
+    def test_list_empty(self):
+        items, total = self.store.list()
+        self.assertEqual(items, [])
+        self.assertEqual(total, 0)
+
+    def test_list_pagination(self):
+        for i in range(5):
+            self.store.create(f"item-{i}", "")
+        items, total = self.store.list(limit=2, offset=0)
+        self.assertEqual(total, 5)
+        self.assertEqual(len(items), 2)
+        self.assertEqual(items[0].name, "item-0")
+        self.assertEqual(items[1].name, "item-1")
+
+        page2, _ = self.store.list(limit=2, offset=2)
+        self.assertEqual(len(page2), 2)
+        self.assertEqual(page2[0].name, "item-2")
+
+    def test_update(self):
+        item = self.store.create("old", "old desc")
+        updated = self.store.update(item.id, "new", "new desc")
+        self.assertEqual(updated.name, "new")
+        self.assertEqual(updated.description, "new desc")
+        self.assertEqual(self.store.get(item.id).name, "new")
+
+    def test_update_not_found(self):
+        with self.assertRaises(NotFoundError):
+            self.store.update("no-such-id", "x", "")
+
+    def test_delete(self):
+        item = self.store.create("to-delete", "")
+        self.store.delete(item.id)
+        with self.assertRaises(NotFoundError):
+            self.store.get(item.id)
+        _, total = self.store.list()
+        self.assertEqual(total, 0)
+
+    def test_delete_not_found(self):
+        with self.assertRaises(NotFoundError):
+            self.store.delete("no-such-id")
+
+    def test_insertion_order_preserved(self):
+        names = ["alpha", "beta", "gamma"]
+        for n in names:
+            self.store.create(n, "")
+        items, _ = self.store.list()
+        self.assertEqual([i.name for i in items], names)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #186

## Changes
**1. Create `examples/exemplars/python-rest/store.py`** (new file)
- `Item` dataclass: `id`, `name`, `description`, `created_at` (ISO string)
- `NotFoundError(Exception)` — mirrors Go's `errNotFound` sentinel
- `Store` class with `threading.Lock`, `dict` storage, `list` for insertion order
- Methods: `create(name, description) -> Item`, `get(id) -> Item`, `list(limit, offset) -> (items, total)`, `update(id, name, description) -> Item`, `delete(id)`
- `uuid.uuid4()` for IDs, `datetime.utcnow().isoformat() + "Z"` for timestamps

**2. Create `examples/exemplars/python-rest/handlers.py`** (new file)
- `write_json(handler, status, data)` and `write_error(handler, status, msg)` — take handler instance as first arg
- Handler functions: `handle_health`, `handle_create_item`, `handle_list_items`, `handle_get_item`, `handle_update_item`, `handle_delete_item`
- Each takes `(handler, store, **kwargs)` where kwargs includes `item_id` when needed
- JSON parse errors → 400, missing name → 400, not found → 404, delete → 204

**3. Create `examples/exemplars/python-rest/app.py`** (new file)
- `ThreadingHTTPServer` + custom `BaseHTTPRequestHandler` subclass
- `do_GET`, `do_POST`, `do_PUT`, `do_DELETE` with manual path routing
- Path parsing: regex or simple `split("/")` to extract item ID from `/items/{id}`
- `Store` instance shared across requests (attached to server or module-level)
- Signal handler for graceful `server.shutdown()`
- Listen on `0.0.0.0:8080`
- Entry point: `if __name__ == "__main__"` block

**4. Create `examples/exemplars/python-rest/Dockerfile`** (new file)
- `FROM python:3.12-slim`
- `WORKDIR /app`, `COPY . .`
- `EXPOSE 8080`
- `CMD ["python3", "app.py"]`

**5. Create `examples/exemplars/python-rest/requirements.txt`** (new file)
- Empty (stdlib only) — serves as Python language marker for `gene.Scan()`

## Review Findings
- Errors: 0
- Warnings: 1
- Nits: 6
- Assessment: **NEEDS CHANGES** (the missing tests warning; the nits are optional but several would improve the exemplar's value as a reference codebase for gene extraction)
