### PR TITLE
fix(scenario): duration_ms always 0 in validate JSON output

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -614,8 +614,9 @@ steps:
     expect: "Status 200 with status 'processed'"
 ```
 
-`StepResult.Duration` reflects total wall time including retries and sleeps. Captures are applied
-only from the final successful attempt.
+`StepResult.Duration` reflects total wall time from executor resolution through execution, including
+retries and sleeps. Duration is recorded even when executor resolution fails (non-zero on error).
+Captures are applied only from the final successful attempt.
 
 ### Variable Capture and Substitution
 

--- a/internal/scenario/runner.go
+++ b/internal/scenario/runner.go
@@ -62,18 +62,19 @@ func (r *Runner) Run(ctx context.Context, scenario Scenario) (Result, error) {
 	// Execute judged steps — non-fatal on failure.
 	results := make([]StepResult, 0, len(scenario.Steps))
 	for i, step := range scenario.Steps {
+		start := time.Now()
 		executor, err := r.resolveExecutor(step)
 		if err != nil {
 			results = append(results, StepResult{
 				Description: step.Description,
 				StepType:    step.StepType(),
+				Duration:    time.Since(start),
 				Err:         err,
 			})
 			r.Logger.Warn("judged step executor error", "step", i, "description", step.Description, "error", err)
 			continue
 		}
 
-		start := time.Now()
 		output, err := r.executeStep(ctx, executor, step, vars)
 		dur := time.Since(start)
 

--- a/internal/scenario/runner_test.go
+++ b/internal/scenario/runner_test.go
@@ -90,6 +90,9 @@ func TestRunnerHappyPath(t *testing.T) {
 	if !strings.Contains(step.CaptureBody, `"id": 99`) {
 		t.Errorf("capture body missing expected content: %s", step.CaptureBody)
 	}
+	if step.Duration <= 0 {
+		t.Error("expected non-zero duration for executed step")
+	}
 }
 
 func TestRunnerVariableSubstitutionInBody(t *testing.T) {
@@ -268,8 +271,14 @@ func TestRunnerTransportErrorOnJudgedStep(t *testing.T) {
 	if result.Steps[0].Err == nil {
 		t.Error("expected error on first step")
 	}
+	if result.Steps[0].Duration <= 0 {
+		t.Error("expected non-zero duration for failed step")
+	}
 	if result.Steps[1].Err != nil {
 		t.Errorf("unexpected error on second step: %v", result.Steps[1].Err)
+	}
+	if result.Steps[1].Duration <= 0 {
+		t.Error("expected non-zero duration for succeeded step")
 	}
 }
 
@@ -906,5 +915,8 @@ func TestRunnerUnknownStepType(t *testing.T) {
 
 	if !errors.Is(result.Steps[0].Err, errUnknownStepType) {
 		t.Errorf("expected errUnknownStepType, got: %v", result.Steps[0].Err)
+	}
+	if result.Steps[0].Duration <= 0 {
+		t.Error("expected non-zero duration even for executor resolution failure")
 	}
 }


### PR DESCRIPTION
Closes #234

## Changes
**`internal/scenario/runner.go`**

Move `start := time.Now()` from line 76 to line 64 (before `resolveExecutor`), and add `Duration: time.Since(start)` to the error-path `StepResult` on line 67-71:

```go
for i, step := range scenario.Steps {
    start := time.Now()
    executor, err := r.resolveExecutor(step)
    if err != nil {
        results = append(results, StepResult{
            Description: step.Description,
            StepType:    step.StepType(),
            Duration:    time.Since(start),
            Err:         err,
        })
        r.Logger.Warn(...)
        continue
    }

    output, err := r.executeStep(ctx, executor, step, vars)
    dur := time.Since(start)
    // ... rest unchanged
```

No other file changes needed.

## Review Findings
- Errors: 0
- Warnings: 0
- Nits: 2
- Assessment: **PASS**

Clean, minimal fix. The `start` timer placement is moved to the right spot, the error-path `StepResult` correctly includes `Duration`, and three targeted test assertions cover the happy path, transport error, and unknown-step-type cases. No style, security, or design concerns.
