### PR TITLE
fix(cmd): v2 verbosity should show judge reasoning in text mode

### DIFF
--- a/cmd/octog/main.go
+++ b/cmd/octog/main.go
@@ -744,7 +744,7 @@ func outputValidation(agg scenario.AggregateResult, target string, threshold flo
 			return fmt.Errorf("write json: %w", err)
 		}
 	default:
-		fprintValidationResult(w, agg)
+		fprintValidationResult(w, agg, verbosity)
 		if verbosity >= 1 {
 			failures := buildDetailedFailures(agg)
 			if len(failures) > 0 {
@@ -1469,7 +1469,7 @@ func truncateObserved(s string, max int) string {
 }
 
 //nolint:gosec // G705 false positive: w is os.Stdout or test buffer, not an HTTP response
-func fprintValidationResult(w io.Writer, agg scenario.AggregateResult) {
+func fprintValidationResult(w io.Writer, agg scenario.AggregateResult, verbosity int) {
 	_, _ = fmt.Fprintln(w, "Scenarios:")
 	for _, sc := range agg.Scenarios {
 		_, _ = fmt.Fprintf(w, "  %-30s %5.1f/100  (weight %.1f)\n", sc.ScenarioID, sc.Score, sc.Weight)
@@ -1479,7 +1479,7 @@ func fprintValidationResult(w io.Writer, agg scenario.AggregateResult) {
 				label = "FAIL"
 			}
 			_, _ = fmt.Fprintf(w, "    [%s]  %3d  %s\n", label, step.StepScore.Score, step.StepResult.Description)
-			if label == "FAIL" && step.StepScore.Reasoning != "" {
+			if step.StepScore.Reasoning != "" && (label == "FAIL" || verbosity >= 2) {
 				_, _ = fmt.Fprintf(w, "           Reasoning: %s\n", step.StepScore.Reasoning)
 			}
 		}

--- a/cmd/octog/main_test.go
+++ b/cmd/octog/main_test.go
@@ -204,7 +204,7 @@ func TestFprintValidationResult(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	fprintValidationResult(&buf, agg)
+	fprintValidationResult(&buf, agg, 0)
 	out := buf.String()
 
 	checks := []struct {
@@ -248,7 +248,7 @@ func TestFprintValidationResultSetupFailure(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	fprintValidationResult(&buf, agg)
+	fprintValidationResult(&buf, agg, 0)
 	out := buf.String()
 
 	if !strings.Contains(out, "0.0/100") {
@@ -1751,6 +1751,17 @@ func TestOutputValidationVerbosity(t *testing.T) {
 					},
 				},
 			},
+			{
+				ScenarioID: "passing-scenario",
+				Score:      100,
+				Weight:     1.0,
+				Steps: []scenario.ScoredStep{
+					{
+						StepResult: scenario.StepResult{Description: "list items", Observed: "HTTP 200"},
+						StepScore:  scenario.StepScore{Score: 100, Reasoning: "item returned correctly"},
+					},
+				},
+			},
 		},
 	}
 
@@ -1764,17 +1775,18 @@ func TestOutputValidationVerbosity(t *testing.T) {
 			name:      "v0 shows summary with reasoning",
 			verbosity: 0,
 			wantLines: []string{"failing-scenario", "Aggregate satisfaction: 55.0/100", "Reasoning: expected 200 got 404"},
-			noLines:   []string{"Step detail:"},
+			noLines:   []string{"Step detail:", "item returned correctly"},
 		},
 		{
 			name:      "v1 shows per-scenario summary line",
 			verbosity: 1,
 			wantLines: []string{"Aggregate satisfaction: 55.0/100", "Step detail:", "failing-scenario", "Reasoning: expected 200 got 404"},
+			noLines:   []string{"item returned correctly"},
 		},
 		{
 			name:      "v2 shows full step detail with reasoning",
 			verbosity: 2,
-			wantLines: []string{"Aggregate satisfaction: 55.0/100", "Step detail:", "expected 200 got 404"},
+			wantLines: []string{"Aggregate satisfaction: 55.0/100", "Step detail:", "expected 200 got 404", "item returned correctly"},
 		},
 	}
 


### PR DESCRIPTION
Closes #235

## Changes
**`cmd/octog/main.go`** — two modifications:

1. **`fprintValidationResult()` (line 1472)**: Change signature from `(w io.Writer, agg scenario.AggregateResult)` to `(w io.Writer, agg scenario.AggregateResult, verbosity int)`. At line 1482, change the condition from `if label == "FAIL" && step.StepScore.Reasoning != ""` to `if step.StepScore.Reasoning != "" && (label == "FAIL" || verbosity >= 2)`.

2. **`outputValidation()` (line 747)**: Update the call to `fprintValidationResult(w, agg, verbosity)`.

## Review Findings
- Errors: 0
- Warnings: 0
- Nits: 3
- Assessment: **PASS**

Clean, minimal change. The feature is well-scoped — threads `verbosity` through to `fprintValidationResult`, adjusts the condition correctly, updates all call sites including tests, and adds targeted test coverage for the new behavior at each verbosity level.
