### PR TITLE
chore: remove legacy config migration code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,6 @@ Config file location (in priority order):
 1. `$OCTOG_CONFIG_DIR/config` — env var override (also used for test isolation)
 1. `~/Library/Application Support/octopusgarden/config` — macOS
 1. `$XDG_CONFIG_HOME/octopusgarden/config` (or `~/.config/octopusgarden/config`) — Linux
-1. `~/.octopusgarden/config` — legacy fallback (deprecated)
 
 ```ini
 ANTHROPIC_API_KEY=sk-ant-...

--- a/cmd/octog/main.go
+++ b/cmd/octog/main.go
@@ -1522,12 +1522,9 @@ var configKeys = []string{"ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OPENAI_BASE_UR
 const configClearValue = "-"
 
 func loadConfig(logger *slog.Logger) error {
-	path, warn, err := paths.ConfigFile()
+	path, err := paths.ConfigFile()
 	if err != nil {
 		return err
-	}
-	if warn != "" {
-		logger.Warn(warn)
 	}
 
 	info, err := os.Stat(path)
@@ -1806,50 +1803,12 @@ func configureCmd(_ context.Context, _ *slog.Logger, args []string) error {
 		return err
 	}
 
-	cfgPath, warn, err := paths.ConfigFile()
+	cfgPath, err := paths.ConfigFile()
 	if err != nil {
 		return err
 	}
 
-	// If using the legacy path, migrate to the new platform-native location.
-	if warn != "" {
-		var migErr error
-		cfgPath, migErr = migrateFromLegacy(cfgPath)
-		if migErr != nil {
-			return migErr
-		}
-	}
-
 	return configureInteractive(os.Stdin, os.Stdout, cfgPath)
-}
-
-// migrateFromLegacy moves config and run history from the legacy ~/.octopusgarden
-// directory to the platform-native location, returning the new config file path.
-func migrateFromLegacy(legacyPath string) (string, error) {
-	newPath, err := paths.NativeConfigFile()
-	if err != nil {
-		return "", err
-	}
-	fmt.Fprintf(os.Stderr, "Migrating config from %s to %s\n\n", legacyPath, newPath) //nolint:gosec // G705 false positive: writing to stderr
-	if err := paths.EnsureParentDir(newPath); err != nil {
-		return "", err
-	}
-
-	// Migrate runs.db if it exists in the legacy directory.
-	legacyDir := filepath.Dir(legacyPath)
-	legacyDB := filepath.Join(legacyDir, "runs.db")
-	if _, statErr := os.Stat(legacyDB); statErr == nil {
-		if newDBPath, dbErr := paths.StorePath(); dbErr == nil {
-			if renameErr := os.Rename(legacyDB, newDBPath); renameErr == nil {
-				fmt.Fprintf(os.Stderr, "Migrated run history to %s\n", newDBPath) //nolint:gosec // G705 false positive: writing to stderr
-			}
-		}
-	}
-
-	// Clean up legacy config file and directory if now empty.
-	_ = os.Remove(legacyPath)
-	_ = os.Remove(legacyDir) // only succeeds if empty
-	return newPath, nil
 }
 
 func configureInteractive(r io.Reader, w io.Writer, cfgPath string) error {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -72,7 +72,7 @@ octopusgarden/
 │   │   └── scenario.go           # CheckScenarios(): coverage, feasibility, isolation, chains
 │   ├── observability/            # OpenTelemetry tracing (OTLP/HTTP)
 │   │   └── setup.go              # InitTracer, TracingLLMClient, TracingContainerManager
-│   ├── paths/                    # Platform-native config/data path resolution (XDG, macOS, legacy)
+│   ├── paths/                    # Platform-native config/data path resolution (XDG, macOS)
 │   ├── view/                     # JSON view models for CLI output
 │   ├── store/                    # SQLite run history (db.go, types.go)
 │   ├── testutil/                 # Test helpers
@@ -1169,7 +1169,6 @@ Config file location (in priority order):
 1. `$OCTOG_CONFIG_DIR/config` — env var override
 2. `~/Library/Application Support/octopusgarden/config` — macOS
 3. `$XDG_CONFIG_HOME/octopusgarden/config` (or `~/.config/octopusgarden/config`) — Linux
-4. `~/.octopusgarden/config` — legacy fallback (deprecated; run `octog configure` to migrate)
 
 ## Gene Transfusion
 

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -7,65 +7,32 @@ import (
 	"path/filepath"
 )
 
-// ConfigDir returns the configuration directory for octog, plus an optional
-// deprecation warning if the legacy ~/.octopusgarden path is being used.
+// ConfigDir returns the configuration directory for octog.
 // It checks, in order:
 //  1. OCTOG_CONFIG_DIR environment variable override
 //  2. os.UserConfigDir()/octopusgarden (platform-native: ~/Library/Application Support on macOS, ~/.config on Linux)
-//  3. ~/.octopusgarden (legacy fallback — returns a non-empty deprecation warning)
 //
-// If neither the new nor legacy directory exists, the new platform-native location
-// is returned so it can be created on demand.
-func ConfigDir() (dir string, deprecationWarning string, err error) {
+// If the platform-native directory does not exist, it is returned so it can be
+// created on demand.
+func ConfigDir() (string, error) {
 	if override := os.Getenv("OCTOG_CONFIG_DIR"); override != "" {
-		return override, "", nil
+		return override, nil
 	}
 
-	base, err := os.UserConfigDir()
-	if err != nil {
-		return "", "", fmt.Errorf("resolve config dir: %w", err)
-	}
-	newDir := filepath.Join(base, "octopusgarden")
-
-	// If the new location already exists, use it.
-	if _, err := os.Stat(newDir); err == nil {
-		return newDir, "", nil
-	}
-
-	// Check for legacy ~/.octopusgarden fallback.
-	home, err := os.UserHomeDir()
-	if err != nil {
-		// Can't find home dir — fall through to new location.
-		return newDir, "", nil
-	}
-	legacyDir := filepath.Join(home, ".octopusgarden")
-	if _, err := os.Stat(legacyDir); err == nil {
-		warn := "config directory ~/.octopusgarden is deprecated; run `octog configure` to migrate to " + newDir
-		return legacyDir, warn, nil
-	}
-
-	// Neither exists — return the new location (will be created on demand).
-	return newDir, "", nil
-}
-
-// ConfigFile returns the path to the octog config file, plus an optional
-// deprecation warning if the legacy ~/.octopusgarden path is being used.
-func ConfigFile() (string, string, error) {
-	dir, warn, err := ConfigDir()
-	if err != nil {
-		return "", "", err
-	}
-	return filepath.Join(dir, "config"), warn, nil
-}
-
-// NativeConfigFile returns the platform-native config file path, ignoring
-// any legacy fallback. Used by configure to determine the migration target.
-func NativeConfigFile() (string, error) {
 	base, err := os.UserConfigDir()
 	if err != nil {
 		return "", fmt.Errorf("resolve config dir: %w", err)
 	}
-	return filepath.Join(base, "octopusgarden", "config"), nil
+	return filepath.Join(base, "octopusgarden"), nil
+}
+
+// ConfigFile returns the path to the octog config file.
+func ConfigFile() (string, error) {
+	dir, err := ConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "config"), nil
 }
 
 // DataDir returns the data directory for octog (where the SQLite run-history database lives).

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -3,7 +3,6 @@ package paths
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
@@ -13,8 +12,7 @@ func TestConfigDir_Default(t *testing.T) {
 	t.Setenv("OCTOG_CONFIG_DIR", "")
 	t.Setenv("XDG_CONFIG_HOME", "") // ensure os.UserConfigDir() uses $HOME, not a pre-set XDG dir
 
-	// Neither new nor legacy dir exists — should return new platform-native location.
-	got, warn, err := ConfigDir()
+	got, err := ConfigDir()
 	if err != nil {
 		t.Fatalf("ConfigDir() error: %v", err)
 	}
@@ -27,83 +25,18 @@ func TestConfigDir_Default(t *testing.T) {
 	if got != want {
 		t.Errorf("ConfigDir() = %q, want %q", got, want)
 	}
-	if warn != "" {
-		t.Errorf("deprecation warning should be empty, got %q", warn)
-	}
 }
 
 func TestConfigDir_EnvOverride(t *testing.T) {
 	override := t.TempDir()
 	t.Setenv("OCTOG_CONFIG_DIR", override)
 
-	got, warn, err := ConfigDir()
+	got, err := ConfigDir()
 	if err != nil {
 		t.Fatalf("ConfigDir() error: %v", err)
 	}
 	if got != override {
 		t.Errorf("ConfigDir() = %q, want %q (override)", got, override)
-	}
-	if warn != "" {
-		t.Errorf("deprecation warning should be empty, got %q", warn)
-	}
-}
-
-func TestConfigDir_LegacyFallback(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("HOME", dir)
-	t.Setenv("OCTOG_CONFIG_DIR", "")
-
-	// Create legacy dir only; new platform-native dir does not exist.
-	legacyDir := filepath.Join(dir, ".octopusgarden")
-	if err := os.MkdirAll(legacyDir, 0o700); err != nil {
-		t.Fatal(err)
-	}
-
-	got, warn, err := ConfigDir()
-	if err != nil {
-		t.Fatalf("ConfigDir() error: %v", err)
-	}
-	if got != legacyDir {
-		t.Errorf("ConfigDir() = %q, want %q (legacy fallback)", got, legacyDir)
-	}
-	if warn == "" {
-		t.Error("deprecation warning should be set when legacy path is used")
-	}
-	if !strings.Contains(warn, "octog configure") {
-		t.Errorf("deprecation warning should mention 'octog configure', got %q", warn)
-	}
-}
-
-func TestConfigDir_NewTakesPrecedence(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("HOME", dir)
-	t.Setenv("OCTOG_CONFIG_DIR", "")
-
-	// Create legacy dir.
-	legacyDir := filepath.Join(dir, ".octopusgarden")
-	if err := os.MkdirAll(legacyDir, 0o700); err != nil {
-		t.Fatal(err)
-	}
-
-	// Create the new platform-native dir.
-	base, err := os.UserConfigDir()
-	if err != nil {
-		t.Fatalf("os.UserConfigDir() error: %v", err)
-	}
-	newDir := filepath.Join(base, "octopusgarden")
-	if err := os.MkdirAll(newDir, 0o700); err != nil {
-		t.Fatal(err)
-	}
-
-	got, warn, err := ConfigDir()
-	if err != nil {
-		t.Fatalf("ConfigDir() error: %v", err)
-	}
-	if got != newDir {
-		t.Errorf("ConfigDir() = %q, want %q (new location wins)", got, newDir)
-	}
-	if warn != "" {
-		t.Errorf("deprecation warning should be empty when new dir exists, got %q", warn)
 	}
 }
 
@@ -111,7 +44,7 @@ func TestConfigFile(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("OCTOG_CONFIG_DIR", dir)
 
-	got, _, err := ConfigFile()
+	got, err := ConfigFile()
 	if err != nil {
 		t.Fatalf("ConfigFile() error: %v", err)
 	}


### PR DESCRIPTION
Closes #270

## Changes
1. **`internal/paths/paths.go`**
   - Simplify `ConfigDir()` signature: `(string, error)`. Remove lines 35-45 (legacy fallback block). Keep env override, platform-native check, and "neither exists" default.
   - Simplify `ConfigFile()` signature: `(string, error)`. Drop `warn` from inner `ConfigDir()` call.
   - Remove `NativeConfigFile()` entirely (lines 61-69).
   - Update doc comments on both functions to remove legacy references.
   - Imports: `fmt`, `os`, `path/filepath` all still needed — no change.

2. **`cmd/octog/main.go`**
   - `loadConfig()` (line 1525): `path, err := paths.ConfigFile()` — remove `warn` variable and the `if warn != ""` log block (lines 1529-1531).
   - `configureCmd()` (lines 1809-1821): `cfgPath, err := paths.ConfigFile()` — remove `warn` variable and the migration branch (lines 1814-1821).
   - Remove `migrateFromLegacy()` function (lines 1826-1853).
   - Imports: `filepath` is still used (lines 1783, 1789, 1959) — no change.

3. **`internal/paths/paths_test.go`**
   - Remove `TestConfigDir_LegacyFallback` (lines 51-75).
   - Remove `TestConfigDir_NewTakesPrecedence` (lines 77-108).
   - `TestConfigDir_Default` (line 17): `got, err := ConfigDir()` — remove `warn` variable and assertion.
   - `TestConfigDir_EnvOverride` (line 39): `got, err := ConfigDir()` — remove `warn` variable and assertion.
   - `TestConfigFile` (line 114): `got, err := ConfigFile()`.
   - Remove `"strings"` import (only used by deleted legacy test).

4. **`CLAUDE.md`** — Remove bullet 4 from the Configuration section (`~/.octopusgarden/config — legacy fallback (deprecated)`).

5. **`docs/architecture.md`**
   - Line 75: Remove "legacy" from paths package description (e.g., `# Platform-native config/data path resolution (XDG, macOS)`).
   - Line 1172: Remove bullet 4 documenting the legacy fallback path.

## Review Findings
- Errors: 0
- Warnings: 0
- Nits: 3
- Assessment: **PASS**

This is a straightforward, well-executed removal of deprecated legacy path support. The API surface is simplified (3-return to 2-return signatures), migration code and its callers are cleanly excised, docs are updated consistently across CLAUDE.md, architecture.md, and the godoc comments. No dangling references, no broken error handling chains.
