### PR TITLE
feat(interview): enhance prompts and add generation spinner

### DIFF
--- a/cmd/octog/main.go
+++ b/cmd/octog/main.go
@@ -1730,7 +1730,7 @@ func interviewCmd(ctx context.Context, logger *slog.Logger, args []string) error
 // When generateScenarios is true, scenario YAML files are generated and written
 // to a scenarios/ directory alongside the spec.
 func interviewRun(ctx context.Context, client llm.Client, model, initialPrompt, outputPath, seedContent string, generateScenarios bool, log *slog.Logger, in io.Reader, display interview.Display, errOut io.Writer) error {
-	iv := interview.New(client, in, display, model)
+	iv := interview.New(client, in, display, errOut, model)
 	var (
 		spec string
 		cost float64

--- a/internal/interview/interview.go
+++ b/internal/interview/interview.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/foundatron/octopusgarden/internal/llm"
 )
@@ -36,16 +37,19 @@ type Interviewer struct {
 	client  llm.Client
 	in      io.Reader
 	display Display
+	errOut  io.Writer
 	model   string
 }
 
 // New creates an Interviewer that reads from in, displays output via display,
-// and uses the given LLM client and model.
-func New(client llm.Client, in io.Reader, display Display, model string) *Interviewer {
+// and uses the given LLM client and model. Status output (spinners) is written
+// to errOut; pass nil to suppress.
+func New(client llm.Client, in io.Reader, display Display, errOut io.Writer, model string) *Interviewer {
 	return &Interviewer{
 		client:  client,
 		in:      in,
 		display: display,
+		errOut:  errOut,
 		model:   model,
 	}
 }
@@ -176,7 +180,9 @@ func (i *Interviewer) run(ctx context.Context, sysPrompt string, messages []llm.
 			if round >= maxRounds && !done {
 				i.display.SystemMessage("Maximum rounds reached. Generating spec now.")
 			}
+			stop := i.startSpinner("Generating spec...")
 			spec, cost, genErr := i.generateFinal(ctx, sysPrompt, messages)
+			stop()
 			return spec, totalCost + cost, genErr
 		}
 	}
@@ -225,6 +231,37 @@ func (i *Interviewer) processAnswer(ctx context.Context, sysPrompt string, messa
 	i.display.SystemMessage(rePromptMsg)
 	i.display.InputPrompt()
 	return resp.CostUSD, nil
+}
+
+// startSpinner displays a braille spinner with the given label on errOut.
+// It returns a stop function that halts the spinner and clears the line.
+// If errOut is nil, the returned function is a no-op.
+func (i *Interviewer) startSpinner(label string) func() {
+	if i.errOut == nil {
+		return func() {}
+	}
+	frames := []rune("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏")
+	done := make(chan struct{})
+	ticker := time.NewTicker(100 * time.Millisecond)
+	go func() {
+		idx := 0
+		for {
+			select {
+			case <-ticker.C:
+				fmt.Fprintf(i.errOut, "\r%c %s", frames[idx%len(frames)], label) //nolint:errcheck
+				idx++
+			case <-done:
+				return
+			}
+		}
+	}()
+	return func() {
+		close(done)
+		ticker.Stop()
+		// Clear the spinner line: overwrite with spaces, then carriage return.
+		clearLen := len(label) + 4
+		fmt.Fprintf(i.errOut, "\r%s\r", strings.Repeat(" ", clearLen)) //nolint:errcheck
+	}
 }
 
 func (i *Interviewer) generateFinal(ctx context.Context, sysPrompt string, messages []llm.Message) (string, float64, error) {

--- a/internal/interview/interview_test.go
+++ b/internal/interview/interview_test.go
@@ -45,7 +45,7 @@ func TestInterviewHappyPath(t *testing.T) {
 	in := strings.NewReader("Go\n\n\ndone\n")
 	var out bytes.Buffer
 
-	iv := New(client, in, ui.NewPlain(&out), "test-model")
+	iv := New(client, in, ui.NewPlain(&out), nil, "test-model")
 	spec, cost, err := iv.Run(context.Background(), "I want to build a CLI app.")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -74,7 +74,7 @@ func TestInterviewEmptyInput(t *testing.T) {
 	in := strings.NewReader("\n\nanswer\n\n\ndone\n")
 	var out bytes.Buffer
 
-	iv := New(client, in, ui.NewPlain(&out), "test-model")
+	iv := New(client, in, ui.NewPlain(&out), nil, "test-model")
 	_, _, err := iv.Run(context.Background(), "I want to build something.")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -111,7 +111,7 @@ func TestInterviewMaxRounds(t *testing.T) {
 	in := strings.NewReader(strings.Join(lines, "\n\n\n") + "\n\n\n")
 	var out bytes.Buffer
 
-	iv := New(client, in, ui.NewPlain(&out), "test-model")
+	iv := New(client, in, ui.NewPlain(&out), nil, "test-model")
 	spec, _, err := iv.Run(context.Background(), "Start.")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -151,7 +151,7 @@ func TestInterviewDoneCaseInsensitive(t *testing.T) {
 			}
 			in := strings.NewReader(input + "\n")
 			var out bytes.Buffer
-			iv := New(client, in, ui.NewPlain(&out), "test-model")
+			iv := New(client, in, ui.NewPlain(&out), nil, "test-model")
 			spec, _, err := iv.Run(context.Background(), "Start.")
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
@@ -176,7 +176,7 @@ func TestInterviewContextCancellation(t *testing.T) {
 
 	in := strings.NewReader("answer\n")
 	var out bytes.Buffer
-	iv := New(client, in, ui.NewPlain(&out), "test-model")
+	iv := New(client, in, ui.NewPlain(&out), nil, "test-model")
 	_, _, err := iv.Run(ctx, "Start.")
 	if err == nil {
 		t.Fatal("expected error for canceled context")
@@ -197,7 +197,7 @@ func TestInterviewLLMError(t *testing.T) {
 
 	in := strings.NewReader("")
 	var out bytes.Buffer
-	iv := New(client, in, ui.NewPlain(&out), "test-model")
+	iv := New(client, in, ui.NewPlain(&out), nil, "test-model")
 	_, _, err := iv.Run(context.Background(), "Start.")
 	if err == nil {
 		t.Fatal("expected error")
@@ -225,7 +225,7 @@ func TestInterviewCostTracking(t *testing.T) {
 	// initial call + 1 round + done → 3 calls total
 	in := strings.NewReader("answer\n\n\ndone\n")
 	var out bytes.Buffer
-	iv := New(client, in, ui.NewPlain(&out), "test-model")
+	iv := New(client, in, ui.NewPlain(&out), nil, "test-model")
 	_, total, err := iv.Run(context.Background(), "Start.")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -251,7 +251,7 @@ func TestInterviewEOF(t *testing.T) {
 	// Reader exhausts without "done"
 	in := strings.NewReader("partial answer")
 	var out bytes.Buffer
-	iv := New(client, in, ui.NewPlain(&out), "test-model")
+	iv := New(client, in, ui.NewPlain(&out), nil, "test-model")
 	spec, _, err := iv.Run(context.Background(), "Start.")
 	if err != nil {
 		t.Fatalf("unexpected error on EOF: %v", err)
@@ -284,7 +284,7 @@ func TestInterviewMultiLineInput(t *testing.T) {
 	in := strings.NewReader("line one\nline two\nline three\n\n\ndone\n")
 	var out bytes.Buffer
 
-	iv := New(client, in, ui.NewPlain(&out), "test-model")
+	iv := New(client, in, ui.NewPlain(&out), nil, "test-model")
 	_, _, err := iv.Run(context.Background(), "Start.")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -334,7 +334,7 @@ func TestInterviewPreservesBlankLines(t *testing.T) {
 	in := strings.NewReader("paragraph one\n\nparagraph two\n\n\ndone\n")
 	var out bytes.Buffer
 
-	iv := New(client, in, ui.NewPlain(&out), "test-model")
+	iv := New(client, in, ui.NewPlain(&out), nil, "test-model")
 	_, _, err := iv.Run(context.Background(), "Start.")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -376,7 +376,7 @@ func TestRunWithSeed(t *testing.T) {
 	in := strings.NewReader("done\n")
 	var out bytes.Buffer
 
-	iv := New(client, in, ui.NewPlain(&out), "test-model")
+	iv := New(client, in, ui.NewPlain(&out), nil, "test-model")
 	spec, cost, err := iv.RunWithSeed(context.Background(), seedSpec)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -429,7 +429,7 @@ func TestRunWithSeedPreservesConversationLoop(t *testing.T) {
 	in := strings.NewReader("Go\n\n\ndone\n")
 	var out bytes.Buffer
 
-	iv := New(client, in, ui.NewPlain(&out), "test-model")
+	iv := New(client, in, ui.NewPlain(&out), nil, "test-model")
 	spec, _, err := iv.RunWithSeed(context.Background(), "## Purpose\nA CLI tool.")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/interview/prompt.go
+++ b/internal/interview/prompt.go
@@ -1,5 +1,16 @@
 package interview
 
+// systemPrompt guides the interviewer through NLSpec dimension coverage,
+// implementation-depth probing, and hidden assumption surfacing.
+//
+// Interviewing strategies inspired by Q00/ouroboros (https://github.com/Q00/ouroboros):
+//   - Implementation-depth probing adapts Ouroboros's ontological questioning framework
+//     ("What IS this, really?") into concrete engineering categories (input multiplexing,
+//     protocol rendering, state machines, concurrency, layout boundaries).
+//   - Hidden assumption surfacing draws from Ouroboros's contrarian persona that challenges
+//     stated requirements to expose unstated conflicts and shared-resource contention.
+//   - The two-implementer test is octog's own scoring concept (see scoring_prompt.go),
+//     applied here during interviews rather than only at scoring time.
 const systemPrompt = `You are an expert software specification interviewer. Your role is to help users
 articulate their software ideas into a clear, complete NLSpec-format specification.
 
@@ -11,16 +22,63 @@ An NLSpec document has these dimensions:
 - **Constraints**: Non-functional requirements (latency, scale, security, cost).
 - **Error handling**: How should the system behave when things go wrong?
 
-Your task:
-1. Ask targeted questions to uncover gaps in each NLSpec dimension.
-2. Ask exactly ONE question per turn. Never ask multiple questions in the same message. Wait for the user's answer before asking the next question.
-3. Once you have enough to write a complete spec (usually 5–10 questions), generate it.
-4. When the user types "done" or you have reached the question limit, produce the final spec.
+## Questioning Strategy
 
-Final spec format:
+1. Ask exactly ONE question per turn. Never ask multiple questions in the same message. Wait for the user's answer before asking the next question.
+2. Target the biggest source of ambiguity in what you know so far.
+3. Build on previous responses rather than asking unrelated questions.
+4. Once you have enough to write a complete spec (usually 5–10 questions), generate it.
+5. When the user types "done" or you reach the question limit, produce the final spec.
+
+## The Two-Implementer Test
+
+Before moving on from a feature, mentally check: if two engineers independently built this
+from the user's description, would they make the same implementation choices? If not, the
+description is ambiguous and you should probe deeper. Do not accept hand-wavy descriptions
+of features that require precise mechanisms.
+
+## Implementation-Depth Probing
+
+When the user describes a feature that involves any of the following, shift from asking
+"what does it do?" to asking "how does it work?":
+
+- **Input multiplexing**: Multiple subsystems competing for the same input channel (e.g.,
+  keyboard events routed to both navigation and a subprocess). Ask: what determines which
+  subsystem gets the input? Is there an explicit mode switch?
+- **Protocol rendering**: Displaying output from another system (terminal emulator, pty,
+  WebSocket stream, raw ANSI sequences). Ask: what interprets and renders the raw output?
+  What library or mechanism transforms it into displayable content?
+- **State machines**: Features with implicit state transitions (e.g., "the process is
+  backgrounded when you leave the slide"). Ask: what triggers each transition? What happens
+  in edge cases between states?
+- **Concurrency**: Background or parallel operations. Ask: how do parallel operations
+  interact? What happens if they conflict?
+- **Layout boundaries**: UI that can overflow, resize, or hit minimum dimensions. Ask: what
+  happens when the content exceeds the available space? What happens on terminal resize?
+
+Identify the single hardest engineering problem in the user's description and allocate at
+least one question specifically to its mechanism, not just its desired behavior.
+
+## Surface Hidden Assumptions
+
+When the user describes two features that could interact or conflict, ask about the
+interaction explicitly. Look for:
+- Key bindings or inputs that serve double duty across different modes or contexts
+- Features that assume a resource (screen space, input focus, process lifecycle) is
+  exclusively theirs when it may be shared
+- Behaviors described at the product level ("keyboard input is passed through") that
+  require non-obvious infrastructure to implement
+
+Ask "what are we assuming about how X works?" when the answer is not obvious from the
+user's description.
+
+## Final Spec Format
+
 - Use markdown with level-2 headings (##) for each NLSpec dimension.
 - Be precise and unambiguous. Avoid filler sentences.
-- Include only what is known; do not invent requirements.`
+- Include only what is known; do not invent requirements.
+- For features where the mechanism matters, specify the mechanism (library, protocol,
+  rendering strategy), not just the desired behavior.`
 
 // seedSystemPrompt is composed from systemPrompt with additional instructions for
 // reviewing an existing spec. Composed via concatenation so NLSpec dimension list
@@ -30,4 +88,7 @@ const seedSystemPrompt = "You are reviewing an existing software specification. 
 	"then help the user improve it through targeted questions.\n\n" +
 	"Preserve what is already well-specified. " +
 	"Focus your questions on what is missing or unclear.\n\n" +
+	"When reviewing the spec, explicitly scan for features where the mechanism " +
+	"(how it works internally) is left to the implementer's judgment. These are " +
+	"your highest-priority gaps -- probe them before cosmetic or structural issues.\n\n" +
 	systemPrompt

--- a/internal/interview/scoring_prompt.go
+++ b/internal/interview/scoring_prompt.go
@@ -1,5 +1,10 @@
 package interview
 
+// Mechanism-awareness enhancement to behavioral_completeness inspired by
+// Q00/ouroboros (https://github.com/Q00/ouroboros): Ouroboros distinguishes
+// behavioral clarity from implementation-mechanism clarity. We apply the same
+// principle here -- specs that describe desired behavior without specifying the
+// mechanism for features where the mechanism IS the hard part should score lower.
 const scoringSystemPrompt = `You are a spec-completeness evaluator. Your job is to score a software specification
 against five dimensions and identify specific gaps that would prevent an engineer from implementing
 the feature without follow-up questions.
@@ -23,6 +28,12 @@ Score each dimension from 0 to 100:
 ### behavioral_completeness (weight: 0.25)
 Does the spec describe all significant behaviors: happy paths, error paths, edge cases, and
 state transitions? Are there implicit behaviors that should be made explicit?
+
+This includes not just WHAT the system does but HOW it does it when the mechanism is
+non-obvious. If a feature requires complex infrastructure (e.g., terminal rendering, protocol
+handling, input routing), the spec must describe the mechanism, not just the desired behavior.
+Two engineers should not have to independently invent the same rendering strategy or input
+routing scheme.
 
 ### interface_precision (weight: 0.25)
 Are all interfaces (API endpoints, CLI flags, config options, data formats, types, field names)


### PR DESCRIPTION
## Summary
- Enhance interview system prompt with implementation-depth probing (input multiplexing, protocol rendering, state machines, concurrency, layout boundaries), two-implementer test, and hidden assumption surfacing (largely inspired by https://github.com/Q00/ouroboros)
- Enhance scoring prompt to penalize specs that describe behavior without specifying mechanisms
- Add braille spinner on stderr during final spec generation LLM call (30-120s wait with no prior feedback)

## Test plan
- [x] `make test` -- all tests pass (spinner suppressed with nil errOut in tests)
- [x] `make lint` -- no violations
- [ ] `make build && ./octog interview` -- verify spinner appears after typing "done"

🤖 Generated with [Claude Code](https://claude.com/claude-code)