### PR TITLE
refactor: use os.UserConfigDir/os.UserCacheDir for config and data paths

### DIFF
--- a/.claude/skills/generate-examples.md
+++ b/.claude/skills/generate-examples.md
@@ -50,7 +50,7 @@ the background — run them sequentially and check each result before proceeding
 
 ## Notes
 
-- API keys are in `~/.octopusgarden/config` — no env vars needed.
+- API keys are in the platform-native config file (macOS: `~/Library/Application Support/octopusgarden/config`; Linux: `~/.config/octopusgarden/config`; legacy: `~/.octopusgarden/config`) — no env vars needed.
 - Default threshold is 95%. Do not override unless the user specifies.
 - If the user asks to run with a specific provider only, use that provider for all examples.
 - If the user asks to run a specific example, run only that one.

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -134,7 +134,7 @@ linters:
     paths:
       - workspace   # generated attractor output — not project source code
     rules:
-      - path: "internal/(scenario|attractor|container|store|spec|lint|gene|observability|view|preflight|e2e)/"
+      - path: "internal/(scenario|attractor|container|store|spec|lint|gene|observability|view|preflight|e2e|paths)/"
         linters:
           - paralleltest  # not yet parallelized; llm package enforces this
       - path: "cmd/"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,8 +89,15 @@ Cross-package and multi-implementation interfaces:
 
 ## Configuration
 
-API keys go in `~/.octopusgarden/config` (preferred) or environment variables. Config file uses
-`KEY=VALUE` format, one per line. Env vars take precedence over config values.
+API keys go in the platform-native config file (preferred) or environment variables. Config file
+uses `KEY=VALUE` format, one per line. Env vars take precedence over config values.
+
+Config file location (in priority order):
+
+1. `$OCTOG_CONFIG_DIR/config` — env var override (also used for test isolation)
+1. `~/Library/Application Support/octopusgarden/config` — macOS
+1. `$XDG_CONFIG_HOME/octopusgarden/config` (or `~/.config/octopusgarden/config`) — Linux
+1. `~/.octopusgarden/config` — legacy fallback (deprecated)
 
 ```ini
 ANTHROPIC_API_KEY=sk-ant-...

--- a/cmd/octog/main.go
+++ b/cmd/octog/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/foundatron/octopusgarden/internal/lint"
 	"github.com/foundatron/octopusgarden/internal/llm"
 	"github.com/foundatron/octopusgarden/internal/observability"
+	"github.com/foundatron/octopusgarden/internal/paths"
 	"github.com/foundatron/octopusgarden/internal/preflight"
 	"github.com/foundatron/octopusgarden/internal/scenario"
 	"github.com/foundatron/octopusgarden/internal/spec"
@@ -46,9 +47,9 @@ var (
 	errSpecAndScenariosRequired   = errors.New("--spec and --scenarios are required")
 	errScenariosAndTargetRequired = errors.New("--scenarios and either --target or --code are required")
 	errCodeAndTargetConflict      = errors.New("--code and --target are mutually exclusive")
-	errMissingAnthropicKey        = errors.New("ANTHROPIC_API_KEY not set (use env var or ~/.octopusgarden/config)")
-	errMissingOpenAIKey           = errors.New("OPENAI_API_KEY not set (use env var or ~/.octopusgarden/config)")
-	errNoAPIKey                   = errors.New("no API key found: set ANTHROPIC_API_KEY or OPENAI_API_KEY (or use ~/.octopusgarden/config)")
+	errMissingAnthropicKey        = errors.New("ANTHROPIC_API_KEY not set (use env var, config file, or `octog configure`)")
+	errMissingOpenAIKey           = errors.New("OPENAI_API_KEY not set (use env var, config file, or `octog configure`)")
+	errNoAPIKey                   = errors.New("no API key found: set ANTHROPIC_API_KEY or OPENAI_API_KEY (env var, config file, or `octog configure`)")
 	errAmbiguousProvider          = errors.New("both ANTHROPIC_API_KEY and OPENAI_API_KEY are set; use --provider to disambiguate")
 	errBelowThreshold             = errors.New("satisfaction below threshold")
 	errInvalidThreshold           = errors.New("--threshold must be between 0 and 100")
@@ -1201,15 +1202,14 @@ func openStore(ctx context.Context) (*store.Store, error) {
 }
 
 func resolveStorePath() (string, error) {
-	home, err := os.UserHomeDir()
+	p, err := paths.StorePath()
 	if err != nil {
 		return "", fmt.Errorf("resolve store path: %w", err)
 	}
-	dir := filepath.Join(home, ".octopusgarden")
-	if err := os.MkdirAll(dir, 0o750); err != nil {
+	if err := paths.EnsureParentDir(p); err != nil {
 		return "", fmt.Errorf("create store dir: %w", err)
 	}
-	return filepath.Join(dir, "runs.db"), nil
+	return p, nil
 }
 
 // executorOpts captures the parameters for building per-goroutine step executors.
@@ -1509,18 +1509,13 @@ var configKeys = []string{"ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OPENAI_BASE_UR
 // configClearValue is the sentinel input that clears an existing config value.
 const configClearValue = "-"
 
-func configPath() (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("resolve config path: %w", err)
-	}
-	return filepath.Join(home, ".octopusgarden", "config"), nil
-}
-
 func loadConfig(logger *slog.Logger) error {
-	path, err := configPath()
+	path, warn, err := paths.ConfigFile()
 	if err != nil {
 		return err
+	}
+	if warn != "" {
+		logger.Warn(warn)
 	}
 
 	info, err := os.Stat(path)
@@ -1537,7 +1532,7 @@ func loadConfig(logger *slog.Logger) error {
 			"path", path, "mode", fmt.Sprintf("%04o", perm))
 	}
 
-	f, err := os.Open(path) //nolint:gosec // G304: path is derived from UserHomeDir, not user input
+	f, err := os.Open(path) //nolint:gosec // G304: path is derived from paths.ConfigFile(), not user input
 	if err != nil {
 		return fmt.Errorf("open config: %w", err)
 	}
@@ -1789,9 +1784,12 @@ func configureCmd(_ context.Context, _ *slog.Logger, args []string) error {
 		return err
 	}
 
-	cfgPath, err := configPath()
+	cfgPath, warn, err := paths.ConfigFile()
 	if err != nil {
 		return err
+	}
+	if warn != "" {
+		fmt.Fprintf(os.Stderr, "Warning: %s\n\n", warn) //nolint:gosec // G705 false positive: writing to stderr
 	}
 
 	return configureInteractive(os.Stdin, os.Stdout, cfgPath)
@@ -1863,7 +1861,7 @@ func maskValue(value string) string {
 // plus the original lines (for comment/ordering preservation). Returns an empty
 // map and nil lines if the file does not exist.
 func readConfigFile(path string) (map[string]string, []string, error) {
-	f, err := os.Open(path) //nolint:gosec // G304: path derives from configPath()/UserHomeDir
+	f, err := os.Open(path) //nolint:gosec // G304: path derives from paths.ConfigFile(), not user input
 	if errors.Is(err, fs.ErrNotExist) {
 		return make(map[string]string), nil, nil
 	}

--- a/cmd/octog/main_test.go
+++ b/cmd/octog/main_test.go
@@ -349,16 +349,12 @@ func TestLoadConfig(t *testing.T) {
 	dir := t.TempDir()
 	content := "# comment\n\nANTHROPIC_API_KEY=sk-test-from-config\nOPENAI_API_KEY=sk-openai-test\n"
 
-	// Override HOME so configPath() resolves to our temp dir.
-	ogDir := filepath.Join(dir, ".octopusgarden")
-	if err := os.MkdirAll(ogDir, 0o750); err != nil {
-		t.Fatal(err)
-	}
-	ogConfig := filepath.Join(ogDir, "config")
+	// Use OCTOG_CONFIG_DIR to redirect config resolution to our temp dir.
+	ogConfig := filepath.Join(dir, "config")
 	if err := os.WriteFile(ogConfig, []byte(content), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("HOME", dir)
+	t.Setenv("OCTOG_CONFIG_DIR", dir)
 
 	// Ensure the env vars are unset before loading.
 	// t.Setenv("", "") makes os.Getenv return "" which loadConfig treats as unset.
@@ -380,16 +376,12 @@ func TestLoadConfig(t *testing.T) {
 
 func TestLoadConfigEnvPrecedence(t *testing.T) {
 	dir := t.TempDir()
-	ogDir := filepath.Join(dir, ".octopusgarden")
-	if err := os.MkdirAll(ogDir, 0o750); err != nil {
-		t.Fatal(err)
-	}
-	ogConfig := filepath.Join(ogDir, "config")
+	ogConfig := filepath.Join(dir, "config")
 	if err := os.WriteFile(ogConfig, []byte("ANTHROPIC_API_KEY=from-config\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
-	t.Setenv("HOME", dir)
+	t.Setenv("OCTOG_CONFIG_DIR", dir)
 	t.Setenv("ANTHROPIC_API_KEY", "from-env")
 
 	logger := testLogger()
@@ -404,7 +396,7 @@ func TestLoadConfigEnvPrecedence(t *testing.T) {
 
 func TestLoadConfigMissing(t *testing.T) {
 	dir := t.TempDir()
-	t.Setenv("HOME", dir)
+	t.Setenv("OCTOG_CONFIG_DIR", dir)
 
 	logger := testLogger()
 	if err := loadConfig(logger); err != nil {
@@ -414,16 +406,12 @@ func TestLoadConfigMissing(t *testing.T) {
 
 func TestLoadConfigUnknownKey(t *testing.T) {
 	dir := t.TempDir()
-	ogDir := filepath.Join(dir, ".octopusgarden")
-	if err := os.MkdirAll(ogDir, 0o750); err != nil {
-		t.Fatal(err)
-	}
-	ogConfig := filepath.Join(ogDir, "config")
+	ogConfig := filepath.Join(dir, "config")
 	if err := os.WriteFile(ogConfig, []byte("UNKNOWN_KEY=value\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
-	t.Setenv("HOME", dir)
+	t.Setenv("OCTOG_CONFIG_DIR", dir)
 
 	// Should not error, just warn.
 	logger := testLogger()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -69,6 +69,7 @@ octopusgarden/
 │   │   └── scenario.go           # CheckScenarios(): coverage, feasibility, isolation, chains
 │   ├── observability/            # OpenTelemetry tracing (OTLP/HTTP)
 │   │   └── setup.go              # InitTracer, TracingLLMClient, TracingContainerManager
+│   ├── paths/                    # Platform-native config/data path resolution (XDG, macOS, legacy)
 │   ├── view/                     # JSON view models for CLI output
 │   ├── store/                    # SQLite run history (db.go, types.go)
 │   ├── testutil/                 # Test helpers
@@ -109,6 +110,7 @@ cmd/octog
     ├── internal/llm            (client interface, anthropic, openai, models, prompts)
     ├── internal/container      (docker build/run, sessions, multi-port)
     ├── internal/spec           (parser, types, summary)
+    ├── internal/paths          (platform-native config/data path resolution)
     ├── internal/view           (JSON view models for CLI output)
     └── internal/store          (sqlite)
 ```
@@ -133,6 +135,7 @@ content and failure feedback as strings. The validator (scenario runner + judge)
 | `observability` | OpenTelemetry tracing wrappers | `setup.go` | `llm`, `container`, otel SDK |
 | `store` | SQLite run/iteration persistence | `db.go`, `types.go` | modernc.org/sqlite |
 | `view` | JSON view models for CLI output | `*.go` | (none) |
+| `paths` | Platform-native config/data path resolution: `ConfigDir()`, `ConfigFile()`, `DataDir()`, `StorePath()`, `EnsureParentDir()` | `paths.go` | (none) |
 | `limits` | Shared constants (MaxResponseBytes) | `limits.go` | (none) |
 | `testutil` | Test helpers | `*.go` | (none) |
 | `e2e` | End-to-end integration tests | `*.go` | multiple |
@@ -1133,8 +1136,15 @@ octog configure
 Subcommands: `interview`, `run`, `validate`, `preflight`, `status`, `lint`, `extract`, `models`, `configure`.
 
 Provider is auto-detected from which API key is set. Use `--provider` to disambiguate when both are
-present. Config file (`~/.octopusgarden/config`) supports `ANTHROPIC_API_KEY` and `OPENAI_API_KEY`;
-env vars take precedence. `OPENAI_BASE_URL` overrides the OpenAI endpoint for Ollama etc.
+present. Config file supports `ANTHROPIC_API_KEY` and `OPENAI_API_KEY`; env vars take precedence.
+`OPENAI_BASE_URL` overrides the OpenAI endpoint for Ollama etc.
+
+Config file location (in priority order):
+
+1. `$OCTOG_CONFIG_DIR/config` — env var override
+2. `~/Library/Application Support/octopusgarden/config` — macOS
+3. `$XDG_CONFIG_HOME/octopusgarden/config` (or `~/.config/octopusgarden/config`) — Linux
+4. `~/.octopusgarden/config` — legacy fallback (deprecated; run `octog configure` to migrate)
 
 ## Gene Transfusion
 

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -1,0 +1,100 @@
+// Package paths resolves platform-native configuration and data paths for octog.
+package paths
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ConfigDir returns the configuration directory for octog, plus an optional
+// deprecation warning if the legacy ~/.octopusgarden path is being used.
+// It checks, in order:
+//  1. OCTOG_CONFIG_DIR environment variable override
+//  2. os.UserConfigDir()/octopusgarden (platform-native: ~/Library/Application Support on macOS, ~/.config on Linux)
+//  3. ~/.octopusgarden (legacy fallback — returns a non-empty deprecation warning)
+//
+// If neither the new nor legacy directory exists, the new platform-native location
+// is returned so it can be created on demand.
+func ConfigDir() (dir string, deprecationWarning string, err error) {
+	if override := os.Getenv("OCTOG_CONFIG_DIR"); override != "" {
+		return override, "", nil
+	}
+
+	base, err := os.UserConfigDir()
+	if err != nil {
+		return "", "", fmt.Errorf("resolve config dir: %w", err)
+	}
+	newDir := filepath.Join(base, "octopusgarden")
+
+	// If the new location already exists, use it.
+	if _, err := os.Stat(newDir); err == nil {
+		return newDir, "", nil
+	}
+
+	// Check for legacy ~/.octopusgarden fallback.
+	home, err := os.UserHomeDir()
+	if err != nil {
+		// Can't find home dir — fall through to new location.
+		return newDir, "", nil
+	}
+	legacyDir := filepath.Join(home, ".octopusgarden")
+	if _, err := os.Stat(legacyDir); err == nil {
+		warn := "config directory ~/.octopusgarden is deprecated; run `octog configure` to migrate to " + newDir
+		return legacyDir, warn, nil
+	}
+
+	// Neither exists — return the new location (will be created on demand).
+	return newDir, "", nil
+}
+
+// ConfigFile returns the path to the octog config file, plus an optional
+// deprecation warning if the legacy ~/.octopusgarden path is being used.
+func ConfigFile() (string, string, error) {
+	dir, warn, err := ConfigDir()
+	if err != nil {
+		return "", "", err
+	}
+	return filepath.Join(dir, "config"), warn, nil
+}
+
+// DataDir returns the data directory for octog (where the SQLite run-history database lives).
+// It follows XDG Base Directory conventions, keeping application data separate from config:
+//  1. OCTOG_CONFIG_DIR environment variable override (covers both config and data)
+//  2. $XDG_DATA_HOME/octopusgarden when XDG_DATA_HOME is set
+//  3. os.UserConfigDir()/octopusgarden as fallback (~/Library/Application Support on macOS,
+//     ~/.config on Linux when XDG_DATA_HOME is unset)
+func DataDir() (string, error) {
+	if override := os.Getenv("OCTOG_CONFIG_DIR"); override != "" {
+		return override, nil
+	}
+	if xdgData := os.Getenv("XDG_DATA_HOME"); xdgData != "" {
+		return filepath.Join(xdgData, "octopusgarden"), nil
+	}
+	base, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve data dir: %w", err)
+	}
+	return filepath.Join(base, "octopusgarden"), nil
+}
+
+// StorePath returns the path to the SQLite run-history database.
+// The database lives in DataDir, not ConfigDir, following XDG data/config separation.
+func StorePath() (string, error) {
+	dir, err := DataDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "runs.db"), nil
+}
+
+// EnsureParentDir creates the parent directory of path with 0700 permissions if it
+// does not already exist. Permissions are 0700 (owner-only) — intentionally tighter
+// than the legacy 0750 to prevent group read of potentially sensitive config and data.
+func EnsureParentDir(path string) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create dir: %w", err)
+	}
+	return nil
+}

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -1,0 +1,179 @@
+package paths
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestConfigDir_Default(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("OCTOG_CONFIG_DIR", "")
+	t.Setenv("XDG_CONFIG_HOME", "") // ensure os.UserConfigDir() uses $HOME, not a pre-set XDG dir
+
+	// Neither new nor legacy dir exists — should return new platform-native location.
+	got, warn, err := ConfigDir()
+	if err != nil {
+		t.Fatalf("ConfigDir() error: %v", err)
+	}
+
+	base, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatalf("os.UserConfigDir() error: %v", err)
+	}
+	want := filepath.Join(base, "octopusgarden")
+	if got != want {
+		t.Errorf("ConfigDir() = %q, want %q", got, want)
+	}
+	if warn != "" {
+		t.Errorf("deprecation warning should be empty, got %q", warn)
+	}
+}
+
+func TestConfigDir_EnvOverride(t *testing.T) {
+	override := t.TempDir()
+	t.Setenv("OCTOG_CONFIG_DIR", override)
+
+	got, warn, err := ConfigDir()
+	if err != nil {
+		t.Fatalf("ConfigDir() error: %v", err)
+	}
+	if got != override {
+		t.Errorf("ConfigDir() = %q, want %q (override)", got, override)
+	}
+	if warn != "" {
+		t.Errorf("deprecation warning should be empty, got %q", warn)
+	}
+}
+
+func TestConfigDir_LegacyFallback(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("OCTOG_CONFIG_DIR", "")
+
+	// Create legacy dir only; new platform-native dir does not exist.
+	legacyDir := filepath.Join(dir, ".octopusgarden")
+	if err := os.MkdirAll(legacyDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	got, warn, err := ConfigDir()
+	if err != nil {
+		t.Fatalf("ConfigDir() error: %v", err)
+	}
+	if got != legacyDir {
+		t.Errorf("ConfigDir() = %q, want %q (legacy fallback)", got, legacyDir)
+	}
+	if warn == "" {
+		t.Error("deprecation warning should be set when legacy path is used")
+	}
+	if !strings.Contains(warn, "octog configure") {
+		t.Errorf("deprecation warning should mention 'octog configure', got %q", warn)
+	}
+}
+
+func TestConfigDir_NewTakesPrecedence(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("OCTOG_CONFIG_DIR", "")
+
+	// Create legacy dir.
+	legacyDir := filepath.Join(dir, ".octopusgarden")
+	if err := os.MkdirAll(legacyDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create the new platform-native dir.
+	base, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatalf("os.UserConfigDir() error: %v", err)
+	}
+	newDir := filepath.Join(base, "octopusgarden")
+	if err := os.MkdirAll(newDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	got, warn, err := ConfigDir()
+	if err != nil {
+		t.Fatalf("ConfigDir() error: %v", err)
+	}
+	if got != newDir {
+		t.Errorf("ConfigDir() = %q, want %q (new location wins)", got, newDir)
+	}
+	if warn != "" {
+		t.Errorf("deprecation warning should be empty when new dir exists, got %q", warn)
+	}
+}
+
+func TestConfigFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("OCTOG_CONFIG_DIR", dir)
+
+	got, _, err := ConfigFile()
+	if err != nil {
+		t.Fatalf("ConfigFile() error: %v", err)
+	}
+	if filepath.Base(got) != "config" {
+		t.Errorf("ConfigFile() base = %q, want config", filepath.Base(got))
+	}
+}
+
+func TestDataDir_EnvOverride(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("OCTOG_CONFIG_DIR", dir)
+
+	got, err := DataDir()
+	if err != nil {
+		t.Fatalf("DataDir() error: %v", err)
+	}
+	if got != dir {
+		t.Errorf("DataDir() = %q, want %q (OCTOG_CONFIG_DIR override)", got, dir)
+	}
+}
+
+func TestDataDir_XDGDataHome(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("OCTOG_CONFIG_DIR", "")
+	t.Setenv("XDG_DATA_HOME", dir)
+
+	got, err := DataDir()
+	if err != nil {
+		t.Fatalf("DataDir() error: %v", err)
+	}
+	want := filepath.Join(dir, "octopusgarden")
+	if got != want {
+		t.Errorf("DataDir() = %q, want %q", got, want)
+	}
+}
+
+func TestStorePath(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("OCTOG_CONFIG_DIR", dir)
+
+	got, err := StorePath()
+	if err != nil {
+		t.Fatalf("StorePath() error: %v", err)
+	}
+	if filepath.Base(got) != "runs.db" {
+		t.Errorf("StorePath() base = %q, want runs.db", filepath.Base(got))
+	}
+}
+
+func TestEnsureParentDir(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "sub", "runs.db")
+
+	if err := EnsureParentDir(target); err != nil {
+		t.Fatalf("EnsureParentDir() error: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(dir, "sub"))
+	if err != nil {
+		t.Fatalf("stat dir: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o700 {
+		t.Errorf("dir perm = %04o, want 0700", perm)
+	}
+}

--- a/scripts/smoke-test.py
+++ b/scripts/smoke-test.py
@@ -95,11 +95,28 @@ def run(
 def has_api_key() -> bool:
     if os.environ.get("ANTHROPIC_API_KEY") or os.environ.get("OPENAI_API_KEY"):
         return True
-    config = Path.home() / ".octopusgarden" / "config"
-    if config.is_file():
-        text = config.read_text()
-        if "ANTHROPIC_API_KEY" in text or "OPENAI_API_KEY" in text:
-            return True
+    # Check OCTOG_CONFIG_DIR override first, then platform-native paths, then legacy.
+    override = os.environ.get("OCTOG_CONFIG_DIR")
+    candidates: list[Path] = []
+    if override:
+        candidates.append(Path(override) / "config")
+    home = Path.home()
+    if sys.platform == "darwin":
+        candidates.append(
+            home / "Library" / "Application Support" / "octopusgarden" / "config"
+        )
+    else:
+        xdg = os.environ.get("XDG_CONFIG_HOME")
+        if xdg:
+            candidates.append(Path(xdg) / "octopusgarden" / "config")
+        else:
+            candidates.append(home / ".config" / "octopusgarden" / "config")
+    candidates.append(home / ".octopusgarden" / "config")  # legacy fallback
+    for config in candidates:
+        if config.is_file():
+            text = config.read_text()
+            if "ANTHROPIC_API_KEY" in text or "OPENAI_API_KEY" in text:
+                return True
     print("Warning: No API key found. Rounds 2-3 will be skipped.")
     return False
 


### PR DESCRIPTION
Closes #261

## Changes
**1. `internal/paths/paths.go` (NEW)**
- `ConfigDir() (string, error)` -- checks `OCTOG_CONFIG_DIR` env override first, then `os.UserConfigDir()/octopusgarden`. If that dir doesn't exist but `~/.octopusgarden` does, return the legacy path and log a deprecation warning via a package-level `var DeprecationWarning string` (caller logs it)
- `ConfigFile() (string, error)` -- returns `ConfigDir()/config`
- `StorePath() (string, error)` -- returns `ConfigDir()/runs.db`
- `EnsureDir(path string) error` -- `os.MkdirAll(filepath.Dir(path), 0o700)`
- No `DataDir`, no `XDG_DATA_HOME`, no `MigrateIfNeeded`

**2. `cmd/octog/main.go` (MODIFY)**
- Replace `configPath()` body: delegate to `paths.ConfigFile()`
- Replace `resolveStorePath()` body: delegate to `paths.StorePath()` + `paths.EnsureDir()`
- Update sentinel error messages (lines 49-51): remove hardcoded `~/.octopusgarden/config`, use generic wording
- If `paths.ConfigDir()` sets a deprecation warning, log it once at startup
- Update `gosec` nolint comment on line 1866

**3. `cmd/octog/main_test.go` (MODIFY)**
- Tests that set `HOME` to redirect paths: set `OCTOG_CONFIG_DIR` via `t.Setenv` instead
- Verify existing `TestLoadConfig*` tests pass with the new path resolution

**4. `scripts/smoke-test.py` (MODIFY)**
- `has_api_key()`: check platform-native config path inline (macOS: `~/Library/Application Support/octopusgarden/config`, Linux: `~/.config/octopusgarden/config`) plus legacy `~/.octopusgarden/config`. No new Python deps.

**5. `docs/architecture.md` (MODIFY)**
- Update config path references to describe platform-native paths

**6. `CLAUDE.md` (MODIFY)**
- Update config path documentation (line 92 area)

**7. `.claude/skills/generate-examples.md` (MODIFY)**
- Update config path reference

**8. Check `internal/interview/` for hardcoded paths** -- if it references `~/.octopusgarden` directly, update to use `paths` package.

## Review Findings
- Errors: 0
- Warnings: 2
- Nits: 4
- Assessment: **NEEDS CHANGES**

The XDG data-vs-config separation (finding 1) is the most significant issue. The refactor does the right thing for config files but misses the opportunity to correctly place data files, and now that you're explicitly opting into platform conventions, the inconsistency is more visible. The permissions tightening (finding 2) should at minimum be a conscious, documented decision.
