### PR TITLE
feat(scenario): add step-level delay field for time-dependent testing

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -391,6 +391,7 @@ type Scenario struct {
 // Step represents a single action within a scenario.
 type Step struct {
 	Description string          `yaml:"description"`
+	Delay       string          `yaml:"delay"`
 	Request     *Request        `yaml:"request"`
 	Exec        *ExecRequest    `yaml:"exec"`
 	Browser     *BrowserRequest `yaml:"browser"`
@@ -619,6 +620,25 @@ steps:
 `StepResult.Duration` reflects total wall time from executor resolution through execution, including
 retries and sleeps. Duration is recorded even when executor resolution fails (non-zero on error).
 Captures are applied only from the final successful attempt.
+
+#### Pre-step Delay
+
+Steps support an optional `delay` field (Go duration string, e.g. `"2s"`, `"500ms"`) that causes
+the runner to sleep before executing the step. Useful for TTL expiration and eventual-consistency
+testing where a fixed wait is preferable to polling. The delay is applied before executor resolution
+for both setup steps (fatal — invalid delay fails the run) and judged steps (non-fatal — invalid
+delay records an error on the step). Context cancellation during delay propagates immediately.
+`octog lint` validates that `delay` parses as a valid Go duration.
+
+```yaml
+steps:
+  - description: "Wait for cache TTL to expire"
+    delay: "2s"
+    request:
+      method: GET
+      path: /items/{item_id}
+    expect: "Returns fresh data after cache expiry"
+```
 
 ### Variable Capture and Substitution
 

--- a/internal/lint/scenario.go
+++ b/internal/lint/scenario.go
@@ -325,6 +325,18 @@ func lintStep(path string, node *yaml.Node, cs *captureSet, isSetup bool) []Diag
 		}
 	}
 
+	// Check delay.
+	if delayFE, hasDelay := fields["delay"]; hasDelay && delayFE.value.Value != "" {
+		if _, err := time.ParseDuration(delayFE.value.Value); err != nil {
+			diags = append(diags, Diagnostic{
+				File:    path,
+				Line:    delayFE.value.Line,
+				Level:   Error,
+				Message: fmt.Sprintf("delay %q is not a valid duration", delayFE.value.Value),
+			})
+		}
+	}
+
 	// Check retry.
 	retryFE, hasRetry := fields["retry"]
 	if hasRetry {

--- a/internal/lint/scenario_test.go
+++ b/internal/lint/scenario_test.go
@@ -1037,6 +1037,34 @@ steps:
 			wantErrors: 0,
 			wantWarns:  0,
 		},
+		{
+			name: "valid delay on step",
+			yaml: `id: test
+steps:
+  - description: A step
+    delay: "2s"
+    request:
+      method: GET
+      path: /items
+    expect: "ok"
+`,
+			wantErrors: 0,
+			wantWarns:  0,
+		},
+		{
+			name: "invalid delay on step",
+			yaml: `id: test
+steps:
+  - description: A step
+    delay: "notaduration"
+    request:
+      method: GET
+      path: /items
+    expect: "ok"
+`,
+			wantErrors: 1,
+			wantMsg:    `delay "notaduration" is not a valid duration`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/scenario/runner.go
+++ b/internal/scenario/runner.go
@@ -19,6 +19,7 @@ var (
 	errNoExecutorRegistered = errors.New("no executor registered for step type")
 	errRetryInvalidInterval = errors.New("retry: invalid interval")
 	errRetryInvalidTimeout  = errors.New("retry: invalid timeout")
+	errInvalidDelay         = errors.New("step: invalid delay duration")
 )
 
 // Runner executes scenario steps by dispatching to registered StepExecutors.
@@ -44,6 +45,10 @@ func (r *Runner) Run(ctx context.Context, scenario Scenario) (Result, error) {
 
 	// Execute setup steps — fatal on failure.
 	for i, step := range scenario.Setup {
+		if err := r.applyDelay(ctx, step.Delay); err != nil {
+			return Result{}, fmt.Errorf("%w: step %d (%s): %w", errSetupFailed, i, step.Description, err)
+		}
+
 		executor, err := r.resolveExecutor(step)
 		if err != nil {
 			return Result{}, fmt.Errorf("%w: step %d (%s): %w", errSetupFailed, i, step.Description, err)
@@ -63,6 +68,18 @@ func (r *Runner) Run(ctx context.Context, scenario Scenario) (Result, error) {
 	results := make([]StepResult, 0, len(scenario.Steps))
 	for i, step := range scenario.Steps {
 		start := time.Now()
+
+		if err := r.applyDelay(ctx, step.Delay); err != nil {
+			results = append(results, StepResult{
+				Description: step.Description,
+				StepType:    step.StepType(),
+				Duration:    time.Since(start),
+				Err:         err,
+			})
+			r.Logger.Warn("judged step delay error", "step", i, "description", step.Description, "error", err)
+			continue
+		}
+
 		executor, err := r.resolveExecutor(step)
 		if err != nil {
 			results = append(results, StepResult{
@@ -161,6 +178,25 @@ func (r *Runner) executeWithRetry(ctx context.Context, executor StepExecutor, st
 		}
 	}
 	return lastOutput, lastErr
+}
+
+func (r *Runner) applyDelay(ctx context.Context, delay string) error {
+	if delay == "" {
+		return nil
+	}
+	d, err := parseStepTimeout(delay, 0)
+	if err != nil {
+		return fmt.Errorf("%w: %w", errInvalidDelay, err)
+	}
+	r.Logger.Debug("step delay", "delay", delay)
+	timer := time.NewTimer(d)
+	select {
+	case <-ctx.Done():
+		timer.Stop()
+		return ctx.Err()
+	case <-timer.C:
+	}
+	return nil
 }
 
 func (r *Runner) resolveExecutor(step Step) (StepExecutor, error) {

--- a/internal/scenario/runner_test.go
+++ b/internal/scenario/runner_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func newTestLogger() *slog.Logger {
@@ -891,6 +892,171 @@ func (e *countingExecutor) Execute(_ context.Context, _ Step, _ map[string]strin
 }
 
 func (e *countingExecutor) ValidCaptureSources() []string { return nil }
+
+func TestRunnerStepDelay(t *testing.T) {
+	mock := &mockExecutor{output: StepOutput{Observed: "ok"}}
+	runner := NewRunner(map[string]StepExecutor{"request": mock}, newTestLogger())
+	sc := Scenario{
+		ID: "delay-judged",
+		Steps: []Step{
+			{
+				Description: "delayed step",
+				Delay:       "100ms",
+				Request:     &Request{Method: "GET", Path: "/ok"},
+				Expect:      "ok",
+			},
+		},
+	}
+
+	start := time.Now()
+	result, err := runner.Run(context.Background(), sc)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Steps) != 1 {
+		t.Fatalf("got %d steps, want 1", len(result.Steps))
+	}
+	if result.Steps[0].Err != nil {
+		t.Fatalf("unexpected step error: %v", result.Steps[0].Err)
+	}
+	if elapsed < 100*time.Millisecond {
+		t.Errorf("expected elapsed >= 100ms, got %s", elapsed)
+	}
+}
+
+func TestRunnerSetupStepDelay(t *testing.T) {
+	mock := &mockExecutor{output: StepOutput{Observed: "ok"}}
+	runner := NewRunner(map[string]StepExecutor{"request": mock}, newTestLogger())
+	sc := Scenario{
+		ID: "delay-setup",
+		Setup: []Step{
+			{
+				Description: "delayed setup",
+				Delay:       "100ms",
+				Request:     &Request{Method: "GET", Path: "/ok"},
+			},
+		},
+		Steps: []Step{
+			{
+				Description: "judged step",
+				Request:     &Request{Method: "GET", Path: "/ok"},
+				Expect:      "ok",
+			},
+		},
+	}
+
+	start := time.Now()
+	_, err := runner.Run(context.Background(), sc)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if elapsed < 100*time.Millisecond {
+		t.Errorf("expected elapsed >= 100ms, got %s", elapsed)
+	}
+}
+
+func TestRunnerStepDelayInvalidDuration(t *testing.T) {
+	mock := &mockExecutor{output: StepOutput{Observed: "ok"}}
+	runner := NewRunner(map[string]StepExecutor{"request": mock}, newTestLogger())
+	sc := Scenario{
+		ID: "delay-invalid",
+		Steps: []Step{
+			{
+				Description: "bad delay",
+				Delay:       "notaduration",
+				Request:     &Request{Method: "GET", Path: "/ok"},
+				Expect:      "ok",
+			},
+		},
+	}
+
+	result, err := runner.Run(context.Background(), sc)
+	if err != nil {
+		t.Fatalf("unexpected error from Run: %v", err)
+	}
+	if len(result.Steps) != 1 {
+		t.Fatalf("got %d steps, want 1", len(result.Steps))
+	}
+	if result.Steps[0].Err == nil {
+		t.Fatal("expected step error for invalid delay, got nil")
+	}
+	if !errors.Is(result.Steps[0].Err, errInvalidDelay) {
+		t.Errorf("expected errInvalidDelay, got: %v", result.Steps[0].Err)
+	}
+}
+
+func TestRunnerSetupStepDelayInvalidDuration(t *testing.T) {
+	mock := &mockExecutor{output: StepOutput{Observed: "ok"}}
+	runner := NewRunner(map[string]StepExecutor{"request": mock}, newTestLogger())
+	sc := Scenario{
+		ID: "delay-setup-invalid",
+		Setup: []Step{
+			{
+				Description: "bad delay setup",
+				Delay:       "notaduration",
+				Request:     &Request{Method: "GET", Path: "/ok"},
+			},
+		},
+		Steps: []Step{
+			{
+				Description: "should not run",
+				Request:     &Request{Method: "GET", Path: "/ok"},
+				Expect:      "never",
+			},
+		},
+	}
+
+	_, err := runner.Run(context.Background(), sc)
+	if err == nil {
+		t.Fatal("expected error for invalid setup delay")
+	}
+	if !errors.Is(err, errSetupFailed) {
+		t.Errorf("expected errSetupFailed, got: %v", err)
+	}
+	if !errors.Is(err, errInvalidDelay) {
+		t.Errorf("expected errInvalidDelay in chain, got: %v", err)
+	}
+}
+
+func TestRunnerStepDelayContextCancellation(t *testing.T) {
+	mock := &mockExecutor{output: StepOutput{Observed: "ok"}}
+	runner := NewRunner(map[string]StepExecutor{"request": mock}, newTestLogger())
+	sc := Scenario{
+		ID: "delay-cancel",
+		Steps: []Step{
+			{
+				Description: "long delay",
+				Delay:       "10s",
+				Request:     &Request{Method: "GET", Path: "/ok"},
+				Expect:      "never",
+			},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	result, err := runner.Run(ctx, sc)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("unexpected error from Run: %v", err)
+	}
+	if len(result.Steps) != 1 {
+		t.Fatalf("got %d steps, want 1", len(result.Steps))
+	}
+	if result.Steps[0].Err == nil {
+		t.Fatal("expected step error from context cancellation")
+	}
+	if elapsed >= time.Second {
+		t.Errorf("expected fast cancellation, got %s", elapsed)
+	}
+}
 
 func TestRunnerUnknownStepType(t *testing.T) {
 	sc := Scenario{

--- a/internal/scenario/types.go
+++ b/internal/scenario/types.go
@@ -69,6 +69,7 @@ type Scenario struct {
 // Step represents a single action within a scenario.
 type Step struct {
 	Description string          `yaml:"description"`
+	Delay       string          `yaml:"delay"`
 	Request     *Request        `yaml:"request"`
 	Exec        *ExecRequest    `yaml:"exec"`
 	Browser     *BrowserRequest `yaml:"browser"`

--- a/schemas/scenario.json
+++ b/schemas/scenario.json
@@ -77,6 +77,11 @@
           "type": "string",
           "description": "Natural-language expectation judged by the LLM."
         },
+        "delay": {
+          "type": "string",
+          "pattern": "^[0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h)+$",
+          "description": "Sleep duration before executing this step (e.g., '2s', '500ms'). Useful for TTL expiration and eventual consistency testing. Duration includes delay time in StepResult."
+        },
         "retry": { "$ref": "#/$defs/retry" },
         "capture": {
           "type": "array",


### PR DESCRIPTION
Closes #243

## Changes
1. **`internal/scenario/types.go`** -- Add `Delay` field to `Step` struct
   - Add `Delay string \`yaml:"delay"\`` field (place between `Description` and `Request` for logical grouping with other step metadata)

2. **`internal/scenario/runner.go`** -- Apply delay before step execution
   - Add a private method `applyDelay(ctx context.Context, delay string) error` that:
     - Returns nil if `delay == ""`
     - Parses via `parseStepTimeout(delay, 0)`
     - Uses `time.NewTimer` + `select { case <-timer.C: case <-ctx.Done(): timer.Stop(); return ctx.Err() }` (matching the existing retry pattern at lines 154-159)
   - **Setup path** (line 46-59): Call `applyDelay` before `r.resolveExecutor`. On error, wrap with `errSetupFailed` and return.
   - **Judged path** (line 64-100): Call `applyDelay` after `start := time.Now()` and before `r.resolveExecutor`. On parse error, record in StepResult and `continue`.
   - Add `errInvalidDelay = errors.New("step: invalid delay duration")` to the sentinel error block in this file (it belongs with the other runner sentinels, not in types.go).
   - Add debug log: `r.Logger.Debug("step delay", "step", i, "delay", d)` inside applyDelay or at call site.

3. **`schemas/scenario.json`** -- Add `delay` to `$defs.step.properties`
   ```json
   "delay": {
     "type": "string",
     "pattern": "^[0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h)+$",
     "description": "Sleep duration before executing this step (e.g., '2s', '500ms'). Useful for TTL expiration and eventual consistency testing."
   }
   ```

4. **`internal/lint/scenario.go`** -- Add delay validation in `lintStep()`
   - After the retry check block (~line 332), add:
     ```go
     if delayFE, hasDelay := fields["delay"]; hasDelay && delayFE.value.Value != "" {
         if _, err := time.ParseDuration(delayFE.value.Value); err != nil {
             diags = append(diags, Diagnostic{
                 File:    path,
                 Line:    delayFE.value.Line,
                 Level:   Error,
                 Message: fmt.Sprintf("delay %q is not a valid duration", delayFE.value.Value),
             })
         }
     }
     ```
   - This follows the exact same pattern used for timeout validation in `lintExec`, `lintRetry`, etc.

## Review Findings
- Errors: 0
- Warnings: 0
- Nits: 4
- Assessment: **PASS**

The implementation is clean and correct. Error handling follows project conventions (sentinel errors, `%w` wrapping, setup-fatal vs judged-non-fatal). Context cancellation is properly handled with `select` on `ctx.Done()` and `timer.Stop()`. Tests cover the key paths: happy-path timing, invalid duration (both setup and judged), and context cancellation. Lint validation mirrors runtime validation. No security concerns.
