### PR TITLE
feat(cmd): add --version flag with goreleaser ldflags

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,6 +9,11 @@ builds:
     binary: octog
     env:
       - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.ShortCommit}}
+      - -X main.date={{.Date}}
     goos: [linux, darwin, windows]
     goarch: [amd64, arm64]
     ignore:
@@ -67,4 +72,4 @@ brews:
     license: MIT
     skip_upload: auto
     test: |
-      system "#{bin}/octog", "--help"
+      system "#{bin}/octog", "--version"

--- a/cmd/octog/main.go
+++ b/cmd/octog/main.go
@@ -37,6 +37,13 @@ import (
 	"github.com/foundatron/octopusgarden/internal/view"
 )
 
+// version information set by goreleaser ldflags.
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
 // stepPassThreshold is the per-step score below which a step is labeled FAIL
 // in validation output and considered failing for detailed feedback. This is
 // purely cosmetic — the --threshold flag on validateCmd controls the aggregate
@@ -89,6 +96,9 @@ func main() {
 	switch os.Args[1] {
 	case "--help", "-h", "-help":
 		printUsage()
+		return
+	case "--version", "-V", "version":
+		fmt.Printf("octog %s (commit %s, built %s)\n", version, commit, date)
 		return
 	case "run":
 		err = runCmd(ctx, logger, os.Args[2:])


### PR DESCRIPTION
## Summary
- Add `--version` / `-V` / `version` subcommand showing version, commit, and build date
- Configure goreleaser ldflags to inject version info at build time
- Update Homebrew formula test to use `--version` instead of `--help`

## Test plan
- [x] `make build && ./octog --version` prints `octog dev (commit none, built unknown)`
- [x] `./octog version` and `./octog -V` also work
- [x] `make lint` passes with 0 issues
- [x] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)