### PR TITLE
feat(interview): generate scenarios that pass preflight quality threshold

### DIFF
--- a/internal/interview/scenarios.go
+++ b/internal/interview/scenarios.go
@@ -15,7 +15,7 @@ import (
 
 // scenarioMaxTokens is the maximum number of tokens to request when generating
 // scenario YAML from a spec.
-const scenarioMaxTokens = 8192
+const scenarioMaxTokens = 12288
 
 var (
 	errNoValidScenarios    = errors.New("interview: no valid scenarios generated")

--- a/internal/interview/scenarios_prompt.go
+++ b/internal/interview/scenarios_prompt.go
@@ -89,16 +89,63 @@ Rules:
 - File names must be bare filenames only — no directory prefix (e.g., "happy-path.yaml" not "scenarios/happy-path.yaml")
 - Each file contains exactly one scenario
 - Use kebab-case for IDs and filenames (they should match)
-- Generate 3–5 scenarios that together provide good coverage
+- Generate 5–8 scenarios that together provide good coverage
 
 ## What Makes a Good Scenario Set
 
 - **Happy path**: The primary use case with valid inputs returns the expected result
+- **Happy-path variants**: include 2-3 happy paths covering full config, minimal config, and edge-case inputs
 - **Error cases**: Invalid inputs, missing auth, not-found resources return appropriate errors
+- **Exhaustive error coverage**: generate a scenario for every error/validation rule in the spec, not just a representative subset
 - **Edge cases**: Boundary values, empty collections, concurrent operations
+- **Multi-error aggregation**: when the spec mentions aggregated error reporting, include a scenario triggering multiple errors in one run
 - **Each scenario is independently runnable**: no hidden dependencies between scenarios
 - **Descriptive IDs**: "create-item-happy-path" not "test1"
 - **Specific satisfaction criteria**: describe observable outcomes, not implementation details
+
+## CLI / Exec Step Best Practices
+
+When generating exec steps, follow these patterns:
+
+**Multi-line shell commands** — use YAML block scalars to avoid quoting issues:
+` + "```yaml" + `
+exec:
+  command: |
+    bash -c '
+      cat > /tmp/config.yaml <<EOF
+    key: value
+    EOF
+      myapp --config /tmp/config.yaml
+    '
+` + "```" + `
+
+**Single-line shell commands** — wrap in bash -c for pipelines and redirects:
+` + "```yaml" + `
+exec:
+  command: "bash -c 'myapp --flag value 2>&1 | grep expected'"
+` + "```" + `
+
+**Cleanup steps** — add a cleanup step in setup to remove temp files created during the scenario:
+` + "```yaml" + `
+setup:
+  - description: Clean up temp files from previous run
+    exec:
+      command: "bash -c 'rm -f /tmp/myapp-*.yaml'"
+    expect: Exit code 0
+` + "```" + `
+
+**Assert exit codes and error content** — check exit code and that stderr is non-empty, not the exact error message:
+` + "```yaml" + `
+  - description: Run with invalid config
+    exec:
+      command: "myapp --config /tmp/bad.yaml"
+    expect: Exit code non-zero and stderr contains an error message
+    capture:
+      - name: exit_code
+        source: exitcode
+      - name: error_output
+        source: stderr
+` + "```" + `
 
 ## Example
 
@@ -149,6 +196,79 @@ steps:
       body:
         body: "No title here"
     expect: Returns 400 with an error message mentioning the missing title field
+=== END FILE ===
+
+For a CLI tool that processes config files:
+
+=== FILE: process-config-happy-path.yaml ===
+id: process-config-happy-path
+description: Processing a valid config file exits cleanly and produces expected output
+type: api
+satisfaction_criteria: |
+  The tool accepts a valid config file, processes it without errors, exits with
+  code 0, and writes output indicating successful processing.
+setup:
+  - description: Clean up temp files from previous run
+    exec:
+      command: "bash -c 'rm -f /tmp/test-config.yaml /tmp/test-output.txt'"
+    expect: Exit code 0
+steps:
+  - description: Write a valid config file
+    exec:
+      command: |
+        bash -c '
+          cat > /tmp/test-config.yaml <<EOF
+        name: example
+        value: 42
+        EOF
+        '
+    expect: Exit code 0, config file written
+  - description: Process the config file
+    exec:
+      command: "mytool --config /tmp/test-config.yaml --output /tmp/test-output.txt"
+      timeout: "10s"
+    expect: Exit code 0 and stderr is empty
+    capture:
+      - name: exit_code
+        source: exitcode
+  - description: Verify output file was created
+    exec:
+      command: "bash -c 'test -f /tmp/test-output.txt && cat /tmp/test-output.txt'"
+    expect: Exit code 0 and stdout contains the processed result
+=== END FILE ===
+
+=== FILE: process-config-missing-required-field.yaml ===
+id: process-config-missing-required-field
+description: Processing a config file missing a required field exits with an error
+type: api
+satisfaction_criteria: |
+  The tool rejects a config file missing the required name field, exits with a
+  non-zero code, and writes an error message to stderr mentioning the missing field.
+setup:
+  - description: Clean up temp files from previous run
+    exec:
+      command: "bash -c 'rm -f /tmp/bad-config.yaml'"
+    expect: Exit code 0
+steps:
+  - description: Write an invalid config file missing the required name field
+    exec:
+      command: |
+        bash -c '
+          cat > /tmp/bad-config.yaml <<EOF
+        value: 42
+        EOF
+        '
+    expect: Exit code 0, config file written
+  - description: Attempt to process the invalid config
+    exec:
+      command: "mytool --config /tmp/bad-config.yaml"
+      timeout: "10s"
+    expect: Exit code non-zero and stderr contains an error about the missing field
+    capture:
+      - name: exit_code
+        source: exitcode
+      - name: error_output
+        source: stderr
 === END FILE ===
 
 Now generate scenarios for the specification provided by the user.`

--- a/internal/interview/scenarios_prompt_test.go
+++ b/internal/interview/scenarios_prompt_test.go
@@ -1,0 +1,29 @@
+package interview
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestScenarioSystemPromptCLIGuidance(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		substring string
+	}{
+		{"block scalar guidance", "command: |"},
+		{"cleanup guidance", "cleanup"},
+		{"exit code assertion", "exit code"},
+		{"exec example present", "exec:"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if !strings.Contains(scenarioSystemPrompt, tc.substring) {
+				t.Errorf("scenarioSystemPrompt missing expected substring %q", tc.substring)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #272

## Changes
**1. `internal/interview/scenarios_prompt.go`** -- Modify `scenarioSystemPrompt`

- **Add a `## CLI / Exec Step Best Practices` section** before the final "Now generate scenarios..." line. Consolidate the 7 patterns into concise guidance (not 7 separate subsections). Target ~30 lines of added prompt text, not 60+. Specifically:
  - YAML block scalars (`command: |`) for multi-line shell with heredocs (Pattern 1)
  - `bash -c '...'` for single-line shell commands (Pattern 2)
  - Cleanup steps for temp files (Pattern 4)
  - Assert exit codes and non-empty stderr, not exact error messages (Pattern 5)
  
- **Add a CLI exec example** to the existing `## Example` section showing a complete exec-based scenario with block scalar, cleanup step, and exit code assertion. This is more valuable than the rules above.

- **Update `## What Makes a Good Scenario Set`** bullets:
  - Add: "**Exhaustive error coverage**: generate a scenario for every error/validation rule in the spec, not just a representative subset" (Pattern 3)
  - Add: "**Happy-path variants**: include 2-3 happy paths covering full config, minimal config, and edge-case inputs" (Pattern 6)
  - Add: "**Multi-error aggregation**: when the spec mentions aggregated error reporting, include a scenario triggering multiple errors in one run" (Pattern 7)

- **Change "Generate 3-5 scenarios"** to "Generate 5-8 scenarios" (not 5-10 -- keeps within `scenarioMaxTokens` budget).

- **Bump `scenarioMaxTokens`** from 8192 to 12288 in `scenarios.go` to accommodate the larger scenario sets.

**2. `internal/interview/scenarios.go`** -- Bump `scenarioMaxTokens` to 12288

One-line change. This is a code logic change the original plan missed.

## Review Findings
- Errors: 0
- Warnings: 0
- Nits: 5
- Assessment: **PASS**

This is a prompt-only change with a supporting smoke test. The expanded guidance for CLI/exec scenarios and the larger token budget are sensible improvements. No logic, error handling, or security concerns. The `type: api` on CLI examples (finding 3) is the only thing I'd double-check before merging — if that field is semantic rather than cosmetic, it could mislead the LLM.
