### PR TITLE
feat(scenario): improve inferTier heuristic with step type and structural signals

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -538,9 +538,11 @@ satisfaction_criteria: |
 ```
 
 `weight` defaults to 1.0 in aggregate scoring when not set. `tier` is auto-inferred by `inferTier`
-in `loader.go` when not set (zero): >6 judged steps or ≥3 steps with captures → 3 (complex); >3
-judged steps or ≥1 step with captures → 2 (moderate); else → 1 (simple). The `octog lint` checker
-warns if `tier` is explicitly set outside the 1–3 range.
+in `loader.go` when not set (zero). Scoring: each step adds +1 base; `browser`, `grpc`, or `ws`
+steps add +1 extra; a gRPC step with `stream` or a WS step with `receive` adds +1 extra; a step
+with `retry` adds +1 extra; mixed step types (>1 unique type) add +2 flat. Thresholds: score >6 or
+≥3 steps with captures → 3 (complex); score >3 or ≥1 step with captures → 2 (moderate); else → 1
+(simple). The `octog lint` checker warns if `tier` is explicitly set outside the 1–3 range.
 
 #### gRPC Step
 

--- a/examples/hello-api/scenarios/list.yaml
+++ b/examples/hello-api/scenarios/list.yaml
@@ -1,7 +1,6 @@
 id: list
 description: Create multiple items and verify list endpoint
 type: functional
-tier: 1
 satisfaction_criteria: List endpoint returns all created items with correct total count
 
 setup:

--- a/examples/hello-api/scenarios/not-found.yaml
+++ b/examples/hello-api/scenarios/not-found.yaml
@@ -1,7 +1,6 @@
 id: not-found
 description: Verify 404 responses for nonexistent items
 type: functional
-tier: 1
 satisfaction_criteria: GET, PUT, and DELETE on nonexistent IDs return 404
 
 steps:

--- a/examples/hello-api/scenarios/pagination.yaml
+++ b/examples/hello-api/scenarios/pagination.yaml
@@ -1,7 +1,6 @@
 id: pagination
 description: Verify pagination with limit and offset
 type: functional
-tier: 2
 satisfaction_criteria: Pagination returns correct subsets and total count
 
 setup:

--- a/examples/hello-api/scenarios/validation.yaml
+++ b/examples/hello-api/scenarios/validation.yaml
@@ -1,7 +1,6 @@
 id: validation
 description: Verify request validation returns 400 for invalid input
 type: functional
-tier: 2
 satisfaction_criteria: Invalid requests are rejected with 400 and an error message
 
 steps:

--- a/internal/scenario/loader.go
+++ b/internal/scenario/loader.go
@@ -99,21 +99,57 @@ func parseScenario(data []byte) (Scenario, error) {
 	return s, nil
 }
 
-// inferTier assigns a difficulty tier based on step count and capture usage.
-// Tier 3: more than 6 judged steps, or 3+ steps with captures.
-// Tier 2: more than 3 judged steps, or at least 1 step with captures.
+// inferTier assigns a difficulty tier based on weighted complexity scoring.
+//
+// Scoring:
+//   - Each step: +1 base
+//   - browser, grpc, or ws step type: +1 extra per step
+//   - gRPC step with Stream set: +1 extra
+//   - WS step with Receive set: +1 extra
+//   - Step with Retry set: +1 extra
+//   - Mixed step types (>1 unique type across all steps): +2 flat bonus
+//   - 3+ steps with captures: tier 3 regardless of score
+//
+// Tier 3: score >6 or ≥3 steps with captures.
+// Tier 2: score >3 or ≥1 step with captures.
 // Tier 1: everything else.
 func inferTier(s Scenario) int {
 	stepsWithCaptures := 0
+	score := 0
+	types := make(map[string]struct{})
+
 	for _, step := range s.Steps {
 		if len(step.Capture) > 0 {
 			stepsWithCaptures++
 		}
+		score++ // base
+
+		t := step.StepType()
+		types[t] = struct{}{}
+
+		switch t {
+		case "browser", "grpc", "ws":
+			score++
+		}
+		if step.GRPC != nil && step.GRPC.Stream != nil {
+			score++
+		}
+		if step.WS != nil && step.WS.Receive != nil {
+			score++
+		}
+		if step.Retry != nil {
+			score++
+		}
 	}
+
+	if len(types) > 1 {
+		score += 2
+	}
+
 	switch {
-	case len(s.Steps) > 6 || stepsWithCaptures >= 3:
+	case score > 6 || stepsWithCaptures >= 3:
 		return 3
-	case len(s.Steps) > 3 || stepsWithCaptures >= 1:
+	case score > 3 || stepsWithCaptures >= 1:
 		return 2
 	default:
 		return 1

--- a/internal/scenario/loader_test.go
+++ b/internal/scenario/loader_test.go
@@ -228,6 +228,20 @@ func TestTierInference(t *testing.T) {
 		}
 		return steps
 	}
+	makeStepOfType := func(stepType string) Step {
+		switch stepType {
+		case "browser":
+			return Step{Browser: &BrowserRequest{Action: "navigate"}}
+		case "grpc":
+			return Step{GRPC: &GRPCRequest{Service: "svc", Method: "M"}}
+		case "ws":
+			return Step{WS: &WSRequest{URL: "/ws"}}
+		case "exec":
+			return Step{Exec: &ExecRequest{Command: "echo"}}
+		default:
+			return Step{Request: &Request{Method: "GET", Path: "/"}}
+		}
+	}
 
 	// Explicit tier round-trips through YAML without inference.
 	t.Run("explicit tier round-trips", func(t *testing.T) {
@@ -270,6 +284,69 @@ func TestTierInference(t *testing.T) {
 			name:     "3 steps 3 captures -> tier 3",
 			scenario: Scenario{ID: "t", Steps: makeStepsWithCaptures(3, 3)},
 			wantTier: 3,
+		},
+		// Weighted complexity cases.
+		{
+			// 2x browser: score = 2*(1+1) = 4 > 3 → tier 2
+			name:     "2 browser steps no captures",
+			scenario: Scenario{ID: "t", Steps: []Step{makeStepOfType("browser"), makeStepOfType("browser")}},
+			wantTier: 2,
+		},
+		{
+			// 1x grpc+stream: score = 1+1+1 = 3 ≤ 3 → tier 1
+			name: "1 grpc streaming step no captures",
+			scenario: Scenario{ID: "t", Steps: []Step{
+				{GRPC: &GRPCRequest{Service: "svc", Method: "M", Stream: &GRPCStream{}}},
+			}},
+			wantTier: 1,
+		},
+		{
+			// 2x grpc+stream, 1 capture: score = 2*(1+1+1) = 6 ≤ 6, captures=1 ≥ 1 → tier 2
+			name: "2 grpc streaming steps 1 capture",
+			scenario: Scenario{ID: "t", Steps: []Step{
+				{GRPC: &GRPCRequest{Service: "svc", Method: "M", Stream: &GRPCStream{}}, Capture: []Capture{{Name: "x", JSONPath: "$.id"}}},
+				{GRPC: &GRPCRequest{Service: "svc", Method: "M", Stream: &GRPCStream{}}},
+			}},
+			wantTier: 2,
+		},
+		{
+			// 2x http with retry: score = 2*(1+1) = 4 > 3 → tier 2
+			name: "2 steps with retry no captures",
+			scenario: Scenario{ID: "t", Steps: []Step{
+				{Request: &Request{Method: "GET", Path: "/"}, Retry: &Retry{Attempts: 3}},
+				{Request: &Request{Method: "GET", Path: "/"}, Retry: &Retry{Attempts: 3}},
+			}},
+			wantTier: 2,
+		},
+		{
+			// 1 http + 1 browser + 1 exec: base=3, browser extra=1, mixed bonus=2 → score=6 ≤ 6 → tier 2 (captures=0 but score>3)
+			name: "3 mixed types no captures",
+			scenario: Scenario{ID: "t", Steps: []Step{
+				makeStepOfType("request"),
+				makeStepOfType("browser"),
+				makeStepOfType("exec"),
+			}},
+			wantTier: 2,
+		},
+		{
+			// 1x ws with receive: score = 1+1+1 = 3 ≤ 3 → tier 1
+			name: "1 ws with receive no captures",
+			scenario: Scenario{ID: "t", Steps: []Step{
+				{WS: &WSRequest{URL: "/ws", Receive: &WSReceive{Count: 1}}},
+			}},
+			wantTier: 1,
+		},
+		{
+			// 4x http: score = 4 > 3 → tier 2
+			name:     "4 http steps no captures",
+			scenario: Scenario{ID: "t", Steps: makeSteps(4)},
+			wantTier: 2,
+		},
+		{
+			// 2x http: score = 2 ≤ 3 → tier 1
+			name:     "2 http steps no captures",
+			scenario: Scenario{ID: "t", Steps: makeSteps(2)},
+			wantTier: 1,
 		},
 	}
 


### PR DESCRIPTION
Closes #244

## Changes
**1. `internal/scenario/loader.go`** (lines 102-121)
- Replace `inferTier()` body with weighted complexity scoring:
  - Each step: +1 base score
  - `browser`, `grpc`, or `ws` step type: +1 extra per step
  - gRPC step with `Stream != nil`: +1 extra
  - WS step with `Receive != nil`: +1 extra
  - Step with `Retry != nil`: +1 extra
  - Mixed step types (>1 unique `StepType()`): +2 flat bonus
  - Capture counting unchanged, tier thresholds unchanged (>6→3, >3→2, else→1)
- Update the function comment to document the new signals
- No new imports needed (no slog)

**2. `internal/scenario/loader_test.go`** (lines 216-295)
- Add `makeStepOfType(stepType string) Step` helper that returns a Step with the right request field set (`Browser: &BrowserRequest{Action: "navigate"}` for "browser", `GRPC: &GRPCRequest{Service: "svc", Method: "M"}` for "grpc", `WS: &WSRequest{URL: "/ws"}` for "ws", `Exec: &ExecRequest{Command: "echo"}` for "exec", `Request: &Request{Method: "GET", Path: "/"}` for "request")
- Add new table cases to `TestTierInference` (see Tests section below)
- Verify all existing cases still pass unchanged

**3. `examples/hello-api/scenarios/list.yaml`** — Remove `tier: 1` line

**4. `examples/hello-api/scenarios/not-found.yaml`** — Remove `tier: 1` line

**5. `examples/hello-api/scenarios/pagination.yaml`** — Remove `tier: 2` line

**6. `examples/hello-api/scenarios/validation.yaml`** — Remove `tier: 2` line

**7. `examples/hello-api/scenarios/crud.yaml`** — **Keep** `tier: 1` (manual override example)

**8. `docs/architecture.md`** (lines 540-543)
- Replace current `inferTier` description with updated weighted scoring documentation.

## Review Findings
- Errors: 0
- Warnings: 0
- Nits: 5
- Assessment: **PASS**

The change is clean and well-structured. The weighted scoring logic is straightforward, the switch/if chain avoids redundant nil checks (grpc bonus only fires when `step.GRPC != nil` is already implied by `StepType() == "grpc"`), and the test cases are thorough with inline score calculations as comments. The doc comment and architecture.md update are consistent with the implementation.
