### PR TITLE
fix(kv-store): resolve TTL scenario stalling at 90% satisfaction

### DIFF
--- a/examples/kv-store/scenarios/ttl.yaml
+++ b/examples/kv-store/scenarios/ttl.yaml
@@ -28,11 +28,12 @@ steps:
     expect: "Status 200. Value is 'goes away'. expires_at is a non-null ISO timestamp."
 
   - description: Wait for expiration and verify key is gone
+    delay: "3s"
     request:
       method: GET
       path: /kv/ephemeral
     retry:
-      attempts: 5
+      attempts: 3
       interval: "1s"
     expect: "Status 404. The key should have expired."
 

--- a/examples/kv-store/spec.md
+++ b/examples/kv-store/spec.md
@@ -29,7 +29,8 @@ Create or overwrite a record.
 Retrieve a record by key.
 
 - Response: `200 OK` with the record JSON
-- If not found or expired: `404 Not Found`
+- If not found: `404 Not Found`
+- If the key exists but `expires_at` is non-null and in the past: return `404 Not Found`
 
 ### DELETE /kv/{key}
 
@@ -40,7 +41,7 @@ Delete a record.
 
 ### GET /kv
 
-List all non-expired keys.
+List keys. Exclude any key whose `expires_at` is non-null and in the past.
 
 - Query parameters:
   - `prefix` -- string, optional, filter keys by prefix


### PR DESCRIPTION
## Summary

- **Add 3s delay** to `ttl.yaml` step 2 so the GET fires after the 2s TTL expires (retry was exiting immediately on HTTP 200 because transport succeeded, even though the status code was wrong)
- **Make spec explicit** about TTL enforcement mechanism: separate "not found" from "expired" in GET /kv/{key}, and spell out the `expires_at` time comparison for GET /kv list endpoint
- Reduce retry attempts from 5 to 3 (now just a transport-error safety net)

## Test plan

- [x] `make lint` -- passes
- [x] `make test` -- passes
- [x] `octog lint --spec examples/kv-store/spec.md --scenarios examples/kv-store/scenarios` -- no issues
- [x] `octog run` on kv-store example -- converged iteration 1, 100% satisfaction (all 7 scenarios including ttl at 100/100)

🤖 Generated with [Claude Code](https://claude.com/claude-code)