### PR TITLE
feat: make octog installable via Homebrew

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,3 +36,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: v${{ steps.semantic.outputs.new_release_version }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -55,3 +55,16 @@ release:
     name: octopusgarden
   draft: false
   prerelease: auto
+
+brews:
+  - repository:
+      owner: foundatron
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    directory: Formula
+    homepage: "https://github.com/foundatron/octopusgarden"
+    description: "Autonomous software dark factory: specs to working code via attractor loop"
+    license: MIT
+    skip_upload: auto
+    test: |
+      system "#{bin}/octog", "--help"

--- a/README.md
+++ b/README.md
@@ -61,7 +61,10 @@ Spec + Scenarios --> Preflight --> Attractor Loop --> Generated Code --> Docker 
 ## Quick Start
 
 ```bash
-# Clone and build
+# Homebrew (macOS/Linux)
+brew install foundatron/tap/octopusgarden
+
+# Or build from source
 git clone https://github.com/foundatron/octopusgarden.git
 cd octopusgarden
 make build


### PR DESCRIPTION
Closes #260

## Changes
**1. `.goreleaser.yaml` — Add `brews` section**

Append a `brews` block after the existing `release` section:

```yaml
brews:
  - repository:
      owner: foundatron
      name: homebrew-tap
      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
    directory: Formula
    homepage: "https://github.com/foundatron/octopusgarden"
    description: "Autonomous software dark factory: specs to working code via attractor loop"
    license: MIT
    skip_upload: auto
    test: |
      system "#{bin}/octog", "--help"
```

**2. `.github/workflows/release.yml` — Pass `HOMEBREW_TAP_TOKEN` to GoReleaser step**

Add `HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}` to the GoReleaser step's `env` block.

**3. Manual: Create `foundatron/homebrew-tap` repo** (out-of-repo, documented for completeness)

**4. Manual: Create `HOMEBREW_TAP_TOKEN` repo secret** (out-of-repo, documented for completeness)

## Review Findings
- Errors: 0
- Warnings: 0
- Nits: 2
- Assessment: **PASS**
