### PR TITLE
feat(attractor): stratified scenario validation by difficulty tier

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ Requires: Go 1.24+, Docker, an Anthropic or OpenAI API key.
   consecutive non-improving iterations, downgrade back after 5 consecutive improvements
 - **Gene Transfusion** -- Extract coding patterns from exemplar codebases to bootstrap generation
   (`octog extract` -> `octog run --genes`)
+- **Stratified Validation** -- `--stratified` flag validates scenarios by ascending difficulty tier
+  (1→2→3), converging each tier before advancing; prevents easy scenarios masking hard failures
 
 ## Documentation
 

--- a/cmd/octog/main.go
+++ b/cmd/octog/main.go
@@ -171,6 +171,7 @@ func runCmd(ctx context.Context, logger *slog.Logger, args []string) error {
 	maxTokensFlag := fs.Int("max-tokens", 0, "max output tokens for generation (0 = auto-scale per model)")
 	agenticFlag := fs.Bool("agentic", false, "enable agentic generation mode (multi-turn tool-use)")
 	agentMaxTurnsFlag := fs.Int("agent-max-turns", 0, "max tool-use turns per iteration (0 = use attractor default)")
+	stratifiedFlag := fs.Bool("stratified", false, "validate scenarios by ascending difficulty tier (1→2→3), converging each tier before advancing")
 
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: octog run [flags]\n\nFlags:\n")
@@ -253,6 +254,7 @@ func runCmd(ctx context.Context, logger *slog.Logger, args []string) error {
 		Agentic:           *agenticFlag,
 		AgentMaxTurns:     *agentMaxTurnsFlag,
 		GeneComponents:    geneComponents,
+		Stratified:        *stratifiedFlag,
 	})
 }
 
@@ -313,6 +315,7 @@ type runLoopParams struct {
 	Agentic           bool
 	AgentMaxTurns     int
 	GeneComponents    []gene.Component
+	Stratified        bool
 }
 
 func runAttractorLoop(ctx context.Context, logger *slog.Logger, llmClient llm.Client, p runLoopParams) error {
@@ -411,6 +414,7 @@ func runAttractorLoop(ctx context.Context, logger *slog.Logger, llmClient llm.Cl
 		AgentMaxTurns:       p.AgentMaxTurns,
 		GeneComponents:      p.GeneComponents,
 		ComponentValidators: componentValidators,
+		Stratified:          p.Stratified,
 	}
 
 	startedAt := time.Now()
@@ -1354,6 +1358,7 @@ func buildComponentValidators(scenarios []scenario.Scenario, llmClient llm.Clien
 		grouped[sc.Component] = append(grouped[sc.Component], sc)
 	}
 
+	// Component validators always use the full per-component scenario set (maxTier is ignored).
 	validators := make(map[string]attractor.ValidateFn, len(grouped))
 	for name, group := range grouped {
 		validators[name] = observability.WrapValidateFn(
@@ -1363,11 +1368,24 @@ func buildComponentValidators(scenarios []scenario.Scenario, llmClient llm.Clien
 }
 
 func buildValidateFn(scenarios []scenario.Scenario, llmClient llm.Client, judgeModel string, baseOpts executorOpts, grpcTargetGetter func() string) attractor.ValidateFn {
-	return func(ctx context.Context, url string, restart attractor.RestartFunc) (float64, []string, float64, error) {
+	return func(ctx context.Context, url string, restart attractor.RestartFunc, maxTier int) (float64, []string, float64, error) {
+		active := scenarios
+		if maxTier > 0 {
+			filtered := make([]scenario.Scenario, 0, len(scenarios))
+			for _, sc := range scenarios {
+				if sc.Tier <= maxTier {
+					filtered = append(filtered, sc)
+				}
+			}
+			if baseOpts.logger != nil {
+				baseOpts.logger.Debug("stratified validation: filtered scenarios", "max_tier", maxTier, "total", len(scenarios), "active", len(filtered))
+			}
+			active = filtered
+		}
 		opts := baseOpts
 		opts.targetURL = url
 		opts.grpcTarget = grpcTargetGetter()
-		agg, err := runAndScore(ctx, scenarios, opts, llmClient, judgeModel, restart, 1)
+		agg, err := runAndScore(ctx, active, opts, llmClient, judgeModel, restart, 1)
 		if err != nil {
 			return 0, nil, 0, err
 		}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -691,7 +691,9 @@ type ContainerManager interface {
 // The attractor never imports internal/scenario — the CLI provides this closure.
 // restart may be called to stop the current container and start a fresh one between scenarios.
 // restart is nil for gRPC and exec-only paths that do not support container restart.
-type ValidateFn func(ctx context.Context, url string, restart RestartFunc) (satisfaction float64, failures []string, cost float64, err error)
+// maxTier, when > 0, restricts validation to scenarios with Tier <= maxTier (stratified mode).
+// maxTier == 0 means run all scenarios (non-stratified or component validators).
+type ValidateFn func(ctx context.Context, url string, restart RestartFunc, maxTier int) (satisfaction float64, failures []string, cost float64, err error)
 ```
 
 [embedmd]:# (../internal/attractor/attractor.go go /^\/\/ RunOptions configures/ /^}/)
@@ -719,6 +721,7 @@ type RunOptions struct {
 	MaxTokens           int                   // max output tokens for generation; 0 = auto-scale per model
 	Agentic             bool                  // if true, use AgentLoop for code generation (tool-use mode)
 	AgentMaxTurns       int                   // max turns per AgentLoop call; 0 = default (50 when Agentic is true)
+	Stratified          bool                  // if true, validate by ascending difficulty tier (1→2→3), converging each before advancing
 	GeneComponents      []gene.Component      // structured component decomposition from gene extraction
 	ComponentValidators map[string]ValidateFn // per-component validators; "" key = integration validator
 }
@@ -773,9 +776,12 @@ type RunResult struct {
    k. Write files to workspace/{run_id}/iter_{n}/
    l. docker build → docker run → wait for health check
    m. Run test command if configured (non-zero exit → test_fail)
-   n. call validate(ctx, url) → satisfaction, failures
+   n. call validate(ctx, url, maxTier) → satisfaction, failures
+      - maxTier = activeTier in stratified mode; 0 = all scenarios (non-stratified)
    o. Detect per-scenario regressions (score dropped below threshold since last validation)
-   p. If satisfaction >= threshold and no regressions blocking → return "converged"
+   p. If satisfaction >= threshold and no regressions blocking → converged for this tier
+      - Stratified: if activeTier < 3, advance activeTier++, reset per-tier state, continue loop
+      - Stratified: if activeTier == 3 (or non-stratified), return "converged"
    q. Determine feedback fidelity: compact (iter 1-2) → standard (3-4) → full (5+)
    r. Track improvement/stalls; patch mode: disable after 2 consecutive regressions
    s. If stall count >= stall limit → return "stalled"
@@ -1090,7 +1096,7 @@ implement it). The service name is `octog`.
 
 ```text
 octog interview  [--output spec.md] [--model ...] [--provider anthropic|openai] [--prompt "What would you like to build?"] [--seed <existing-spec.md>] [--scenarios]
-octog run        --spec <path> --scenarios <dir> [--model claude-sonnet-4-6] [--frugal-model ...] [--judge-model claude-haiku-4-5] [--budget 5.00] [--threshold 95] [--genes genes.json] [--language go] [--patch] [--block-on-regression] [--context-budget 0] [--otel-endpoint ...] [--skip-preflight] [--preflight-threshold 0.8] [-v 0|1|2] [--provider anthropic|openai]
+octog run        --spec <path> --scenarios <dir> [--model claude-sonnet-4-6] [--frugal-model ...] [--judge-model claude-haiku-4-5] [--budget 5.00] [--threshold 95] [--genes genes.json] [--language go] [--patch] [--block-on-regression] [--context-budget 0] [--stratified] [--agentic] [--agent-max-turns N] [--otel-endpoint ...] [--skip-preflight] [--preflight-threshold 0.8] [-v 0|1|2] [--provider anthropic|openai]
 octog validate   --scenarios <dir> --target <url> [--grpc-target host:port] [--judge-model claude-haiku-4-5] [--threshold 0] [--format text|json] [-v 0|1|2] [--provider anthropic|openai]
 octog preflight  [--judge-model claude-haiku-4-5] [--threshold 0.8] [--verbose] [--scenarios <dir>] <spec-path>
 octog status     [--format text|json]

--- a/internal/attractor/attractor.go
+++ b/internal/attractor/attractor.go
@@ -47,6 +47,10 @@ const summarizeModel = "claude-haiku-4-5"
 // when no AgentMaxTurns is specified in RunOptions.
 const defaultAgentMaxTurns = 50
 
+// maxStratifiedTier is the highest difficulty tier in stratified validation mode.
+// Tiers progress 1 -> 2 -> 3; convergence at tier 3 ends the run.
+const maxStratifiedTier = 3
+
 // Status constants for RunResult.
 const (
 	StatusConverged      = "converged"
@@ -124,7 +128,9 @@ type RestartFunc func(ctx context.Context) (newURL string, err error)
 // The attractor never imports internal/scenario — the CLI provides this closure.
 // restart may be called to stop the current container and start a fresh one between scenarios.
 // restart is nil for gRPC and exec-only paths that do not support container restart.
-type ValidateFn func(ctx context.Context, url string, restart RestartFunc) (satisfaction float64, failures []string, cost float64, err error)
+// maxTier, when > 0, restricts validation to scenarios with Tier <= maxTier (stratified mode).
+// maxTier == 0 means run all scenarios (non-stratified or component validators).
+type ValidateFn func(ctx context.Context, url string, restart RestartFunc, maxTier int) (satisfaction float64, failures []string, cost float64, err error)
 
 // Attractor orchestrates the convergence loop: generate code → build → validate → iterate.
 type Attractor struct {
@@ -157,6 +163,7 @@ type RunOptions struct {
 	MaxTokens           int                   // max output tokens for generation; 0 = auto-scale per model
 	Agentic             bool                  // if true, use AgentLoop for code generation (tool-use mode)
 	AgentMaxTurns       int                   // max turns per AgentLoop call; 0 = default (50 when Agentic is true)
+	Stratified          bool                  // if true, validate by ascending difficulty tier (1→2→3), converging each before advancing
 	GeneComponents      []gene.Component      // structured component decomposition from gene extraction
 	ComponentValidators map[string]ValidateFn // per-component validators; "" key = integration validator
 }
@@ -208,6 +215,7 @@ type runState struct {
 	codeHashes             []string                // SHA-256 hashes of generated file sets, in iteration order
 	escalation             *escalationState        // nil when FrugalModel is empty (escalation disabled)
 	lastTurns              int                     // number of agent turns used in the last iteration (0 for non-agentic)
+	activeTier             int                     // 0 = non-stratified; 1-3 = current difficulty tier in stratified mode
 }
 
 // currentModel returns the model to use for generation, respecting escalation state.
@@ -324,6 +332,7 @@ func (a *Attractor) Run(ctx context.Context, rawSpec string, opts RunOptions, va
 		grpcTargetProvider: grpcTargetProvider,
 		escalation:         newEscalationState(opts.FrugalModel, opts.Model, a.logger),
 		totalCost:          composedCost,
+		activeTier:         initialActiveTier(opts.Stratified),
 	}
 	s.baseDir = filepath.Join(opts.WorkspaceDir, s.runID)
 	s.bestDir = filepath.Join(s.baseDir, "best")
@@ -382,7 +391,8 @@ func (a *Attractor) Run(ctx context.Context, rawSpec string, opts RunOptions, va
 			s.escalation.recordOutcome(s.lastImproved, a.logger)
 		}
 
-		if result != nil {
+		// In stratified mode, converging a tier advances to the next; otherwise return result.
+		if result != nil && !a.advanceTierIfNeeded(result, s) {
 			a.setRunSpanAttrs(runSpan, result)
 			return result, nil
 		}
@@ -576,7 +586,7 @@ func (a *Attractor) validateComposed(ctx context.Context, composedFiles map[stri
 		defer stop()
 	}
 
-	satisfaction, failures, valCost, err := integrationValidate(ctx, url, nil)
+	satisfaction, failures, valCost, err := integrationValidate(ctx, url, nil, 0)
 	if err != nil {
 		return nil, fmt.Errorf("attractor: integration validate: %w", err)
 	}
@@ -775,7 +785,7 @@ func (a *Attractor) buildAndValidateComponent(ctx context.Context, iterDir, comp
 		defer stop()
 	}
 
-	satisfaction, failures, valCost, valErr := validate(ctx, url, nil)
+	satisfaction, failures, valCost, valErr := validate(ctx, url, nil, 0)
 	if valErr != nil {
 		return 0, nil, fmt.Errorf("attractor: validate component %q: %w", compName, valErr)
 	}
@@ -1186,7 +1196,7 @@ func (a *Attractor) buildRunValidate(ctx context.Context, iter int, iterDir stri
 		return stall, err
 	}
 
-	satisfaction, failures, valCost, err := validate(ctx, url, restartFn)
+	satisfaction, failures, valCost, err := validate(ctx, url, restartFn, s.activeTier)
 	if err != nil {
 		return nil, fmt.Errorf("attractor: validate iteration %d: %w", iter, err)
 	}
@@ -1495,6 +1505,50 @@ func (a *Attractor) checkStalled(iter int, s *runState) *RunResult {
 		return s.result(iter, StatusStalled)
 	}
 	return nil
+}
+
+// advanceTierIfNeeded checks whether stratified mode should advance to the next tier
+// after a convergence result. Returns true when the tier was advanced (caller should continue
+// the loop); returns false when the result should be returned to the caller.
+func (a *Attractor) advanceTierIfNeeded(result *RunResult, s *runState) bool {
+	if result.Status != StatusConverged || s.activeTier == 0 || s.activeTier >= maxStratifiedTier {
+		return false
+	}
+	s.activeTier++
+	a.logger.Info("tier advanced", "tier", s.activeTier, "prev_satisfaction", result.Satisfaction)
+	s.resetForTierAdvancement()
+	if s.escalation != nil {
+		s.escalation = newEscalationState(s.opts.FrugalModel, s.opts.Model, a.logger)
+	}
+	return true
+}
+
+// resetForTierAdvancement resets per-tier mutable state when stratified mode advances to the
+// next difficulty tier. Fields that must persist across tiers (bestFiles, bestDir, totalCost,
+// codeHashes, runID, startTime) are intentionally NOT reset here.
+func (s *runState) resetForTierAdvancement() {
+	s.bestSatisfaction = 0
+	s.stallCount = 0
+	s.scoreHistory = nil
+	s.history = nil
+	s.patchActive = s.opts.PatchMode
+	s.patchRegressionCount = 0
+	s.scenarioScores = nil
+	s.scenarioScoreIteration = 0
+	s.lastFailures = nil
+	s.lastOutcome = ""
+	s.lastSatisfaction = 0
+	s.lastImproved = false
+	s.lastTurns = 0
+}
+
+// initialActiveTier returns the starting activeTier for a run. In stratified mode tiers
+// begin at 1; non-stratified mode uses 0 (no tier filtering).
+func initialActiveTier(stratified bool) int {
+	if stratified {
+		return 1
+	}
+	return 0
 }
 
 // withDefaults fills in zero-value fields with sensible defaults.

--- a/internal/attractor/attractor_test.go
+++ b/internal/attractor/attractor_test.go
@@ -124,7 +124,7 @@ func TestConvergesImmediately(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -148,7 +148,7 @@ func TestConvergesOnIteration2(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		n := callCount.Add(1)
 		if n == 1 {
 			return 60, []string{"missing endpoint"}, 0.005, nil
@@ -175,7 +175,7 @@ func TestStalls(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 50, []string{"not good enough"}, 0.005, nil
 	}
 
@@ -204,7 +204,7 @@ func TestStallResetsOnImprovement(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		n := callCount.Add(1)
 		idx := int(n) - 1
 		if idx >= len(scores) {
@@ -237,7 +237,7 @@ func TestBudgetExceeded(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.04}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 50, []string{"not done"}, 0.02, nil
 	}
 
@@ -274,7 +274,7 @@ func TestBuildFailureFeedback(t *testing.T) {
 			return nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -307,7 +307,7 @@ func TestHealthCheckFailure(t *testing.T) {
 			return nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -327,7 +327,7 @@ func TestMaxIterations(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 80, []string{"close but no cigar"}, 0.005, nil
 	}
 
@@ -419,7 +419,7 @@ func TestCacheControlSet(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -444,7 +444,7 @@ func TestCheckpointWritten(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		n := callCount.Add(1)
 		return scores[int(n)-1], nil, 0.005, nil
 	}
@@ -482,7 +482,7 @@ func TestContainerRunFailure(t *testing.T) {
 			return container.RunResult{URL: "http://127.0.0.1:9999", ContainerID: "mock-container-id"}, func() {}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -513,7 +513,7 @@ func TestNeedsBrowserTriggersHTTPContainer(t *testing.T) {
 			return nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -544,7 +544,7 @@ func TestProgressCallback(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		n := callCount.Add(1)
 		return scores[int(n)-1], []string{"needs work"}, 0.005, nil
 	}
@@ -621,7 +621,7 @@ func TestProgressCallbackBuildFailure(t *testing.T) {
 			return nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -681,7 +681,7 @@ func TestPatchModeUsedOnIteration2(t *testing.T) {
 		},
 	}
 	var callCount atomic.Int32
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		n := callCount.Add(1)
 		if n == 1 {
 			return 60, []string{"missing endpoint"}, 0.005, nil
@@ -729,7 +729,7 @@ func TestPatchModeFallbackOnRegressions(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		n := callCount.Add(1)
 		idx := int(n) - 1
 		if idx >= len(scores) {
@@ -777,7 +777,7 @@ func TestPatchModeRegressionResets(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		n := callCount.Add(1)
 		idx := int(n) - 1
 		if idx >= len(scores) {
@@ -817,7 +817,7 @@ func TestPatchModeDisabledByDefault(t *testing.T) {
 		},
 	}
 	var callCount atomic.Int32
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		n := callCount.Add(1)
 		if n == 1 {
 			return 60, []string{"needs work"}, 0.005, nil
@@ -861,7 +861,7 @@ func TestPatchModeNotActiveWithoutBestFiles(t *testing.T) {
 			return nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -920,7 +920,7 @@ func main() { serveFixed() }
 	}
 
 	var valCount atomic.Int32
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		n := valCount.Add(1)
 		if n == 1 {
 			return 60, []string{"needs fix"}, 0.005, nil
@@ -962,7 +962,7 @@ func TestValidateError(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 0, nil, 0, fmt.Errorf("judge unavailable")
 	}
 
@@ -988,7 +988,7 @@ func TestContextBudgetZeroPreservesBehavior(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -1034,7 +1034,7 @@ Brief abstract of the spec.`,
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		n := callCount.Add(1)
 		if n == 1 {
 			return 60, []string{"missing endpoint"}, 0.005, nil
@@ -1085,7 +1085,7 @@ func TestContextBudgetSummarizeFailureNonFatal(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -1117,7 +1117,7 @@ func TestAttractorRunWithGenes(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -1151,7 +1151,7 @@ func TestAttractorRunGenesInSystemPrompt(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -1186,7 +1186,7 @@ func TestAttractorRunGenesPersistAcrossIterations(t *testing.T) {
 		},
 	}
 	var callCount atomic.Int32
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		n := callCount.Add(1)
 		if n < 3 {
 			return 60, []string{"needs work"}, 0.005, nil
@@ -1225,7 +1225,7 @@ func TestAttractorCrossLanguagePrompt(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -1292,7 +1292,7 @@ func TestStallNoticeAppearsInGenerateByIteration3(t *testing.T) {
 	}
 
 	// ValidateFn always returns the same failing scenario in the format parsed by parseFailedScenarios.
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 45, []string{"✗ stall-scenario (45/100)"}, 0.005, nil
 	}
 
@@ -1369,7 +1369,7 @@ func TestMinimalismPromptAppearsAbove80(t *testing.T) {
 			}
 			failures := []string{FormatScenarioFailureLine("test-scenario", 50)}
 			var validateCount atomic.Int32
-			validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+			validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 				n := validateCount.Add(1)
 				if n == 1 {
 					return tt.score, failures, 0, nil
@@ -1411,7 +1411,7 @@ func TestMinimalismPromptIncludesFailingScenarios(t *testing.T) {
 		FormatScenarioFailureLine("list-items", 55),
 	}
 	var validateCount atomic.Int32
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		n := validateCount.Add(1)
 		if n == 1 {
 			return 85, failures, 0, nil
@@ -1456,7 +1456,7 @@ func TestMinimalismPromptProgression(t *testing.T) {
 		},
 	}
 	var validateCount atomic.Int32
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		n := int(validateCount.Add(1)) - 1
 		if n < len(scores) {
 			return scores[n], scenarioFailures[n], 0, nil
@@ -1513,7 +1513,7 @@ func TestRegressionFeedbackInjected(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		n := validateCount.Add(1)
 		switch n {
 		case 1:
@@ -1597,7 +1597,7 @@ CMD ["./server"]
 	}
 
 	// Validation always fails — drives stall without converging.
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 30, []string{"not good enough"}, 0.005, nil
 	}
 
@@ -1657,7 +1657,7 @@ func TestBlockOnRegressionPreventsConvergence(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		n := validateCount.Add(1)
 		switch n {
 		case 1:
@@ -1702,7 +1702,7 @@ func TestTestCommandEmpty_SkipsMechanicalTest(t *testing.T) {
 			return container.ExecResult{ExitCode: 0}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -1735,7 +1735,7 @@ func TestTestCommandExitZero_ProceedsToJudge(t *testing.T) {
 			return container.ExecResult{ExitCode: 0, Stdout: "ok\n"}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		validateCalled = true
 		return 100, nil, 0.005, nil
 	}
@@ -1773,7 +1773,7 @@ func TestTestCommandExitNonZero_SkipsJudge(t *testing.T) {
 			return container.ExecResult{ExitCode: 1, Stderr: "FAIL: test_foo\n"}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		validateCalled = true
 		return 100, nil, 0.005, nil
 	}
@@ -1820,7 +1820,7 @@ func TestTestCommandOutput_IncludedInFeedback(t *testing.T) {
 			return container.ExecResult{ExitCode: 1, Stdout: testOutput, Stderr: ""}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -1847,7 +1847,7 @@ func validDiagnosisJSON() string {
 // Failure format matches FormatScenarioFailureLine so buildSteeringText can detect the stall.
 func stallingValidateFn(n int) (ValidateFn, *atomic.Int32) {
 	var count atomic.Int32
-	fn := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	fn := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		c := int(count.Add(1))
 		if c <= n {
 			return 50, []string{FormatScenarioFailureLine("auth", 50)}, 0.005, nil
@@ -2052,7 +2052,7 @@ func TestWonderReflect_OnlyOnStall(t *testing.T) {
 	}
 
 	// Always succeeds — no stall, no wonder/reflect.
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -2162,7 +2162,7 @@ func TestModelEscalationPassedToGenerate(t *testing.T) {
 			return nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -2211,7 +2211,7 @@ func TestNoEscalationWithoutFrugalModel(t *testing.T) {
 		},
 	}
 	var callCount atomic.Int32
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		n := callCount.Add(1)
 		if n < 3 {
 			return 50, []string{"not yet"}, 0.005, nil
@@ -2288,7 +2288,7 @@ func TestAgenticConverge(t *testing.T) {
 			return llm.AgentResponse{Turns: 2, TotalCost: 0.05}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -2321,7 +2321,7 @@ func TestAgenticCostTracking(t *testing.T) {
 			return llm.AgentResponse{Turns: 1, TotalCost: agentCost}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -2346,7 +2346,7 @@ func TestAgenticTurnsReported(t *testing.T) {
 			return llm.AgentResponse{Turns: wantTurns, TotalCost: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -2401,7 +2401,7 @@ func TestAgenticPatchPreSeed(t *testing.T) {
 	}
 
 	var callCount atomic.Int32
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		n := callCount.Add(1)
 		if n == 1 {
 			return 60, []string{"needs work"}, 0.005, nil
@@ -2456,7 +2456,7 @@ func TestAgenticPatchMergesUnchangedFiles(t *testing.T) {
 	}
 
 	var callCount atomic.Int32
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		n := callCount.Add(1)
 		if n == 1 {
 			return 60, []string{"needs work"}, 0.005, nil
@@ -2491,7 +2491,7 @@ func TestAgenticRequiresAgentClient(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput()}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -2521,7 +2521,7 @@ func TestAgenticBuildFailure(t *testing.T) {
 		},
 	}
 
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -2560,7 +2560,7 @@ func TestAgenticWonderReflectSkipped(t *testing.T) {
 	}
 
 	var callCount atomic.Int32
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		n := callCount.Add(1)
 		if n < 3 {
 			return 50, []string{"scenario-a (50/100)"}, 0.005, nil
@@ -2648,7 +2648,7 @@ func TestTruncationWithParsableOutput(t *testing.T) {
 			}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -2668,10 +2668,10 @@ func TestComposedConvergence_BothComponentsConverge(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	componentValidate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	componentValidate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
-	integrationValidate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	integrationValidate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -2706,7 +2706,7 @@ func TestComposedConvergence_FallbackToMonolithic(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	monolithicValidate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	monolithicValidate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -2734,7 +2734,7 @@ func TestComposedConvergence_NoComponents(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -2777,7 +2777,7 @@ func TestComposedConvergence_BudgetExhausted(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.50}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 50, []string{"not done"}, 0.01, nil
 	}
 
@@ -2814,7 +2814,7 @@ func TestComposedConvergence_AgenticSkip(t *testing.T) {
 			return llm.AgentResponse{Turns: 1, TotalCost: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -2871,10 +2871,10 @@ func TestComposedConvergence_TransitiveDeps(t *testing.T) {
 		},
 	}
 
-	componentValidate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	componentValidate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
-	integrationValidate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	integrationValidate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -2919,13 +2919,13 @@ func TestComposedConvergence_IntegrationFail(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	componentValidate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	componentValidate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
-	integrationValidate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	integrationValidate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 40, []string{"integration broken"}, 0.005, nil
 	}
-	monolithicValidate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	monolithicValidate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -2946,5 +2946,232 @@ func TestComposedConvergence_IntegrationFail(t *testing.T) {
 	}
 	if result.Status != StatusConverged {
 		t.Errorf("expected status %q, got %q", StatusConverged, result.Status)
+	}
+}
+
+// TestNonStratifiedUnchanged verifies that Stratified: false passes maxTier=0 to ValidateFn
+// and the loop behaves identically to pre-stratification behavior.
+func TestNonStratifiedUnchanged(t *testing.T) {
+	client := &mockLLMClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
+		},
+	}
+	var receivedMaxTier int
+	validate := func(_ context.Context, _ string, _ RestartFunc, maxTier int) (float64, []string, float64, error) {
+		receivedMaxTier = maxTier
+		return 96, nil, 0.005, nil
+	}
+
+	opts := defaultOpts(t)
+	// Stratified is false by default.
+
+	a := New(client, &mockContainerMgr{}, testLogger(), nil)
+	result, err := a.Run(context.Background(), "Build a hello world app", opts, validate, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != StatusConverged {
+		t.Errorf("expected status %q, got %q", StatusConverged, result.Status)
+	}
+	if receivedMaxTier != 0 {
+		t.Errorf("expected maxTier=0 for non-stratified mode, got %d", receivedMaxTier)
+	}
+}
+
+// TestStratifiedTierAdvancement verifies that Stratified: true advances through tiers 1→2→3,
+// passing the correct maxTier to ValidateFn for each tier, and returns StatusConverged after tier 3.
+func TestStratifiedTierAdvancement(t *testing.T) {
+	client := &mockLLMClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
+		},
+	}
+
+	var receivedTiers []int
+	validate := func(_ context.Context, _ string, _ RestartFunc, maxTier int) (float64, []string, float64, error) {
+		receivedTiers = append(receivedTiers, maxTier)
+		return 96, nil, 0.005, nil
+	}
+
+	opts := defaultOpts(t)
+	opts.Stratified = true
+	opts.MaxIterations = 10
+
+	a := New(client, &mockContainerMgr{}, testLogger(), nil)
+	result, err := a.Run(context.Background(), "Build an app", opts, validate, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != StatusConverged {
+		t.Errorf("expected status %q, got %q", StatusConverged, result.Status)
+	}
+
+	// Three tiers should have been validated: maxTier 1, 2, 3.
+	if len(receivedTiers) != 3 {
+		t.Fatalf("expected 3 validation calls (one per tier), got %d: %v", len(receivedTiers), receivedTiers)
+	}
+	if receivedTiers[0] != 1 {
+		t.Errorf("first call should have maxTier=1, got %d", receivedTiers[0])
+	}
+	if receivedTiers[1] != 2 {
+		t.Errorf("second call should have maxTier=2, got %d", receivedTiers[1])
+	}
+	if receivedTiers[2] != 3 {
+		t.Errorf("third call should have maxTier=3, got %d", receivedTiers[2])
+	}
+}
+
+// TestStratifiedStallAtTier1 verifies that when stratified mode is on but satisfaction never
+// improves past the stall limit, the run terminates with StatusStalled at tier 1.
+func TestStratifiedStallAtTier1(t *testing.T) {
+	client := &mockLLMClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
+		},
+	}
+	var tiersSeen []int
+	validate := func(_ context.Context, _ string, _ RestartFunc, maxTier int) (float64, []string, float64, error) {
+		tiersSeen = append(tiersSeen, maxTier)
+		return 50, []string{"not good enough"}, 0.005, nil
+	}
+
+	opts := defaultOpts(t)
+	opts.Stratified = true
+	opts.StallLimit = 3
+
+	a := New(client, &mockContainerMgr{}, testLogger(), nil)
+	result, err := a.Run(context.Background(), "Build an app", opts, validate, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != StatusStalled {
+		t.Errorf("expected status %q, got %q", StatusStalled, result.Status)
+	}
+
+	// All calls should have maxTier=1 — never advanced to tier 2.
+	for i, tier := range tiersSeen {
+		if tier != 1 {
+			t.Errorf("call %d: expected maxTier=1 (never advanced), got %d", i, tier)
+		}
+	}
+}
+
+// TestStratifiedFullProgression verifies that stall count resets between tiers so that
+// a brief stall on tier 3 does not carry over the stall count from tier 2.
+func TestStratifiedFullProgression(t *testing.T) {
+	client := &mockLLMClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
+		},
+	}
+
+	// Tier 1: converges on call 1 (96%)
+	// Tier 2: converges on call 2 (96%)
+	// Tier 3: fails call 3 (40%), then converges call 4 (96%)
+	var callCount atomic.Int32
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
+		n := callCount.Add(1)
+		switch n {
+		case 3:
+			return 40, []string{"failing"}, 0.005, nil
+		default:
+			return 96, nil, 0.005, nil
+		}
+	}
+
+	opts := defaultOpts(t)
+	opts.Stratified = true
+	opts.StallLimit = 3
+	opts.MaxIterations = 10
+
+	a := New(client, &mockContainerMgr{}, testLogger(), nil)
+	result, err := a.Run(context.Background(), "Build an app", opts, validate, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != StatusConverged {
+		t.Errorf("expected status %q, got %q", StatusConverged, result.Status)
+	}
+	// 4 total validation calls (1 per tier for tiers 1-2, 2 for tier 3).
+	if result.Iterations != 4 {
+		t.Errorf("expected 4 total iterations, got %d", result.Iterations)
+	}
+}
+
+// TestStratifiedMaxIterationsExhausted verifies that when MaxIterations is exhausted
+// during stratified mode (mid-tier), the run returns StatusMaxIterations.
+func TestStratifiedMaxIterationsExhausted(t *testing.T) {
+	client := &mockLLMClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
+		},
+	}
+
+	// Tier 1: converges at iteration 1.
+	// Tier 2: converges at iteration 2.
+	// Tier 3: iterations 3-4 return 50% — MaxIterations=4 exhausted.
+	var callCount atomic.Int32
+	validate := func(_ context.Context, _ string, _ RestartFunc, maxTier int) (float64, []string, float64, error) {
+		n := callCount.Add(1)
+		if n <= 2 {
+			return 96, nil, 0.005, nil
+		}
+		return 50, []string{"tier 3 not passing"}, 0.005, nil
+	}
+
+	opts := defaultOpts(t)
+	opts.Stratified = true
+	opts.MaxIterations = 4
+	opts.StallLimit = 10 // won't stall
+
+	a := New(client, &mockContainerMgr{}, testLogger(), nil)
+	result, err := a.Run(context.Background(), "Build an app", opts, validate, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != StatusMaxIterations {
+		t.Errorf("expected status %q, got %q", StatusMaxIterations, result.Status)
+	}
+	if result.Iterations != 4 {
+		t.Errorf("expected 4 total iterations, got %d", result.Iterations)
+	}
+}
+
+// TestStratifiedBudgetExhaustedMidTier verifies that when the cost budget is exhausted
+// during tier 2 of stratified mode, the run returns StatusBudgetExceeded.
+func TestStratifiedBudgetExhaustedMidTier(t *testing.T) {
+	client := &mockLLMClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.04}, nil
+		},
+	}
+
+	// Tier 1: converges on call 1 (96%), cost so far: 0.04 (generate) + 0.02 (validate) = 0.06
+	// Tier 2: iteration 2 generate costs 0.04, total = 0.10 which hits the budget before validation.
+	var callCount atomic.Int32
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
+		callCount.Add(1)
+		return 96, nil, 0.02, nil
+	}
+
+	opts := defaultOpts(t)
+	opts.Stratified = true
+	opts.BudgetUSD = 0.10
+	opts.MaxIterations = 10
+	opts.StallLimit = 5
+
+	a := New(client, &mockContainerMgr{}, testLogger(), nil)
+	result, err := a.Run(context.Background(), "Build an app", opts, validate, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != StatusBudgetExceeded {
+		t.Errorf("expected status %q, got %q", StatusBudgetExceeded, result.Status)
+	}
+	// Should have advanced to tier 2 but not completed it.
+	calls := callCount.Load()
+	if calls < 1 {
+		t.Errorf("expected at least 1 validation call, got %d", calls)
 	}
 }

--- a/internal/attractor/isolation_test.go
+++ b/internal/attractor/isolation_test.go
@@ -46,7 +46,7 @@ func TestSystemPromptContainsOnlySpec(t *testing.T) {
 			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
 		},
 	}
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		return 100, nil, 0.005, nil
 	}
 
@@ -93,7 +93,7 @@ func TestScenarioContentNeverInSystemPrompt(t *testing.T) {
 		},
 	}
 
-	validate := func(_ context.Context, _ string, _ RestartFunc) (float64, []string, float64, error) {
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
 		n := callCount.Add(1)
 		// Return failures containing sentinels — these should appear in user
 		// messages (feedback channel) but never in system prompts.

--- a/internal/e2e/e2e_integration_test.go
+++ b/internal/e2e/e2e_integration_test.go
@@ -230,7 +230,7 @@ func checkDockerAvailable(ctx context.Context, t *testing.T) {
 // makeValidateFn builds an attractor.ValidateFn that runs all scenarios sequentially
 // and returns the aggregate satisfaction score.
 func makeValidateFn(t *testing.T, scenarios []scenario.Scenario, llmClient llm.Client, logger *slog.Logger) attractor.ValidateFn {
-	return func(ctx context.Context, baseURL string, _ attractor.RestartFunc) (float64, []string, float64, error) {
+	return func(ctx context.Context, baseURL string, _ attractor.RestartFunc, _ int) (float64, []string, float64, error) {
 		httpCli := &http.Client{Timeout: 30 * time.Second}
 		executors := map[string]scenario.StepExecutor{
 			"request": &scenario.HTTPExecutor{Client: httpCli, BaseURL: baseURL},

--- a/internal/observability/validate.go
+++ b/internal/observability/validate.go
@@ -13,13 +13,14 @@ import (
 // WrapValidateFn wraps a ValidateFn with a scenario.validate span.
 func WrapValidateFn(fn attractor.ValidateFn, tp trace.TracerProvider) attractor.ValidateFn {
 	tracer := tp.Tracer("octog/scenario")
-	return func(ctx context.Context, url string, restart attractor.RestartFunc) (float64, []string, float64, error) {
+	return func(ctx context.Context, url string, restart attractor.RestartFunc, maxTier int) (float64, []string, float64, error) {
 		ctx, span := tracer.Start(ctx, "scenario.validate", trace.WithAttributes(
 			attribute.String("scenario.target_url", url),
+			attribute.Int("scenario.max_tier", maxTier),
 		))
 		defer span.End()
 
-		satisfaction, failures, cost, err := fn(ctx, url, restart)
+		satisfaction, failures, cost, err := fn(ctx, url, restart, maxTier)
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())

--- a/internal/observability/validate_test.go
+++ b/internal/observability/validate_test.go
@@ -13,12 +13,14 @@ func TestWrapValidateFnSuccess(t *testing.T) {
 	exp, tp := newTestTP()
 	defer func() { _ = tp.Shutdown(context.Background()) }()
 
-	inner := func(_ context.Context, _ string, _ attractor.RestartFunc) (float64, []string, float64, error) {
+	var receivedMaxTier int
+	inner := func(_ context.Context, _ string, _ attractor.RestartFunc, maxTier int) (float64, []string, float64, error) {
+		receivedMaxTier = maxTier
 		return 85.0, []string{"minor issue"}, 0.005, nil
 	}
 
 	wrapped := WrapValidateFn(inner, tp)
-	sat, failures, cost, err := wrapped(context.Background(), "http://localhost:8080", nil)
+	sat, failures, cost, err := wrapped(context.Background(), "http://localhost:8080", nil, 2)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -31,6 +33,9 @@ func TestWrapValidateFnSuccess(t *testing.T) {
 	if cost != 0.005 {
 		t.Errorf("expected cost 0.005, got %f", cost)
 	}
+	if receivedMaxTier != 2 {
+		t.Errorf("expected maxTier=2 forwarded to inner, got %d", receivedMaxTier)
+	}
 
 	_ = tp.ForceFlush(context.Background())
 	spans := exp.GetSpans()
@@ -42,6 +47,7 @@ func TestWrapValidateFnSuccess(t *testing.T) {
 	}
 
 	assertHasAttr(t, spans[0].Attributes, "scenario.target_url")
+	assertHasAttr(t, spans[0].Attributes, "scenario.max_tier")
 	assertHasAttr(t, spans[0].Attributes, "scenario.satisfaction")
 	assertHasAttr(t, spans[0].Attributes, "scenario.failure_count")
 	assertHasAttr(t, spans[0].Attributes, "scenario.cost_usd")
@@ -51,12 +57,12 @@ func TestWrapValidateFnError(t *testing.T) {
 	exp, tp := newTestTP()
 	defer func() { _ = tp.Shutdown(context.Background()) }()
 
-	inner := func(_ context.Context, _ string, _ attractor.RestartFunc) (float64, []string, float64, error) {
+	inner := func(_ context.Context, _ string, _ attractor.RestartFunc, _ int) (float64, []string, float64, error) {
 		return 0, nil, 0, errMock
 	}
 
 	wrapped := WrapValidateFn(inner, tp)
-	_, _, _, err := wrapped(context.Background(), "http://localhost:8080", nil)
+	_, _, _, err := wrapped(context.Background(), "http://localhost:8080", nil, 0)
 	if err == nil {
 		t.Fatal("expected error")
 	}


### PR DESCRIPTION
Closes #182

## Changes
**1. `internal/attractor/attractor.go`**
- **Update `ValidateFn` signature** (line 127): Add `maxTier int` parameter:
  ```go
  type ValidateFn func(ctx context.Context, url string, restart RestartFunc, maxTier int) (satisfaction float64, failures []string, cost float64, err error)
  ```
- **Add `Stratified bool` to `RunOptions`** (after `Agentic`, line 158)
- **Add `activeTier int` to `runState`** (line 183 area): 0 = non-stratified, 1-3 = current tier
- **Initialize `activeTier` in `Run()`** (line 318): `activeTier: 1` when `opts.Stratified`, else `0`
- **Tier advancement in `Run()` loop** (line 385-388): When `result != nil && result.Status == StatusConverged && s.activeTier > 0 && s.activeTier < 3`:
  - Increment `s.activeTier`
  - Log: `slog.Info("tier advanced", "tier", s.activeTier, "prev_satisfaction", result.Satisfaction)`
  - Reset: `bestSatisfaction`, `stallCount`, `scoreHistory`, `history`, `patchActive` (to `opts.PatchMode`), `patchRegressionCount`, `scenarioScores`, `scenarioScoreIteration`, `lastFailures`, `lastOutcome`, `lastSatisfaction`, `lastImproved`
  - If `escalation != nil`: reinitialize via `newEscalationState()`
  - Do NOT reset: `bestFiles`, `bestDir`, `totalCost`, `codeHashes`, `runID`, `startTime`
  - Set `result = nil` and `continue` (don't return)
- **Update `buildRunValidate`** (line 1189): Pass `s.activeTier` to `validate(ctx, url, restartFn, s.activeTier)`
- **Update `buildAndValidateComponent`** (line 778): Pass `0` as `maxTier`: `validate(ctx, url, nil, 0)`

**2. `cmd/octog/main.go`**
- **Add `--stratified` flag** (near `--agentic`):
  ```go
  stratifiedFlag := fs.Bool("stratified", false, "validate scenarios by ascending difficulty tier (1→2→3)")
  ```
- **Add `Stratified` to `runLoopParams`** and pass through to `RunOptions.Stratified`
- **Update `buildValidateFn`** (line 1365): Add `maxTier int` to returned closure. When `maxTier > 0`, filter `scenarios` to those with `s.Tier <= maxTier` before passing to `runAndScore`. Log filtered count at debug level.
- **Update `buildComponentValidators`** (line 1350): Closures accept `maxTier int` and ignore it (always use full scenario set for component validators)

**3. `internal/observability/validate.go`**
- Update `WrapValidateFn`: Add `maxTier int` parameter to wrapper and inner call. Add `attribute.Int("scenario.max_tier", maxTier)` to the span.

**4. `internal/e2e/e2e_integration_test.go`**
- Update `makeValidateFn` closure signature to accept `maxTier int` (ignored).

**5. `docs/architecture.md`**
- Run `make docs` to auto-sync `embedmd` code blocks after code changes. `make docs-check` in CI catches staleness.

## Review Findings
- Errors: 0
- Warnings: 2
- Nits: 3
- Assessment: **NEEDS CHANGES** (the `slog` vs `a.logger` inconsistency in `advanceTierIfNeeded` should be fixed before merge; it's a method on `*Attractor` that already has the logger available)
