### PR TITLE
fix: interview-generated specs and scenarios should pass preflight checks

### DIFF
--- a/internal/interview/scenarios_prompt.go
+++ b/internal/interview/scenarios_prompt.go
@@ -1,5 +1,6 @@
 package interview
 
+// scenarioSystemPrompt is coupled with internal/preflight/scenario.go buildScenarioSystemPrompt() -- keep dimensions aligned.
 const scenarioSystemPrompt = `You are a scenario generator for OctopusGarden, an autonomous software factory.
 Given a software specification, generate a set of holdout validation scenarios in YAML format.
 
@@ -74,6 +75,9 @@ capture:
     source: exitcode      # for exec steps: stdout, stderr, exitcode
 ` + "```" + `
 
+Every ` + "`{{variable}}`" + ` reference must correspond to a ` + "`capture`" + ` in a preceding step of the same scenario.
+Use ` + "`jsonpath`" + ` for HTTP responses and ` + "`source`" + ` (stdout/stderr/exitcode) for exec steps -- never mix them within a single capture block.
+
 ## Output Format
 
 Output each scenario as a separate file block using EXACTLY this format.
@@ -99,11 +103,23 @@ Rules:
 - **Exhaustive error coverage**: generate a scenario for every error/validation rule in the spec, not just a representative subset
 - **Edge cases**: Boundary values, empty collections, concurrent operations
 - **Multi-error aggregation**: when the spec mentions aggregated error reporting, include a scenario triggering multiple errors in one run
+- **Single behavior per scenario**: each scenario tests exactly one coherent behavior; do not combine unrelated assertions
 - **Each scenario is independently runnable**: no hidden dependencies between scenarios
 - **Descriptive IDs**: "create-item-happy-path" not "test1"
 - **Specific satisfaction criteria**: describe observable outcomes, not implementation details
 
+## Quality Criteria (self-check before finalizing)
+
+Before finalizing output, verify your scenarios score well on all four criteria and revise any that fall short:
+
+- **coverage**: Do the scenarios collectively exercise all behaviors described in the spec? Happy paths, edge cases, and failure modes all represented?
+- **feasibility**: Are the scenarios executable as written? Do steps reference valid endpoints, commands, and data an implementation could satisfy?
+- **isolation**: Does each scenario test one coherent behavior? No hidden dependencies on other scenarios' side effects?
+- **chains**: For multi-step scenarios, do step sequences form coherent chains? Are captures and variable substitutions used correctly?
+
 ## CLI / Exec Step Best Practices
+
+All shell commands involving heredocs, pipes, redirects, or multi-line logic MUST be wrapped in bash -c '...' -- the exec runner does not invoke a shell by default.
 
 When generating exec steps, follow these patterns:
 

--- a/internal/interview/scenarios_prompt_test.go
+++ b/internal/interview/scenarios_prompt_test.go
@@ -16,6 +16,10 @@ func TestScenarioSystemPromptCLIGuidance(t *testing.T) {
 		{"cleanup guidance", "cleanup"},
 		{"exit code assertion", "exit code"},
 		{"exec example present", "exec:"},
+		{"quality criteria self-check section", "Quality Criteria"},
+		{"capture chain requirement", "preceding step"},
+		{"isolation requirement", "Single behavior per scenario"},
+		{"bash -c requirement language", "MUST be wrapped"},
 	}
 
 	for _, tc := range tests {

--- a/internal/preflight/scenario.go
+++ b/internal/preflight/scenario.go
@@ -52,6 +52,7 @@ type scenarioPreflightResponse struct {
 	Issues      []ScenarioIssue `json:"issues"`
 }
 
+// buildScenarioSystemPrompt is coupled with internal/interview/scenarios_prompt.go -- keep dimensions aligned.
 func buildScenarioSystemPrompt() string {
 	return `You are a scenario quality analyst. Your job is to assess how well a set of test scenarios covers and exercises a software specification.
 


### PR DESCRIPTION
Closes #271

## Changes
1. **`internal/interview/scenarios_prompt.go`** -- Add preflight-aligned guidance to `scenarioSystemPrompt`

   - **Add self-check section** (highest impact): After the "What Makes a Good Scenario Set" section, add a new section "## Quality Criteria (self-check before finalizing)" listing the four preflight dimensions (coverage, feasibility, isolation, chains) with one-line descriptions matching the preflight rubric in `buildScenarioSystemPrompt()`. Instruct the LLM: "Before finalizing output, verify your scenarios score well on all four criteria and revise any that fall short." Keep to ~10 lines max.
   
   - **Strengthen capture/chain guidance**: In the "Capture and Variable Substitution" section, add: "Every `{{variable}}` reference must correspond to a `capture` in a preceding step of the same scenario. Use `jsonpath` for HTTP responses and `source` (stdout/stderr/exitcode) for exec steps -- never mix them within a single capture block."
   
   - **Add isolation note**: In "What Makes a Good Scenario Set," add bullet: "**Single behavior per scenario**: each scenario tests exactly one coherent behavior; do not combine unrelated assertions"
   
   - **Add feasibility reinforcement**: At the top of "CLI / Exec Step Best Practices," add one line: "All shell commands involving heredocs, pipes, redirects, or multi-line logic MUST be wrapped in `bash -c '...'` -- the exec runner does not invoke a shell by default."
   
   - **Add cross-reference comment**: At the top of the file, add a comment: `// scenarioSystemPrompt is coupled with internal/preflight/scenario.go buildScenarioSystemPrompt() -- keep dimensions aligned.`

2. **`internal/preflight/scenario.go`** -- Add cross-reference comment
   - Above `buildScenarioSystemPrompt()`, add: `// buildScenarioSystemPrompt is coupled with internal/interview/scenarios_prompt.go -- keep dimensions aligned.`

## Review Findings
- Errors: 0
- Warnings: 0
- Nits: 4
- Assessment: **PASS**

This is a clean, low-risk change — prompt content additions with matching test coverage and helpful cross-reference comments. No logic, no error handling, no concurrency, no security surface.
