### PR TITLE
feat(scenario): add TUIRequest struct and loader support for tui step type

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -338,7 +338,7 @@ import (
 )
 
 var (
-	errUnknownStepType = errors.New("step has no recognized step type (need request, exec, browser, grpc, or ws)")
+	errUnknownStepType = errors.New("step has no recognized step type (need request, exec, browser, grpc, ws, or tui)")
 	errNoCapture       = errors.New("capture has neither source nor jsonpath")
 )
 
@@ -405,6 +405,7 @@ type Step struct {
 	Browser     *BrowserRequest `yaml:"browser"`
 	GRPC        *GRPCRequest    `yaml:"grpc"`
 	WS          *WSRequest      `yaml:"ws"`
+	TUI         *TUIRequest     `yaml:"tui"`
 	Retry       *Retry          `yaml:"retry"`
 	Expect      string          `yaml:"expect"` // natural language, judged by LLM
 	Capture     []Capture       `yaml:"capture"`
@@ -417,7 +418,7 @@ type Retry struct {
 	Timeout  string `yaml:"timeout"`  // overall timeout cap (optional)
 }
 
-// StepType returns the step type key: "request", "exec", "browser", "grpc", "ws", or "" if unknown.
+// StepType returns the step type key: "request", "exec", "browser", "grpc", "ws", "tui", or "" if unknown.
 func (s Step) StepType() string {
 	if s.Request != nil {
 		return "request"
@@ -433,6 +434,9 @@ func (s Step) StepType() string {
 	}
 	if s.WS != nil {
 		return "ws"
+	}
+	if s.TUI != nil {
+		return "tui"
 	}
 	return ""
 }
@@ -510,6 +514,17 @@ type WSReceive struct {
 	Timeout string `yaml:"timeout"` // receive timeout (default: 5s)
 	Count   int    `yaml:"count"`   // number of messages to collect (default: 1)
 }
+
+// TUIRequest describes a terminal UI interaction step.
+type TUIRequest struct {
+	Command      string `yaml:"command"`       // command to launch the TUI application (launch step)
+	SendKey      string `yaml:"send_key"`      // key sequence to send (e.g. "Enter", "ctrl+c")
+	SendText     string `yaml:"send_text"`     // text to type into the TUI
+	WaitFor      string `yaml:"wait_for"`      // text to wait for on screen before proceeding
+	AssertScreen string `yaml:"assert_screen"` // text that must be visible on screen
+	AssertAbsent string `yaml:"assert_absent"` // text that must NOT be visible on screen
+	Timeout      string `yaml:"timeout"`       // operation timeout as a Go duration
+}
 ```
 
 Result types (`HTTPResponse`, `StepResult`, `Result`, `StepScore`, `ScoredStep`, `ScoredScenario`,
@@ -547,7 +562,7 @@ satisfaction_criteria: |
 ```
 
 `weight` defaults to 1.0 in aggregate scoring when not set. `tier` is auto-inferred by `inferTier`
-in `loader.go` when not set (zero). Scoring: each step adds +1 base; `browser`, `grpc`, or `ws`
+in `loader.go` when not set (zero). Scoring: each step adds +1 base; `browser`, `grpc`, `ws`, or `tui`
 steps add +1 extra; a gRPC step with `stream` or a WS step with `receive` adds +1 extra; a step
 with `retry` adds +1 extra; mixed step types (>1 unique type) add +2 flat. Thresholds: score >6 or
 ≥3 steps with captures → 3 (complex); score >3 or ≥1 step with captures → 2 (moderate); else → 1
@@ -657,7 +672,7 @@ and gRPC fields. JSONPath evaluation supports dot-notation only (`$.field.sub`).
 ## Scenario Runner
 
 `Runner` (`internal/scenario/runner.go`) executes scenario steps via pluggable `StepExecutor`
-implementations (HTTP, exec, browser, gRPC). Setup steps are fatal — if any fails, the runner
+implementations (HTTP, exec, browser, gRPC, WS). The `tui` step type is recognized but returns `errTUINotImplemented` until a TUI executor is registered. Setup steps are fatal — if any fails, the runner
 returns an error immediately. Judged steps are non-fatal — transport
 errors are recorded and the step is scored 0 without making an LLM call.
 

--- a/internal/lint/rules.go
+++ b/internal/lint/rules.go
@@ -138,8 +138,8 @@ var ScenarioRules = []Rule{
 	{
 		ID:          "SC015",
 		Level:       Error,
-		Summary:     "step must have exactly one step type (request, exec, browser, grpc, or ws)",
-		MsgContains: "exactly one of request, exec, browser, grpc, or ws is required",
+		Summary:     "step must have exactly one step type (request, exec, browser, grpc, ws, or tui)",
+		MsgContains: "exactly one of request, exec, browser, grpc, ws, or tui is required",
 	},
 	{
 		ID:          "SC016",
@@ -245,7 +245,7 @@ var ScenarioRules = []Rule{
 		ID:          "SC032",
 		Level:       Error,
 		Summary:     "step must not have multiple step types",
-		MsgContains: "step has multiple step types; exactly one of request, exec, browser, grpc, or ws is required",
+		MsgContains: "step has multiple step types; exactly one of request, exec, browser, grpc, ws, or tui is required",
 	},
 	{
 		ID:          "SC033",
@@ -411,5 +411,30 @@ var ScenarioRules = []Rule{
 		Level:       Error,
 		Summary:     "ws receive count must be a positive integer",
 		MsgContains: "ws receive count must be a positive integer",
+	},
+	// TUI step rules.
+	{
+		ID:          "SC070",
+		Level:       Error,
+		Summary:     "tui must be a YAML mapping",
+		MsgContains: "tui must be a mapping",
+	},
+	{
+		ID:          "SC071",
+		Level:       Error,
+		Summary:     "tui step requires command or at least one interaction field",
+		MsgContains: "tui step requires command",
+	},
+	{
+		ID:          "SC072",
+		Level:       Error,
+		Summary:     "tui command must not be empty",
+		MsgContains: "tui command must not be empty",
+	},
+	{
+		ID:          "SC073",
+		Level:       Error,
+		Summary:     "tui timeout must be a valid Go duration",
+		MsgContains: "tui timeout: invalid duration",
 	},
 }

--- a/internal/lint/rules_test.go
+++ b/internal/lint/rules_test.go
@@ -169,6 +169,14 @@ func TestScenarioRulesSync(t *testing.T) {
 		"id: test\nsteps:\n  - description: d\n    ws:\n      url: /ws\n      receive:\n        timeout: badvalue\n    expect: ok\n",
 		// SC063: ws receive count zero
 		"id: test\nsteps:\n  - description: d\n    ws:\n      url: /ws\n      receive:\n        count: 0\n    expect: ok\n",
+		// SC070: tui not a mapping
+		"id: test\nsteps:\n  - description: d\n    tui: notamapping\n    expect: ok\n",
+		// SC071: tui step empty (no command, no actions)
+		"id: test\nsteps:\n  - description: d\n    tui: {}\n    expect: ok\n",
+		// SC072: tui command empty
+		"id: test\nsteps:\n  - description: d\n    tui:\n      command: \"\"\n    expect: ok\n",
+		// SC073: tui timeout invalid
+		"id: test\nsteps:\n  - description: d\n    tui:\n      command: myapp\n      timeout: notaduration\n    expect: ok\n",
 	}
 
 	// Rules that can only be triggered by dir-level checks.

--- a/internal/lint/scenario.go
+++ b/internal/lint/scenario.go
@@ -358,8 +358,9 @@ func lintStepType(path string, node *yaml.Node, fields map[string]*fieldEntry, c
 	browserFE, hasBrowser := fields["browser"]
 	grpcFE, hasGRPC := fields["grpc"]
 	wsFE, hasWS := fields["ws"]
+	tuiFE, hasTUI := fields["tui"]
 
-	typeCount := countTrue(hasReq, hasExec, hasBrowser, hasGRPC, hasWS)
+	typeCount := countTrue(hasReq, hasExec, hasBrowser, hasGRPC, hasWS, hasTUI)
 
 	switch {
 	case typeCount > 1:
@@ -367,14 +368,14 @@ func lintStepType(path string, node *yaml.Node, fields map[string]*fieldEntry, c
 			File:    path,
 			Line:    node.Line,
 			Level:   Error,
-			Message: "step has multiple step types; exactly one of request, exec, browser, grpc, or ws is required",
+			Message: "step has multiple step types; exactly one of request, exec, browser, grpc, ws, or tui is required",
 		}}
 	case typeCount == 0:
 		return "", []Diagnostic{{
 			File:    path,
 			Line:    node.Line,
 			Level:   Error,
-			Message: "step missing step type: exactly one of request, exec, browser, grpc, or ws is required",
+			Message: "step missing step type: exactly one of request, exec, browser, grpc, ws, or tui is required",
 		}}
 	case hasReq:
 		return "request", lintRequest(path, reqFE.value, cs)
@@ -386,6 +387,8 @@ func lintStepType(path string, node *yaml.Node, fields map[string]*fieldEntry, c
 		return "grpc", lintGRPC(path, grpcFE.value, cs)
 	case hasWS:
 		return "ws", lintWS(path, wsFE.value, cs)
+	case hasTUI:
+		return "tui", lintTUI(path, tuiFE.value, cs)
 	default:
 		return "", nil
 	}
@@ -982,6 +985,80 @@ func lintWS(path string, node *yaml.Node, cs *captureSet) []Diagnostic {
 	// Check receive (optional mapping with timeout and count).
 	if recvFE, ok := fields["receive"]; ok && recvFE.value.Kind == yaml.MappingNode {
 		diags = append(diags, lintWSReceive(path, recvFE.value)...)
+	}
+
+	return diags
+}
+
+func lintTUICommand(path string, fe *fieldEntry, cs *captureSet) []Diagnostic {
+	if fe.value.Kind != yaml.ScalarNode {
+		return []Diagnostic{{
+			File:    path,
+			Line:    fe.value.Line,
+			Level:   Error,
+			Message: "tui command must be a string",
+		}}
+	}
+	if fe.value.Value == "" {
+		return []Diagnostic{{
+			File:    path,
+			Line:    fe.value.Line,
+			Level:   Error,
+			Message: "tui command must not be empty",
+		}}
+	}
+	return checkVarRefs(extractVarRefs(fe.value.Value), cs, path, fe.value.Line)
+}
+
+func lintTUI(path string, node *yaml.Node, cs *captureSet) []Diagnostic {
+	if node.Kind != yaml.MappingNode {
+		return []Diagnostic{{
+			File:    path,
+			Line:    node.Line,
+			Level:   Error,
+			Message: "tui must be a mapping",
+		}}
+	}
+
+	var diags []Diagnostic
+	fields := nodeFields(node)
+
+	cmdFE, hasCmd := fields["command"]
+	_, hasSendKey := fields["send_key"]
+	_, hasSendText := fields["send_text"]
+	_, hasWaitFor := fields["wait_for"]
+	_, hasAssertScreen := fields["assert_screen"]
+	_, hasAssertAbsent := fields["assert_absent"]
+
+	if hasCmd {
+		diags = append(diags, lintTUICommand(path, cmdFE, cs)...)
+	} else if !hasSendKey && !hasSendText && !hasWaitFor && !hasAssertScreen && !hasAssertAbsent {
+		// Interaction step: must have at least one action field.
+		diags = append(diags, Diagnostic{
+			File:    path,
+			Line:    node.Line,
+			Level:   Error,
+			Message: "tui step requires command (launch) or at least one of send_key, send_text, wait_for, assert_screen, assert_absent (interaction)",
+		})
+	}
+
+	// Check var refs in action string fields.
+	for _, key := range []string{"send_key", "send_text", "wait_for", "assert_screen", "assert_absent"} {
+		if fe, ok := fields[key]; ok && fe.value.Value != "" {
+			diags = append(diags, checkVarRefs(extractVarRefs(fe.value.Value), cs, path, fe.value.Line)...)
+		}
+	}
+
+	// Validate timeout.
+	if timeoutFE, ok := fields["timeout"]; ok && timeoutFE.value.Value != "" {
+		if _, err := time.ParseDuration(timeoutFE.value.Value); err != nil {
+			diags = append(diags, Diagnostic{
+				File:    path,
+				Line:    timeoutFE.value.Line,
+				Level:   Error,
+				Message: fmt.Sprintf("tui timeout: invalid duration %q", timeoutFE.value.Value),
+			})
+		}
 	}
 
 	return diags

--- a/internal/lint/scenario_test.go
+++ b/internal/lint/scenario_test.go
@@ -86,7 +86,7 @@ steps:
     expect: "ok"
 `,
 			wantErrors: 1,
-			wantMsg:    "exactly one of request, exec, browser, grpc, or ws is required",
+			wantMsg:    "exactly one of request, exec, browser, grpc, ws, or tui is required",
 		},
 		{
 			name: "missing method",
@@ -1150,6 +1150,166 @@ steps:
 	}
 	if !found {
 		t.Errorf("expected duplicate ID diagnostic; got: %v", diags)
+	}
+}
+
+func TestLintTUISteps(t *testing.T) {
+	tests := []struct {
+		name       string
+		yaml       string
+		wantErrors int
+		wantWarns  int
+		wantMsg    string
+	}{
+		{
+			name: "valid tui launch step",
+			yaml: `id: test
+steps:
+  - description: Launch app
+    tui:
+      command: myapp
+    expect: "App launches"
+`,
+			wantErrors: 0,
+			wantWarns:  0,
+		},
+		{
+			name: "valid tui interaction step no command",
+			yaml: `id: test
+steps:
+  - description: Send key
+    tui:
+      send_key: "Enter"
+    expect: "ok"
+`,
+			wantErrors: 0,
+			wantWarns:  0,
+		},
+		{
+			name: "valid tui step all action fields",
+			yaml: `id: test
+steps:
+  - description: Interact
+    tui:
+      send_text: "hello"
+      wait_for: "prompt"
+      assert_screen: "ready"
+      assert_absent: "error"
+      timeout: 10s
+    expect: "ok"
+`,
+			wantErrors: 0,
+			wantWarns:  0,
+		},
+		{
+			name: "tui step empty no command no actions",
+			yaml: `id: test
+steps:
+  - description: Empty tui
+    tui: {}
+    expect: "ok"
+`,
+			wantErrors: 1,
+			wantMsg:    "tui step requires command",
+		},
+		{
+			name: "tui step empty command",
+			yaml: `id: test
+steps:
+  - description: Bad command
+    tui:
+      command: ""
+    expect: "ok"
+`,
+			wantErrors: 1,
+			wantMsg:    "tui command must not be empty",
+		},
+		{
+			name: "tui step invalid timeout",
+			yaml: `id: test
+steps:
+  - description: Bad timeout
+    tui:
+      command: myapp
+      timeout: notaduration
+    expect: "ok"
+`,
+			wantErrors: 1,
+			wantMsg:    "tui timeout: invalid duration",
+		},
+		{
+			name: "tui and request on same step",
+			yaml: `id: test
+steps:
+  - description: Ambiguous
+    tui:
+      command: myapp
+    request:
+      method: GET
+      path: /items
+    expect: "ok"
+`,
+			wantErrors: 1,
+			wantMsg:    "multiple step types",
+		},
+		{
+			name: "tui step with captured variable reference",
+			yaml: `id: test
+setup:
+  - description: Get name
+    request:
+      method: GET
+      path: /config
+    capture:
+      - name: app_name
+        jsonpath: $.name
+steps:
+  - description: Launch with var
+    tui:
+      command: "{app_name}"
+    expect: "ok"
+`,
+			wantErrors: 0,
+			wantWarns:  0,
+		},
+		{
+			name: "tui step with uncaptured variable",
+			yaml: `id: test
+steps:
+  - description: Launch missing var
+    tui:
+      command: "{missing_var}"
+    expect: "ok"
+`,
+			wantErrors: 0,
+			wantWarns:  1,
+			wantMsg:    "never captured",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			diags := lintScenarioContent("test.yaml", []byte(tt.yaml))
+			errs, warns := CountByLevel(diags)
+			if errs != tt.wantErrors {
+				t.Errorf("errors: got %d, want %d; diags: %v", errs, tt.wantErrors, diags)
+			}
+			if tt.wantWarns > 0 && warns != tt.wantWarns {
+				t.Errorf("warnings: got %d, want %d", warns, tt.wantWarns)
+			}
+			if tt.wantMsg != "" {
+				found := false
+				for _, d := range diags {
+					if strings.Contains(d.Message, tt.wantMsg) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected diagnostic containing %q, got: %v", tt.wantMsg, diags)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/scenario/loader.go
+++ b/internal/scenario/loader.go
@@ -128,7 +128,7 @@ func inferTier(s Scenario) int {
 		types[t] = struct{}{}
 
 		switch t {
-		case "browser", "grpc", "ws":
+		case "browser", "grpc", "ws", "tui":
 			score++
 		}
 		if step.GRPC != nil && step.GRPC.Stream != nil {

--- a/internal/scenario/loader_test.go
+++ b/internal/scenario/loader_test.go
@@ -238,6 +238,8 @@ func TestTierInference(t *testing.T) {
 			return Step{WS: &WSRequest{URL: "/ws"}}
 		case "exec":
 			return Step{Exec: &ExecRequest{Command: "echo"}}
+		case "tui":
+			return Step{TUI: &TUIRequest{Command: "myapp"}}
 		default:
 			return Step{Request: &Request{Method: "GET", Path: "/"}}
 		}
@@ -337,6 +339,12 @@ func TestTierInference(t *testing.T) {
 			wantTier: 1,
 		},
 		{
+			// 2x tui: score = 2*(1+1) = 4 > 3 → tier 2 (same as browser/grpc/ws)
+			name:     "2 tui steps no captures",
+			scenario: Scenario{ID: "t", Steps: []Step{makeStepOfType("tui"), makeStepOfType("tui")}},
+			wantTier: 2,
+		},
+		{
 			// 4x http: score = 4 > 3 → tier 2
 			name:     "4 http steps no captures",
 			scenario: Scenario{ID: "t", Steps: makeSteps(4)},
@@ -369,6 +377,60 @@ func TestTierInference(t *testing.T) {
 			t.Errorf("Tier = %d, want 1", s.Tier)
 		}
 	})
+}
+
+func TestLoad_TUIStep(t *testing.T) {
+	const input = `
+id: tui-test
+description: "Test TUI step loading"
+steps:
+  - description: "Launch app"
+    tui:
+      command: myapp
+      send_key: "Enter"
+      send_text: "hello"
+      wait_for: "prompt"
+      assert_screen: "ready"
+      assert_absent: "error"
+      timeout: 10s
+    expect: "App launches and responds"
+`
+	s, err := Load(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(s.Steps) != 1 {
+		t.Fatalf("len(Steps) = %d, want 1", len(s.Steps))
+	}
+	step := s.Steps[0]
+	if step.StepType() != "tui" {
+		t.Errorf("StepType() = %q, want %q", step.StepType(), "tui")
+	}
+	tui := step.TUI
+	if tui == nil {
+		t.Fatal("TUI is nil")
+	}
+	if tui.Command != "myapp" {
+		t.Errorf("Command = %q, want %q", tui.Command, "myapp")
+	}
+	if tui.SendKey != "Enter" {
+		t.Errorf("SendKey = %q, want %q", tui.SendKey, "Enter")
+	}
+	if tui.SendText != "hello" {
+		t.Errorf("SendText = %q, want %q", tui.SendText, "hello")
+	}
+	if tui.WaitFor != "prompt" {
+		t.Errorf("WaitFor = %q, want %q", tui.WaitFor, "prompt")
+	}
+	if tui.AssertScreen != "ready" {
+		t.Errorf("AssertScreen = %q, want %q", tui.AssertScreen, "ready")
+	}
+	if tui.AssertAbsent != "error" {
+		t.Errorf("AssertAbsent = %q, want %q", tui.AssertAbsent, "error")
+	}
+	if tui.Timeout != "10s" {
+		t.Errorf("Timeout = %q, want %q", tui.Timeout, "10s")
+	}
 }
 
 func TestComponentFieldRoundTrip(t *testing.T) {

--- a/internal/scenario/runner.go
+++ b/internal/scenario/runner.go
@@ -17,6 +17,7 @@ const (
 var (
 	errSetupFailed          = errors.New("runner: setup step failed")
 	errNoExecutorRegistered = errors.New("no executor registered for step type")
+	errTUINotImplemented    = errors.New("tui step type is not yet implemented")
 	errRetryInvalidInterval = errors.New("retry: invalid interval")
 	errRetryInvalidTimeout  = errors.New("retry: invalid timeout")
 	errInvalidDelay         = errors.New("step: invalid delay duration")
@@ -203,6 +204,9 @@ func (r *Runner) resolveExecutor(step Step) (StepExecutor, error) {
 	st := step.StepType()
 	if st == "" {
 		return nil, errUnknownStepType
+	}
+	if st == "tui" {
+		return nil, errTUINotImplemented
 	}
 	executor, ok := r.Executors[st]
 	if !ok {

--- a/internal/scenario/types.go
+++ b/internal/scenario/types.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	errUnknownStepType = errors.New("step has no recognized step type (need request, exec, browser, grpc, or ws)")
+	errUnknownStepType = errors.New("step has no recognized step type (need request, exec, browser, grpc, ws, or tui)")
 	errNoCapture       = errors.New("capture has neither source nor jsonpath")
 )
 
@@ -75,6 +75,7 @@ type Step struct {
 	Browser     *BrowserRequest `yaml:"browser"`
 	GRPC        *GRPCRequest    `yaml:"grpc"`
 	WS          *WSRequest      `yaml:"ws"`
+	TUI         *TUIRequest     `yaml:"tui"`
 	Retry       *Retry          `yaml:"retry"`
 	Expect      string          `yaml:"expect"` // natural language, judged by LLM
 	Capture     []Capture       `yaml:"capture"`
@@ -87,7 +88,7 @@ type Retry struct {
 	Timeout  string `yaml:"timeout"`  // overall timeout cap (optional)
 }
 
-// StepType returns the step type key: "request", "exec", "browser", "grpc", "ws", or "" if unknown.
+// StepType returns the step type key: "request", "exec", "browser", "grpc", "ws", "tui", or "" if unknown.
 func (s Step) StepType() string {
 	if s.Request != nil {
 		return "request"
@@ -103,6 +104,9 @@ func (s Step) StepType() string {
 	}
 	if s.WS != nil {
 		return "ws"
+	}
+	if s.TUI != nil {
+		return "tui"
 	}
 	return ""
 }
@@ -179,4 +183,15 @@ type WSRequest struct {
 type WSReceive struct {
 	Timeout string `yaml:"timeout"` // receive timeout (default: 5s)
 	Count   int    `yaml:"count"`   // number of messages to collect (default: 1)
+}
+
+// TUIRequest describes a terminal UI interaction step.
+type TUIRequest struct {
+	Command      string `yaml:"command"`       // command to launch the TUI application (launch step)
+	SendKey      string `yaml:"send_key"`      // key sequence to send (e.g. "Enter", "ctrl+c")
+	SendText     string `yaml:"send_text"`     // text to type into the TUI
+	WaitFor      string `yaml:"wait_for"`      // text to wait for on screen before proceeding
+	AssertScreen string `yaml:"assert_screen"` // text that must be visible on screen
+	AssertAbsent string `yaml:"assert_absent"` // text that must NOT be visible on screen
+	Timeout      string `yaml:"timeout"`       // operation timeout as a Go duration
 }

--- a/schemas/scenario-format.md
+++ b/schemas/scenario-format.md
@@ -21,7 +21,7 @@ Violations prevent the scenario from being loaded.
 | SC012 | steps must be a non-empty array |
 | SC013 | setup must be an array |
 | SC014 | each step must be a YAML mapping |
-| SC015 | step must have exactly one step type (request, exec, browser, grpc, or ws) |
+| SC015 | step must have exactly one step type (request, exec, browser, grpc, ws, or tui) |
 | SC018 | request must be a YAML mapping |
 | SC019 | request must have a method |
 | SC020 | HTTP method must be valid — Allowed: GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS. |
@@ -60,6 +60,10 @@ Violations prevent the scenario from being loaded.
 | SC060 | ws must be a YAML mapping |
 | SC062 | ws receive timeout must be a valid Go duration |
 | SC063 | ws receive count must be a positive integer |
+| SC070 | tui must be a YAML mapping |
+| SC071 | tui step requires command or at least one interaction field |
+| SC072 | tui command must not be empty |
+| SC073 | tui timeout must be a valid Go duration |
 
 ## SHOULD (Warnings)
 

--- a/schemas/scenario.json
+++ b/schemas/scenario.json
@@ -61,7 +61,8 @@
         { "required": ["exec"] },
         { "required": ["browser"] },
         { "required": ["grpc"] },
-        { "required": ["ws"] }
+        { "required": ["ws"] },
+        { "required": ["tui"] }
       ],
       "properties": {
         "description": {
@@ -73,13 +74,14 @@
         "browser": { "$ref": "#/$defs/browser_request" },
         "grpc": { "$ref": "#/$defs/grpc_request" },
         "ws": { "$ref": "#/$defs/ws_request" },
+        "tui": { "$ref": "#/$defs/tui_request" },
         "expect": {
           "type": "string",
           "description": "Natural-language expectation judged by the LLM."
         },
         "delay": {
           "type": "string",
-          "pattern": "^[0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h)+$",
+          "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
           "description": "Sleep duration before executing this step (e.g., '2s', '500ms'). Useful for TTL expiration and eventual consistency testing. Duration includes delay time in StepResult."
         },
         "retry": { "$ref": "#/$defs/retry" },
@@ -101,12 +103,12 @@
         },
         "interval": {
           "type": "string",
-          "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)+$",
+          "pattern": "^([0-9]+(ns|us|µs|ms|s|m|h))+$",
           "description": "Delay between retries as a Go duration (e.g. '1s', '500ms'). Default: 1s."
         },
         "timeout": {
           "type": "string",
-          "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)+$",
+          "pattern": "^([0-9]+(ns|us|µs|ms|s|m|h))+$",
           "description": "Overall timeout cap for all retry attempts as a Go duration. Optional."
         }
       }
@@ -155,7 +157,7 @@
         },
         "timeout": {
           "type": "string",
-          "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)+$",
+          "pattern": "^([0-9]+(ns|us|µs|ms|s|m|h))+$",
           "description": "Command timeout as a Go duration (e.g. '30s', '5m', '100ms'). Default: 30s."
         },
         "files": {
@@ -291,6 +293,49 @@
           "type": "integer",
           "minimum": 1,
           "description": "Number of messages to collect. Default: 1."
+        }
+      }
+    },
+    "tui_request": {
+      "type": "object",
+      "additionalProperties": false,
+      "anyOf": [
+        {"required": ["command"]},
+        {"required": ["send_key"]},
+        {"required": ["send_text"]},
+        {"required": ["wait_for"]},
+        {"required": ["assert_screen"]},
+        {"required": ["assert_absent"]}
+      ],
+      "properties": {
+        "command": {
+          "type": "string",
+          "description": "Command to launch the TUI application (launch step). May contain {variable} references."
+        },
+        "send_key": {
+          "type": "string",
+          "description": "Key sequence to send to the TUI (e.g. 'Enter', 'ctrl+c'). May contain {variable} references."
+        },
+        "send_text": {
+          "type": "string",
+          "description": "Text to type into the TUI. May contain {variable} references."
+        },
+        "wait_for": {
+          "type": "string",
+          "description": "Text to wait for on screen before proceeding. May contain {variable} references."
+        },
+        "assert_screen": {
+          "type": "string",
+          "description": "Text that must be visible on screen. May contain {variable} references."
+        },
+        "assert_absent": {
+          "type": "string",
+          "description": "Text that must NOT be visible on screen. May contain {variable} references."
+        },
+        "timeout": {
+          "type": "string",
+          "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
+          "description": "Operation timeout as a Go duration (e.g. '30s', '5s')."
         }
       }
     },


### PR DESCRIPTION
Closes #276

## Changes
1. **`internal/scenario/types.go`**
   - Add `TUI *TUIRequest` field to `Step` (after `WS`, before `Retry`), yaml tag `"tui"`
   - Add `TUIRequest` struct: `Command string`, `SendKey string`, `SendText string`, `WaitFor string`, `AssertScreen string`, `AssertAbsent string`, `Timeout string` (all with yaml tags)
   - Add `"tui"` case to `StepType()` (after ws, before default return)
   - Update `errUnknownStepType` message to include `"tui"`
   - Update `StepType()` doc comment to include `"tui"`

2. **`internal/scenario/loader.go`**
   - Add `"tui"` to `inferTier()` complexity bonus: `case "browser", "grpc", "ws", "tui":`

3. **`internal/lint/scenario.go`**
   - In `lintStepType()`: add `tuiFE, hasTUI` lookup, add `hasTUI` to `countTrue()`, add `case hasTUI` branch returning `lintTUI()`, update both error messages to include `"tui"`
   - Add `lintTUI(path string, node *yaml.Node, cs *captureSet) []Diagnostic`:
     - Validate mapping
     - If `command` present: require non-empty
     - If `command` absent: require at least one of `send_key`, `send_text`, `wait_for`, `assert_screen`, `assert_absent`
     - Validate `timeout` as Go duration if present
     - Check var refs in all string fields

4. **`schemas/scenario.json`**
   - Add `TUIRequest` definition with the seven fields
   - Add `tui` property to step definition, reference the new definition
   - Add to the step type oneOf/validation as appropriate

## Review Findings
- Errors: 0
- Warnings: 2
- Nits: 2
- Assessment: NEEDS CHANGES

The type definitions, lint rules, tests, and docs are all well-structured and follow the established pattern precisely. The two warnings are about runtime safety (runner dispatch for unimplemented step type) and schema/linter parity (JSON schema missing constraints). Both are worth addressing before merge.
