### PR TITLE
test(scenario): add unit tests for browser executor retry logic

### DIFF
--- a/internal/scenario/browser.go
+++ b/internal/scenario/browser.go
@@ -244,41 +244,65 @@ func isTransientCDPError(err error) bool {
 		strings.Contains(msg, "No node with given id")
 }
 
+// retryOnTransient calls fn up to maxRetries times, retrying on transient CDP
+// errors. The action label appears only in debug log messages.
+//
+// Return values:
+//   - nil: fn succeeded
+//   - non-transient error from fn: returned immediately (caller wraps if needed)
+//   - errPageContextLost: all retries exhausted (caller wraps)
+//   - ctx.Err(): context canceled during retry sleep (caller wraps)
+func retryOnTransient(ctx context.Context, maxRetries int, retryDelay time.Duration, logger *slog.Logger, action string, fn func() error) error {
+	for attempt := range maxRetries {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(retryDelay):
+			}
+		}
+
+		err := fn()
+		if err == nil {
+			return nil
+		}
+
+		if !isTransientCDPError(err) {
+			return err
+		}
+
+		logger.Debug("page mid-navigation, retrying",
+			"action", action, "attempt", attempt+1, "max", maxRetries)
+	}
+
+	return errPageContextLost
+}
+
 // readPageWithRetry reads DOM state, retrying on transient CDP errors that
 // occur when the page is mid-navigation (e.g. form submit → 303 redirect).
 func (e *BrowserExecutor) readPageWithRetry(ctx context.Context, action string) (StepOutput, error) {
 	const maxRetries = 5
 	const retryDelay = 200 * time.Millisecond
 
-	for attempt := range maxRetries {
-		if attempt > 0 {
-			select {
-			case <-ctx.Done():
-				return StepOutput{}, fmt.Errorf("browser: %s read: %w", action, ctx.Err())
-			case <-time.After(retryDelay):
-			}
-		}
-
+	// out is captured via closure side-effect when fn succeeds.
+	var out StepOutput
+	err := retryOnTransient(ctx, maxRetries, retryDelay, e.Logger, action, func() error {
 		var text, html, location string
-		err := chromedp.Run(ctx,
+		if runErr := chromedp.Run(ctx,
 			chromedp.WaitReady("body", chromedp.ByQuery),
 			chromedp.InnerHTML("body", &html, chromedp.ByQuery),
 			chromedp.Text("body", &text, chromedp.ByQuery),
 			chromedp.Location(&location),
-		)
-		if err == nil {
-			return buildBrowserOutput(location, text, html, -1), nil
+		); runErr != nil {
+			return runErr
 		}
-
-		if !isTransientCDPError(err) {
-			return StepOutput{}, fmt.Errorf("browser: %s read: %w", action, err)
-		}
-
-		e.Logger.Debug("page mid-navigation, retrying DOM read",
-			"action", action, "attempt", attempt+1, "max", maxRetries)
+		out = buildBrowserOutput(location, text, html, -1)
+		return nil
+	})
+	if err != nil {
+		return StepOutput{}, fmt.Errorf("browser: %s read: %w", action, err)
 	}
-
-	return StepOutput{}, fmt.Errorf("browser: %s read: %w", action, errPageContextLost)
+	return out, nil
 }
 
 func (e *BrowserExecutor) doFill(ctx context.Context, req BrowserRequest) (StepOutput, error) {
@@ -318,29 +342,22 @@ func (e *BrowserExecutor) doAssert(ctx context.Context, req BrowserRequest) (Ste
 	const maxRetries = 5
 	const retryDelay = 200 * time.Millisecond
 
-	for attempt := range maxRetries {
-		if attempt > 0 {
-			select {
-			case <-ctx.Done():
-				return StepOutput{}, fmt.Errorf("browser: assert: %w", ctx.Err())
-			case <-time.After(retryDelay):
-			}
-		}
-
-		out, err := e.doAssertOnce(ctx, req)
-		if err == nil {
-			return out, nil
-		}
-
-		if !isTransientCDPError(err) {
-			return StepOutput{}, err
-		}
-
-		e.Logger.Debug("page mid-navigation, retrying assert",
-			"attempt", attempt+1, "max", maxRetries)
+	// out is captured via closure side-effect when fn succeeds.
+	var out StepOutput
+	err := retryOnTransient(ctx, maxRetries, retryDelay, e.Logger, "assert", func() error {
+		var callErr error
+		out, callErr = e.doAssertOnce(ctx, req)
+		return callErr
+	})
+	if err == nil {
+		return out, nil
 	}
-
-	return StepOutput{}, fmt.Errorf("browser: assert: %w", errPageContextLost)
+	// errPageContextLost and context errors (from the sleep path or from chromedp
+	// calls inside doAssertOnce) need the browser prefix.
+	if errors.Is(err, errPageContextLost) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return StepOutput{}, fmt.Errorf("browser: assert: %w", err)
+	}
+	return StepOutput{}, err
 }
 
 func (e *BrowserExecutor) doAssertOnce(ctx context.Context, req BrowserRequest) (StepOutput, error) {
@@ -379,6 +396,27 @@ func (e *BrowserExecutor) doAssertOnce(ctx context.Context, req BrowserRequest) 
 	}
 
 	// Build assertion results as observed text (NOT errors -- let the judge score).
+	assertions := evaluateAssertions(elemText, matchCount, req)
+
+	observed := fmt.Sprintf("URL: %s\nSelector: %s\nMatching elements: %d\nElement text: %s\nAssertions:\n%s",
+		location, req.Selector, matchCount, elemText, strings.Join(assertions, "\n"))
+
+	return StepOutput{
+		Observed:    observed,
+		CaptureBody: elemText,
+		CaptureSources: map[string]string{
+			BrowserSourceText:     elemText,
+			BrowserSourceHTML:     elemHTML,
+			BrowserSourceCount:    strconv.Itoa(matchCount),
+			BrowserSourceLocation: location,
+		},
+	}, nil
+}
+
+// evaluateAssertions builds PASS/FAIL result strings for each assertion
+// configured in req. Returns an empty slice when no assertions are configured.
+// Count is skipped when req.Count is nil.
+func evaluateAssertions(elemText string, matchCount int, req BrowserRequest) []string {
 	var assertions []string
 	if req.Text != "" {
 		if strings.Contains(elemText, req.Text) {
@@ -401,20 +439,7 @@ func (e *BrowserExecutor) doAssertOnce(ctx context.Context, req BrowserRequest) 
 			assertions = append(assertions, fmt.Sprintf("FAIL: expected %d matching elements, found %d", *req.Count, matchCount))
 		}
 	}
-
-	observed := fmt.Sprintf("URL: %s\nSelector: %s\nMatching elements: %d\nElement text: %s\nAssertions:\n%s",
-		location, req.Selector, matchCount, elemText, strings.Join(assertions, "\n"))
-
-	return StepOutput{
-		Observed:    observed,
-		CaptureBody: elemText,
-		CaptureSources: map[string]string{
-			BrowserSourceText:     elemText,
-			BrowserSourceHTML:     elemHTML,
-			BrowserSourceCount:    strconv.Itoa(matchCount),
-			BrowserSourceLocation: location,
-		},
-	}, nil
+	return assertions
 }
 
 // maxObservedHTML caps the HTML included in observed output to avoid

--- a/internal/scenario/browser_test.go
+++ b/internal/scenario/browser_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"strings"
 	"testing"
@@ -225,6 +226,203 @@ func TestNewBrowserExecutor(t *testing.T) {
 	}
 	if exec.parentCtx != ctx {
 		t.Error("parentCtx not set correctly")
+	}
+}
+
+func TestRetryOnTransient(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	const maxRetries = 3
+	const retryDelay = 1 * time.Millisecond
+
+	transientErr := errors.New("Cannot find context with specified id")
+	nonTransientErr := errors.New("connection refused")
+
+	tests := []struct {
+		name      string
+		mkFn      func(calls *int) func() error
+		ctxFn     func() context.Context
+		wantErr   error
+		wantCalls int
+	}{
+		{
+			name: "success on first attempt",
+			mkFn: func(calls *int) func() error {
+				return func() error {
+					*calls++
+					return nil
+				}
+			},
+			ctxFn:     context.Background,
+			wantErr:   nil,
+			wantCalls: 1,
+		},
+		{
+			name: "transient then success",
+			mkFn: func(calls *int) func() error {
+				return func() error {
+					*calls++
+					if *calls < 3 {
+						return transientErr
+					}
+					return nil
+				}
+			},
+			ctxFn:     context.Background,
+			wantErr:   nil,
+			wantCalls: 3,
+		},
+		{
+			name: "all transient exhausted",
+			mkFn: func(calls *int) func() error {
+				return func() error {
+					*calls++
+					return transientErr
+				}
+			},
+			ctxFn:     context.Background,
+			wantErr:   errPageContextLost,
+			wantCalls: maxRetries,
+		},
+		{
+			name: "non-transient fails immediately",
+			mkFn: func(calls *int) func() error {
+				return func() error {
+					*calls++
+					return nonTransientErr
+				}
+			},
+			ctxFn:     context.Background,
+			wantErr:   nonTransientErr,
+			wantCalls: 1,
+		},
+		{
+			name: "context canceled during delay",
+			mkFn: func(calls *int) func() error {
+				return func() error {
+					*calls++
+					return transientErr
+				}
+			},
+			ctxFn: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			},
+			wantErr:   context.Canceled,
+			wantCalls: 1, // attempt 0 runs, sleep on attempt 1 returns immediately
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls int
+			fn := tt.mkFn(&calls)
+			ctx := tt.ctxFn()
+			err := retryOnTransient(ctx, maxRetries, retryDelay, logger, "test", fn)
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("got error %v, want %v", err, tt.wantErr)
+			}
+			if calls != tt.wantCalls {
+				t.Errorf("fn called %d times, want %d", calls, tt.wantCalls)
+			}
+		})
+	}
+}
+
+func TestEvaluateAssertions(t *testing.T) {
+	intPtr := func(n int) *int { return &n }
+
+	tests := []struct {
+		name       string
+		elemText   string
+		matchCount int
+		req        BrowserRequest
+		wantLines  []string
+	}{
+		{
+			name:     "text contains PASS",
+			elemText: "say hello world",
+			req:      BrowserRequest{Text: "hello"},
+			wantLines: []string{
+				`PASS: element text contains "hello"`,
+			},
+		},
+		{
+			name:     "text contains FAIL",
+			elemText: "hello",
+			req:      BrowserRequest{Text: "goodbye"},
+			wantLines: []string{
+				`FAIL: element text does not contain "goodbye" (got "hello")`,
+			},
+		},
+		{
+			name:     "text absent PASS",
+			elemText: "success",
+			req:      BrowserRequest{TextAbsent: "error"},
+			wantLines: []string{
+				`PASS: element text does not contain "error"`,
+			},
+		},
+		{
+			name:     "text absent FAIL",
+			elemText: "error occurred",
+			req:      BrowserRequest{TextAbsent: "error"},
+			wantLines: []string{
+				`FAIL: element text contains "error" (should be absent)`,
+			},
+		},
+		{
+			name:       "count match PASS",
+			matchCount: 3,
+			req:        BrowserRequest{Count: intPtr(3)},
+			wantLines: []string{
+				"PASS: found 3 matching elements",
+			},
+		},
+		{
+			name:       "count mismatch FAIL",
+			matchCount: 5,
+			req:        BrowserRequest{Count: intPtr(2)},
+			wantLines: []string{
+				"FAIL: expected 2 matching elements, found 5",
+			},
+		},
+		{
+			name:       "multiple assertions",
+			elemText:   "hello world",
+			matchCount: 2,
+			req:        BrowserRequest{Text: "hello", TextAbsent: "error", Count: intPtr(2)},
+			wantLines: []string{
+				`PASS: element text contains "hello"`,
+				`PASS: element text does not contain "error"`,
+				"PASS: found 2 matching elements",
+			},
+		},
+		{
+			name:      "no assertions configured",
+			req:       BrowserRequest{},
+			wantLines: nil,
+		},
+		{
+			name:      "nil count skipped",
+			elemText:  "",
+			req:       BrowserRequest{Count: nil},
+			wantLines: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := evaluateAssertions(tt.elemText, tt.matchCount, tt.req)
+			if len(got) != len(tt.wantLines) {
+				t.Fatalf("got %d assertions, want %d: %v", len(got), len(tt.wantLines), got)
+			}
+			for i, line := range tt.wantLines {
+				if got[i] != line {
+					t.Errorf("assertion[%d] = %q, want %q", i, got[i], line)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Closes #250

## Changes
**1. `internal/scenario/browser.go` -- Extract testable helpers**

- Add `retryOnTransient(ctx context.Context, maxRetries int, retryDelay time.Duration, logger *slog.Logger, action string, fn func() error) error`:
  - Calls `fn` up to `maxRetries` times
  - On nil error from `fn`, returns nil immediately  
  - On non-transient error from `fn`, returns that error immediately (unwrapped -- caller wraps)
  - On transient error, logs debug and sleeps `retryDelay` (respecting ctx cancellation)
  - After exhausting retries, returns `errPageContextLost` (unwrapped -- caller wraps)
  - On context cancellation during sleep, returns `ctx.Err()` (unwrapped -- caller wraps)

- Add `evaluateAssertions(elemText string, matchCount int, req BrowserRequest) []string`:
  - Extracts lines 382-403 of `doAssertOnce`
  - Handles nil `req.Count` (skips count assertion)
  - Returns slice of "PASS: ..." / "FAIL: ..." strings

- Refactor `readPageWithRetry` to use `retryOnTransient`. The chromedp call and `StepOutput` construction go in the closure; `StepOutput` captured via closure variable. Caller wraps errors with `fmt.Errorf("browser: %s read: %w", action, err)`.

- Refactor `doAssert` to use `retryOnTransient`. The `doAssertOnce` call goes in the closure; `StepOutput` captured via closure variable. Caller wraps errors with `fmt.Errorf("browser: assert: %w", err)`.

- Refactor `doAssertOnce` to call `evaluateAssertions` instead of inline assertion logic.

## Review Findings
- Errors: 0
- Warnings: 0
- Nits: 3
- Assessment: **PASS**

Clean extraction of two well-scoped helpers with thorough tests. The retry loop is properly generalized (context-aware, configurable parameters, no coupling to chromedp), error wrapping responsibilities are clearly split between `retryOnTransient` (returns raw) and callers (wrap with domain prefix), and the test coverage hits all branches including the exhaustion and cancellation paths.
