### PR TITLE
fix: total_tokens always 0 in status JSON output

### DIFF
--- a/cmd/octog/main.go
+++ b/cmd/octog/main.go
@@ -531,6 +531,7 @@ func recordRun(ctx context.Context, logger *slog.Logger, st *store.Store, result
 		FinishedAt:   &finishedAt,
 		Satisfaction: result.Satisfaction,
 		Iterations:   result.Iterations,
+		TotalTokens:  result.TotalTokens,
 		TotalCostUSD: result.CostUSD,
 		Status:       result.Status,
 		Language:     language,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -735,6 +735,7 @@ type RunResult struct {
 	Iterations   int
 	Satisfaction float64
 	CostUSD      float64
+	TotalTokens  int
 	OutputDir    string
 	Status       string
 }
@@ -853,12 +854,12 @@ It asks the judge-tier model to return a JSON array of paths most relevant to th
 then merges in any entry-point files present in `allFiles` (Dockerfile, main.go, go.mod, etc.),
 regardless of LLM output.
 
-Skip conditions (returns `allFiles` unchanged, zero cost):
+Skip conditions (returns `allFiles` unchanged, zero cost, zero tokens):
 
 - `len(allFiles) <= 5`
 - `len(failures) == 0`
 
-On error or empty result, falls back to the full file set. Cost is accumulated into `totalCost`.
+On error or empty result, falls back to the full file set. Cost and token count are accumulated into `totalCost` and `totalTokens`.
 The count of omitted files is passed to `buildPatchMessages` as `omittedCount`; when > 0, a
 `(N other files not relevant to current failures, not shown)` note is appended to the prompt.
 

--- a/internal/attractor/attractor.go
+++ b/internal/attractor/attractor.go
@@ -174,6 +174,7 @@ type RunResult struct {
 	Iterations   int
 	Satisfaction float64
 	CostUSD      float64
+	TotalTokens  int
 	OutputDir    string
 	Status       string
 }
@@ -193,6 +194,7 @@ type runState struct {
 	baseDir                string
 	bestDir                string
 	totalCost              float64
+	totalTokens            int
 	bestSatisfaction       float64
 	stallCount             int
 	history                []iterationFeedback
@@ -233,6 +235,7 @@ func (s *runState) result(iter int, status string) *RunResult {
 		Iterations:   iter,
 		Satisfaction: s.bestSatisfaction,
 		CostUSD:      s.totalCost,
+		TotalTokens:  s.totalTokens,
 		OutputDir:    s.bestDir,
 		Status:       status,
 	}
@@ -699,6 +702,7 @@ func (a *Attractor) componentIteration(ctx context.Context, rawSpec string, comp
 		return nil, fmt.Errorf("attractor: generate component %q iteration %d: %w", comp.Name, iter, err)
 	}
 	s.totalCost += genResp.CostUSD
+	s.totalTokens += genResp.InputTokens + genResp.OutputTokens
 
 	files, parseErr := ParseFiles(genResp.Content)
 	if parseErr != nil {
@@ -829,6 +833,7 @@ func (a *Attractor) generateContent(ctx context.Context, specContent string, mes
 		return llm.GenerateResponse{}, fmt.Errorf("attractor: generate iteration %d: %w", iter, err)
 	}
 	s.totalCost += genResp.CostUSD
+	s.totalTokens += genResp.InputTokens + genResp.OutputTokens
 	s.lastInputTokens = genResp.InputTokens
 	s.lastOutputTokens = genResp.OutputTokens
 	return genResp, nil
@@ -872,6 +877,7 @@ func (a *Attractor) wonderReflect(ctx context.Context, rawSpec string, iter int,
 		return "", "", 0, nil
 	}
 	s.totalCost += wonderResp.CostUSD
+	s.totalTokens += wonderResp.InputTokens + wonderResp.OutputTokens
 	a.logger.Debug("wonder phase complete", "iteration", iter, "cost_usd", wonderResp.CostUSD)
 
 	// Check budget before proceeding to reflect phase.
@@ -909,6 +915,7 @@ func (a *Attractor) wonderReflect(ctx context.Context, rawSpec string, iter int,
 		return "", "", 0, nil
 	}
 	s.totalCost += reflectResp.CostUSD
+	s.totalTokens += reflectResp.InputTokens + reflectResp.OutputTokens
 	s.lastInputTokens = wonderResp.InputTokens + reflectResp.InputTokens
 	s.lastOutputTokens = wonderResp.OutputTokens + reflectResp.OutputTokens
 	a.logger.Debug("reflect phase complete", "iteration", iter, "cost_usd", reflectResp.CostUSD)
@@ -1041,6 +1048,7 @@ func (a *Attractor) generateAgentic(ctx context.Context, specContent, iterDir st
 	}
 
 	s.totalCost += resp.TotalCost
+	s.totalTokens += resp.InputTokens + resp.OutputTokens
 	s.lastInputTokens = resp.InputTokens
 	s.lastOutputTokens = resp.OutputTokens
 	s.lastTurns = resp.Turns
@@ -1069,8 +1077,9 @@ func (a *Attractor) generateStandard(ctx context.Context, specContent, iterDir s
 	// Build messages: patch mode sends previous best files + failures.
 	var messages []llm.Message
 	if patching {
-		relevantFiles, triageCost := a.triageFiles(ctx, s.bestFiles, s.lastFailures, s.opts.JudgeModel)
+		relevantFiles, triageCost, triageTokens := a.triageFiles(ctx, s.bestFiles, s.lastFailures, s.opts.JudgeModel)
 		s.totalCost += triageCost
+		s.totalTokens += triageTokens
 		omitted := len(s.bestFiles) - len(relevantFiles)
 		messages = buildPatchMessages(s.history, relevantFiles, s.bestSatisfaction, omitted)
 	} else {

--- a/internal/attractor/attractor_test.go
+++ b/internal/attractor/attractor_test.go
@@ -121,7 +121,7 @@ func defaultOpts(t *testing.T) RunOptions {
 func TestConvergesImmediately(t *testing.T) {
 	client := &mockLLMClient{
 		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
-			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01}, nil
+			return llm.GenerateResponse{Content: validLLMOutput(), CostUSD: 0.01, InputTokens: 100, OutputTokens: 50}, nil
 		},
 	}
 	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
@@ -138,6 +138,9 @@ func TestConvergesImmediately(t *testing.T) {
 	}
 	if result.Iterations != 1 {
 		t.Errorf("expected 1 iteration, got %d", result.Iterations)
+	}
+	if result.TotalTokens != 150 {
+		t.Errorf("expected TotalTokens 150, got %d", result.TotalTokens)
 	}
 }
 
@@ -166,6 +169,49 @@ func TestConvergesOnIteration2(t *testing.T) {
 	}
 	if result.Iterations != 2 {
 		t.Errorf("expected 2 iterations, got %d", result.Iterations)
+	}
+}
+
+func TestTokenAccumulation(t *testing.T) {
+	// Each Generate call returns 200 input + 80 output = 280 tokens.
+	// With 3 iterations we expect TotalTokens = 3 * 280 = 840.
+	const (
+		perInput  = 200
+		perOutput = 80
+		iters     = 3
+	)
+	var callCount atomic.Int32
+	client := &mockLLMClient{
+		generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+			return llm.GenerateResponse{
+				Content:      validLLMOutput(),
+				CostUSD:      0.01,
+				InputTokens:  perInput,
+				OutputTokens: perOutput,
+			}, nil
+		},
+	}
+	validate := func(_ context.Context, _ string, _ RestartFunc, _ int) (float64, []string, float64, error) {
+		n := callCount.Add(1)
+		if int(n) < iters {
+			return 50, []string{"not yet"}, 0, nil
+		}
+		return 100, nil, 0, nil
+	}
+
+	opts := defaultOpts(t)
+	opts.StallLimit = iters + 1 // prevent stall from terminating early
+	a := New(client, &mockContainerMgr{}, testLogger(), nil)
+	result, err := a.Run(context.Background(), "Build an app", opts, validate, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Iterations != iters {
+		t.Errorf("expected %d iterations, got %d", iters, result.Iterations)
+	}
+	want := iters * (perInput + perOutput)
+	if result.TotalTokens != want {
+		t.Errorf("TotalTokens = %d, want %d", result.TotalTokens, want)
 	}
 }
 

--- a/internal/attractor/triage.go
+++ b/internal/attractor/triage.go
@@ -38,16 +38,17 @@ func isEntryPoint(path string) bool {
 
 // triageFiles asks the LLM to identify which files from allFiles are relevant to
 // the given failures. It returns a filtered map containing only the relevant files
-// plus any entry-point files present in allFiles.
+// plus any entry-point files present in allFiles, the cost in USD, and the total
+// token count used.
 //
-// Skip conditions (returns allFiles, 0 with no LLM call):
+// Skip conditions (returns allFiles, 0, 0 with no LLM call):
 //   - len(allFiles) <= 5
 //   - len(failures) == 0
 //
-// On any error, logs a warning and returns allFiles, 0.
-func (a *Attractor) triageFiles(ctx context.Context, allFiles map[string]string, failures []string, model string) (map[string]string, float64) {
+// On any error, logs a warning and returns allFiles, 0, 0.
+func (a *Attractor) triageFiles(ctx context.Context, allFiles map[string]string, failures []string, model string) (map[string]string, float64, int) {
 	if len(allFiles) <= 5 || len(failures) == 0 {
-		return allFiles, 0
+		return allFiles, 0, 0
 	}
 
 	// Build sorted file path list for deterministic prompts.
@@ -74,14 +75,15 @@ func (a *Attractor) triageFiles(ctx context.Context, allFiles map[string]string,
 	})
 	if err != nil {
 		slog.Warn("triage: LLM call failed, using all files", "error", err)
-		return allFiles, 0
+		return allFiles, 0, 0
 	}
+	tokens := resp.InputTokens + resp.OutputTokens
 
 	cleaned := llm.ExtractJSON(resp.Content)
 	var suggested []string
 	if jsonErr := json.Unmarshal([]byte(cleaned), &suggested); jsonErr != nil {
 		slog.Warn("triage: failed to parse LLM response, using all files", "error", jsonErr)
-		return allFiles, resp.CostUSD
+		return allFiles, resp.CostUSD, tokens
 	}
 
 	// Build result: LLM-suggested paths that actually exist + entry points from allFiles.
@@ -101,9 +103,9 @@ func (a *Attractor) triageFiles(ctx context.Context, allFiles map[string]string,
 	// Guard: if result is empty (LLM returned nothing useful), fall back to all files.
 	if len(result) == 0 {
 		slog.Warn("triage: result set empty after filtering, using all files")
-		return allFiles, resp.CostUSD
+		return allFiles, resp.CostUSD, tokens
 	}
 
 	slog.Debug("triage: file set narrowed", "suggested", len(suggested), "result", len(result), "total", len(allFiles))
-	return result, resp.CostUSD
+	return result, resp.CostUSD, tokens
 }

--- a/internal/attractor/triage_test.go
+++ b/internal/attractor/triage_test.go
@@ -31,12 +31,15 @@ func TestTriageFilesSkipSmallSets(t *testing.T) {
 	}
 	files := makeFiles(3)
 	failures := []string{"something broke"}
-	got, cost := a.triageFiles(context.Background(), files, failures, "")
+	got, cost, tokens := a.triageFiles(context.Background(), files, failures, "")
 	if len(got) != len(files) {
 		t.Errorf("expected all %d files, got %d", len(files), len(got))
 	}
 	if cost != 0 {
 		t.Errorf("expected zero cost, got %f", cost)
+	}
+	if tokens != 0 {
+		t.Errorf("expected zero tokens, got %d", tokens)
 	}
 }
 
@@ -49,12 +52,15 @@ func TestTriageFilesSkipNoFailures(t *testing.T) {
 		},
 	}
 	files := makeFiles(10)
-	got, cost := a.triageFiles(context.Background(), files, nil, "")
+	got, cost, tokens := a.triageFiles(context.Background(), files, nil, "")
 	if len(got) != len(files) {
 		t.Errorf("expected all %d files, got %d", len(files), len(got))
 	}
 	if cost != 0 {
 		t.Errorf("expected zero cost, got %f", cost)
+	}
+	if tokens != 0 {
+		t.Errorf("expected zero tokens, got %d", tokens)
 	}
 }
 
@@ -68,7 +74,7 @@ func TestTriageFilesReturnsSubset(t *testing.T) {
 	}
 	files := makeFiles(10)
 	failures := []string{"nil pointer in file00.go"}
-	got, _ := a.triageFiles(context.Background(), files, failures, "model")
+	got, _, _ := a.triageFiles(context.Background(), files, failures, "model")
 	if _, ok := got["file00.go"]; !ok {
 		t.Error("expected file00.go in result")
 	}
@@ -91,7 +97,7 @@ func TestTriageFilesAlwaysIncludesDockerfile(t *testing.T) {
 	}
 	files := makeFiles(10, "Dockerfile")
 	failures := []string{"build failed"}
-	got, _ := a.triageFiles(context.Background(), files, failures, "model")
+	got, _, _ := a.triageFiles(context.Background(), files, failures, "model")
 	if _, ok := got["Dockerfile"]; !ok {
 		t.Error("Dockerfile should always be included")
 	}
@@ -107,7 +113,7 @@ func TestTriageFilesAlwaysIncludesEntryPoints(t *testing.T) {
 	}
 	files := makeFiles(10, "main.go", "go.mod", "Dockerfile", "lib/util.go")
 	failures := []string{"compilation error"}
-	got, _ := a.triageFiles(context.Background(), files, failures, "model")
+	got, _, _ := a.triageFiles(context.Background(), files, failures, "model")
 	for _, ep := range []string{"main.go", "go.mod", "Dockerfile", "lib/util.go"} {
 		if _, ok := got[ep]; !ok {
 			t.Errorf("expected entry point %q in result", ep)
@@ -125,12 +131,15 @@ func TestTriageFilesFallbackOnError(t *testing.T) {
 	}
 	files := makeFiles(10)
 	failures := []string{"something broke"}
-	got, cost := a.triageFiles(context.Background(), files, failures, "model")
+	got, cost, tokens := a.triageFiles(context.Background(), files, failures, "model")
 	if len(got) != len(files) {
 		t.Errorf("expected fallback to all %d files, got %d", len(files), len(got))
 	}
 	if cost != 0 {
 		t.Errorf("expected zero cost on error, got %f", cost)
+	}
+	if tokens != 0 {
+		t.Errorf("expected zero tokens on error, got %d", tokens)
 	}
 }
 
@@ -144,12 +153,15 @@ func TestTriageFilesUnparseableJSON(t *testing.T) {
 	}
 	files := makeFiles(10)
 	failures := []string{"something broke"}
-	got, cost := a.triageFiles(context.Background(), files, failures, "model")
+	got, cost, tokens := a.triageFiles(context.Background(), files, failures, "model")
 	if len(got) != len(files) {
 		t.Errorf("expected fallback to all %d files on bad JSON, got %d", len(files), len(got))
 	}
 	if cost != 0 {
 		t.Errorf("expected zero cost on parse error, got %f", cost)
+	}
+	if tokens != 0 {
+		t.Errorf("expected zero tokens on parse error, got %d", tokens)
 	}
 }
 
@@ -163,7 +175,7 @@ func TestTriageFilesUnknownPaths(t *testing.T) {
 	}
 	files := makeFiles(10)
 	failures := []string{"error in file00.go"}
-	got, _ := a.triageFiles(context.Background(), files, failures, "model")
+	got, _, _ := a.triageFiles(context.Background(), files, failures, "model")
 	if _, ok := got["nonexistent.go"]; ok {
 		t.Error("nonexistent.go should be dropped from result")
 	}
@@ -186,8 +198,30 @@ func TestTriageFilesCostTracked(t *testing.T) {
 	}
 	files := makeFiles(10)
 	failures := []string{"error"}
-	_, cost := a.triageFiles(context.Background(), files, failures, "model")
+	_, cost, _ := a.triageFiles(context.Background(), files, failures, "model")
 	if cost != wantCost {
 		t.Errorf("expected cost %f, got %f", wantCost, cost)
+	}
+}
+
+func TestTriageFilesTokensTracked(t *testing.T) {
+	const wantInput = 100
+	const wantOutput = 50
+	a := &Attractor{
+		llm: &mockLLMClient{
+			generateFn: func(_ context.Context, _ llm.GenerateRequest) (llm.GenerateResponse, error) {
+				return llm.GenerateResponse{
+					Content:      `["file00.go"]`,
+					InputTokens:  wantInput,
+					OutputTokens: wantOutput,
+				}, nil
+			},
+		},
+	}
+	files := makeFiles(10)
+	failures := []string{"error"}
+	_, _, tokens := a.triageFiles(context.Background(), files, failures, "model")
+	if tokens != wantInput+wantOutput {
+		t.Errorf("expected tokens %d, got %d", wantInput+wantOutput, tokens)
 	}
 }

--- a/internal/view/view_test.go
+++ b/internal/view/view_test.go
@@ -188,6 +188,9 @@ func TestNewStatusOutput(t *testing.T) {
 	if r0.Satisfaction != 99.0 {
 		t.Errorf("runs[0].satisfaction = %f, want 99.0", r0.Satisfaction)
 	}
+	if r0.TotalTokens != 5000 {
+		t.Errorf("runs[0].total_tokens = %d, want 5000", r0.TotalTokens)
+	}
 
 	r1 := out.Runs[1]
 	if r1.FinishedAt != nil {


### PR DESCRIPTION
Closes #229

## Changes
**1. `internal/attractor/attractor.go`**
- Add `TotalTokens int` to `RunResult` struct (after `CostUSD`)
- Add `totalTokens int` to `runState` struct (after `totalCost`)
- Add `TotalTokens: s.totalTokens` to `result()` helper
- Accumulate tokens at these call sites (mirroring `totalCost +=`):
  - Line 701 (`convergeComponent`): `s.totalTokens += genResp.InputTokens + genResp.OutputTokens`
  - Line 831 (`generateContent`): `s.totalTokens += genResp.InputTokens + genResp.OutputTokens`
  - Line 874 (`wonderReflect` wonder phase): `s.totalTokens += wonderResp.InputTokens + wonderResp.OutputTokens`
  - Line 911 (`wonderReflect` reflect phase): `s.totalTokens += reflectResp.InputTokens + reflectResp.OutputTokens`
  - Line 1043 (`generateAgentic`): `s.totalTokens += resp.InputTokens + resp.OutputTokens`

**2. `internal/attractor/triage.go`**
- Change `triageFiles` return signature from `(map[string]string, float64)` to `(map[string]string, float64, int)` (add token count)
- Return `resp.InputTokens + resp.OutputTokens` as third value
- Return `0` for tokens in early-return and error paths

**3. `internal/attractor/attractor.go` (triage call site, line 1072-1073)**
- Update caller in `generateStandard` to capture token count: `relevantFiles, triageCost, triageTokens := a.triageFiles(...)`
- Add `s.totalTokens += triageTokens`

**4. `cmd/octog/main.go`**
- In `recordRun()` (line 524-537): add `TotalTokens: result.TotalTokens` to `store.Run` literal

## Review Findings
- Errors: 0
- Warnings: 0
- Nits: 4
- Assessment: **PASS**

The change is mechanically consistent: every site that accumulates `totalCost` now also accumulates `totalTokens`. The store schema and types already support the field. Tests cover the happy path (single iteration, multi-iteration accumulation) and triage edge cases (skip conditions, errors, unparseable JSON). No correctness, concurrency, or security issues found.
