### PR TITLE
fix(preflight): scenario coverage score penalizes CLI-only test suites

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1008,7 +1008,7 @@ per-dimension strengths and gaps.
 
 Four dimensions, each scored 0.0–1.0 (unweighted average):
 
-- **Coverage** — Do scenarios exercise all spec behaviors?
+- **Coverage** — Do scenarios exercise all spec behaviors? Scoped to step types present in the suite (e.g., exec-only suites evaluated against CLI-observable behavior: exit codes, stdout/stderr, filesystem effects). Gaps flagged only for behavior the available step types could reasonably test.
 - **Feasibility** — Are scenarios executable as written?
 - **Isolation** — Does each scenario test one coherent behavior?
 - **Chains** — Are multi-step variable captures and substitutions correct?

--- a/internal/preflight/scenario.go
+++ b/internal/preflight/scenario.go
@@ -57,7 +57,7 @@ func buildScenarioSystemPrompt() string {
 
 Evaluate the scenarios on four dimensions, each scored from 0.0 (completely inadequate) to 1.0 (excellent):
 
-- coverage: Do the scenarios collectively exercise all behaviors described in the spec? Are happy paths, edge cases, and failure modes represented?
+- coverage: Do the scenarios collectively exercise all behaviors described in the spec? Are happy paths, edge cases, and failure modes represented? Scope your coverage evaluation to behavior that is testable via the step types present in the scenarios — for example, exec-only suites should be scored against CLI-observable behavior such as exit codes, stdout/stderr, and file system effects. Flag genuine gaps only when the spec describes behavior that the available step types could reasonably test.
 - feasibility: Are the scenarios executable as written? Do steps reference valid endpoints, actions, and data that an implementation could satisfy?
 - isolation: Does each scenario test one coherent behavior? Are scenarios free from hidden dependencies on each other's side effects?
 - chains: For multi-step scenarios, do step sequences form coherent chains? Are captures and variable substitutions used correctly?

--- a/internal/preflight/scenario_test.go
+++ b/internal/preflight/scenario_test.go
@@ -106,7 +106,7 @@ func TestParseScenarioResponse(t *testing.T) {
 
 func TestBuildScenarioSystemPrompt(t *testing.T) {
 	prompt := buildScenarioSystemPrompt()
-	for _, keyword := range []string{"coverage", "feasibility", "isolation", "chains", "JSON"} {
+	for _, keyword := range []string{"coverage", "feasibility", "isolation", "chains", "JSON", "step types", "testable"} {
 		if !strings.Contains(prompt, keyword) {
 			t.Errorf("system prompt missing keyword: %q", keyword)
 		}


### PR DESCRIPTION
Closes #273

## Changes
1. **`internal/preflight/scenario.go`** -- Modify `buildScenarioSystemPrompt()` (line 60)
   - Expand the `coverage` bullet point to instruct the LLM judge to scope coverage evaluation to behavior testable via the step types present in the scenarios (e.g., `exec`-only suites should be scored against CLI-observable behavior like exit codes, stdout/stderr, and file system effects -- not interactive or runtime behavior)
   - Insert after the existing sentence ("Are happy paths, edge cases, and failure modes represented?"), keeping it to 1-2 sentences

## Review Findings
- Errors: 0
- Warnings: 1
- Nits: 2
- Assessment: **NEEDS CHANGES** — the `.claude/worktrees/brave-feistel` submodule entry should be removed before merge.
