### PR TITLE
feat(examples): add TUI example spec and scenarios

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -129,13 +129,13 @@ content and failure feedback as strings. The validator (scenario runner + judge)
 | ------- | ------- | --------- | ------------ |
 | `attractor` | Convergence loop: generate code, build, validate, iterate | `attractor.go`, `convergence.go`, `diagnosis.go`, `escalation.go`, `oscillation.go`, `regression.go`, `prompts.go`, `fileparse.go`, `languages.go`, `triage.go`, `toposort.go` | `llm`, `spec`, `container`, `gene` |
 | `container` | Docker image build, container run, health check, exec sessions | `docker.go` | docker SDK |
-| `scenario` | Load YAML scenarios, execute steps, LLM-judge scoring | `types.go`, `loader.go`, `runner.go`, `judge.go`, `result.go`, `jsonpath.go`, `grpc.go` | `llm` |
+| `scenario` | Load YAML scenarios, execute steps, LLM-judge scoring | `types.go`, `loader.go`, `runner.go`, `judge.go`, `result.go`, `jsonpath.go`, `grpc.go`, `sources.go`, `sources_tui.go` (Unix), `sources_tui_windows.go` | `llm` |
 | `spec` | Parse markdown specs, pyramid summarization | `parser.go`, `types.go`, `summary.go` | (none) |
 | `llm` | Model-agnostic LLM client, cost tracking, prompt templates | `client.go`, `anthropic.go`, `openai.go`, `models.go`, `json.go`, `prompt.go` | anthropic-sdk, openai-sdk |
 | `gene` | Scan exemplar codebases, LLM pattern extraction | `gene.go`, `scan.go`, `analyze.go` | `llm`, `spec` |
 | `interview` | Conversational spec-drafting, spec-completeness scoring, holdout scenario generation | `interview.go`, `prompt.go`, `scoring.go`, `scoring_prompt.go`, `scenarios.go`, `scenarios_prompt.go` | `llm`, `attractor`, `scenario` |
 | `preflight` | Pre-run quality assessment of specs and scenarios | `preflight.go`, `scenario.go` | `llm` |
-| `lint` | Structural linting for specs and scenario YAML | `spec.go`, `scenario.go`, `diagnostic.go`, `varcheck.go` | (none) |
+| `lint` | Structural linting for specs and scenario YAML | `spec.go`, `scenario.go`, `diagnostic.go`, `varcheck.go`, `tui_unix.go`, `tui_windows.go` | (none) |
 | `observability` | OpenTelemetry tracing wrappers | `setup.go` | `llm`, `container`, otel SDK |
 | `store` | SQLite run/iteration persistence | `db.go`, `types.go` | modernc.org/sqlite |
 | `ui` | Display implementations for interview TUI (plain text + styled terminal) | `display.go`, `styled.go` | lipgloss, glamour |
@@ -706,6 +706,11 @@ Capture sources: `screen` (current terminal screen, trailing whitespace stripped
 `TUIExecutor` is stateful across steps. `Close()` signals the entire process group with `SIGTERM`,
 waits up to 500ms, then `SIGKILL` if still running. Registered via `registerTUIExecutor`
 (`cmd/octog/tui.go`) when `ScenarioCapabilities.NeedsTUI` is true; no-op on Windows (`tui_windows.go`).
+
+Platform-conditional build tags apply in two other places:
+
+- **Capture source map** (`scenario/sources_tui.go` / `scenario/sources_tui_windows.go`): on Unix, `tuiStepExecutor()` returns `&TUIExecutor{}` so TUI capture sources are registered in `CaptureSourceMap()`; on Windows it returns nil and TUI is excluded.
+- **Lint diagnostics** (`lint/tui_unix.go` / `lint/tui_windows.go`): `tuiPlatformDiags()` returns nil on Unix; on Windows it returns a `Warning` diagnostic: _"tui steps are not supported on Windows; this scenario will fail at runtime"_.
 
 ### Variable Capture and Substitution
 

--- a/examples/tui-demo/scenarios/navigation.yaml
+++ b/examples/tui-demo/scenarios/navigation.yaml
@@ -1,0 +1,49 @@
+id: navigation
+description: Menu navigation increments, decrements, and quits cleanly
+type: functional
+tier: 1
+satisfaction_criteria: Menu navigation works, counter updates correctly, quit exits cleanly
+
+setup:
+  - description: Launch app and wait for initial render
+    tui:
+      command: "./app"
+      wait_for: "Counter: 0"
+
+steps:
+  - description: Verify menu is visible
+    tui:
+      assert_screen: "Increment"
+    expect: "Menu is visible with at least an Increment option"
+
+  - description: Increment counter to 1
+    tui:
+      send_key: "1"
+      wait_for: "Counter: 1"
+    expect: "Counter displays 1 after pressing 1"
+
+  - description: Increment counter to 2
+    tui:
+      send_key: "1"
+      wait_for: "Counter: 2"
+    expect: "Counter displays 2 after pressing 1 again"
+
+  - description: Decrement counter to 1
+    tui:
+      send_key: "2"
+      wait_for: "Counter: 1"
+    expect: "Counter displays 1 after pressing 2 to decrement"
+
+  - description: Verify counter is 1 and Counter:2 is absent
+    tui:
+      assert_screen: "Counter: 1"
+      assert_absent: "Counter: 2"
+    expect: "Screen shows Counter: 1 and does not show Counter: 2"
+
+  - description: Quit and capture exit code
+    tui:
+      send_key: "4"
+    capture:
+      - name: exit_code
+        source: exit_code
+    expect: "Exit code is 0"

--- a/examples/tui-demo/scenarios/reset.yaml
+++ b/examples/tui-demo/scenarios/reset.yaml
@@ -1,0 +1,44 @@
+id: reset
+description: Reset returns counter to zero after incrementing
+type: functional
+tier: 1
+satisfaction_criteria: Reset returns counter to zero after incrementing
+
+setup:
+  - description: Launch app and wait for initial render
+    tui:
+      command: "./app"
+      wait_for: "Counter: 0"
+
+steps:
+  - description: Increment counter to 1
+    tui:
+      send_key: "1"
+      wait_for: "Counter: 1"
+    expect: "Counter displays 1 after pressing 1"
+
+  - description: Increment counter to 2
+    tui:
+      send_key: "1"
+      wait_for: "Counter: 2"
+    expect: "Counter displays 2 after pressing 1 again"
+
+  - description: Reset counter to 0
+    tui:
+      send_key: "3"
+      wait_for: "Counter: 0"
+    expect: "Counter displays 0 after pressing 3 to reset"
+
+  - description: Verify counter is 0 and Counter:2 is absent
+    tui:
+      assert_screen: "Counter: 0"
+      assert_absent: "Counter: 2"
+    expect: "Screen shows Counter: 0 and does not show Counter: 2"
+
+  - description: Quit and capture exit code
+    tui:
+      send_key: "4"
+    capture:
+      - name: exit_code
+        source: exit_code
+    expect: "Exit code is 0"

--- a/examples/tui-demo/spec.md
+++ b/examples/tui-demo/spec.md
@@ -1,0 +1,33 @@
+# Counter TUI
+
+A menu-driven terminal counter application.
+
+## Display
+
+The application renders in the terminal with:
+
+- A header showing the current counter value: `Counter: N` (starts at 0)
+- A numbered menu with four options:
+  1. Increment
+  1. Decrement
+  1. Reset
+  1. Quit
+
+All output must fit within 80 columns and 24 rows.
+
+## Behavior
+
+- Pressing `1` increments the counter by 1 and re-renders the display
+- Pressing `2` decrements the counter by 1 and re-renders the display
+- Pressing `3` resets the counter to 0 and re-renders the display
+- Pressing `4` exits the application with exit code 0
+- Any other key is ignored; the display re-renders unchanged
+
+## Requirements
+
+- Pure stdin/stdout terminal application; no network required
+- Runs as a single binary named `app` in the container working directory
+- The command to launch is `./app`
+- After each key press the updated counter value is visible immediately
+- Counter may go negative (decrement below 0 is allowed)
+- Any programming language

--- a/internal/lint/scenario.go
+++ b/internal/lint/scenario.go
@@ -1020,7 +1020,7 @@ func lintTUI(path string, node *yaml.Node, cs *captureSet) []Diagnostic {
 		}}
 	}
 
-	var diags []Diagnostic
+	diags := tuiPlatformDiags(path, node)
 	fields := nodeFields(node)
 
 	cmdFE, hasCmd := fields["command"]

--- a/internal/lint/tui_unix.go
+++ b/internal/lint/tui_unix.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package lint
+
+import "gopkg.in/yaml.v3"
+
+// tuiPlatformDiags returns nil on non-Windows platforms where TUI steps are supported.
+func tuiPlatformDiags(_ string, _ *yaml.Node) []Diagnostic {
+	return nil
+}

--- a/internal/lint/tui_windows.go
+++ b/internal/lint/tui_windows.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+package lint
+
+import "gopkg.in/yaml.v3"
+
+// tuiPlatformDiags returns a warning on Windows where TUI steps are not supported.
+func tuiPlatformDiags(path string, node *yaml.Node) []Diagnostic {
+	return []Diagnostic{{
+		File:    path,
+		Line:    node.Line,
+		Level:   Warning,
+		Message: "tui steps are not supported on Windows; this scenario will fail at runtime",
+	}}
+}

--- a/internal/scenario/sources.go
+++ b/internal/scenario/sources.go
@@ -12,6 +12,10 @@ func CaptureSourceMap() map[string]map[string]bool {
 		"request": &HTTPExecutor{},
 	}
 
+	if e := tuiStepExecutor(); e != nil {
+		types["tui"] = e
+	}
+
 	result := make(map[string]map[string]bool, len(types))
 	for name, exec := range types {
 		sources := exec.ValidCaptureSources()

--- a/internal/scenario/sources_tui.go
+++ b/internal/scenario/sources_tui.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package scenario
+
+// tuiStepExecutor returns the TUIExecutor for inclusion in the capture source map on Unix.
+func tuiStepExecutor() StepExecutor {
+	return &TUIExecutor{}
+}

--- a/internal/scenario/sources_tui_windows.go
+++ b/internal/scenario/sources_tui_windows.go
@@ -1,0 +1,8 @@
+//go:build windows
+
+package scenario
+
+// tuiStepExecutor returns nil on Windows; TUI steps are not supported.
+func tuiStepExecutor() StepExecutor {
+	return nil
+}

--- a/scripts/e2e-test.py
+++ b/scripts/e2e-test.py
@@ -32,7 +32,7 @@ THRESHOLD = os.environ.get("E2E_THRESHOLD", "95")
 RESULTS_DIR = Path(os.environ.get("E2E_RESULTS_DIR", "e2e-results"))
 PARALLEL = int(os.environ.get("E2E_PARALLEL", "4"))
 
-AVAILABLE_SUITES = ("validate", "basic", "stratified", "modes", "multilang")
+AVAILABLE_SUITES = ("validate", "basic", "stratified", "modes", "multilang", "tui")
 
 # ---------------------------------------------------------------------------
 # Output helpers
@@ -420,12 +420,26 @@ def suite_validate(r: Results) -> None:
     )
 
 
+def suite_tui(r: Results) -> None:
+    header("TUI Convergence")
+    print("Menu-driven counter TUI application.")
+
+    r.record(
+        _run_convergence(
+            "tui-demo-basic",
+            "examples/tui-demo/spec.md",
+            "examples/tui-demo/scenarios/",
+        )
+    )
+
+
 SUITE_MAP = {
     "basic": suite_basic,
     "stratified": suite_stratified,
     "modes": suite_modes,
     "multilang": suite_multilang,
     "validate": suite_validate,
+    "tui": suite_tui,
 }
 
 


### PR DESCRIPTION
Closes #287

## Changes
**1. Create `examples/tui-demo/spec.md`**
A minimal spec for a menu-driven counter TUI application. Requirements:
- Display a numbered menu (1. Increment, 2. Decrement, 3. Reset, 4. Quit)
- Show current counter value (starts at 0)
- Respond to number key presses to select menu items
- Exit cleanly with code 0 when Quit is selected
- No network; pure stdin/stdout TUI; runs via `command` in the container
- Keep terminal output well within 80x24 (the TUI executor's fixed dimensions)

**2. Create `examples/tui-demo/scenarios/navigation.yaml`**
Primary scenario exercising core TUI features. All TUI actions nested under `tui:` key:
- `id: navigation`, `type: functional`, `tier: 1`
- `setup`:
  - Step 1: `tui: { command: "./app", wait_for: "Counter: 0" }` -- launch and wait for initial render
- `steps`:
  - `tui: { assert_screen: "Increment" }` -- verify menu visible
  - `tui: { send_key: "1", wait_for: "Counter: 1" }` -- select increment, verify update
  - `tui: { send_key: "1", wait_for: "Counter: 2" }` -- increment again
  - `tui: { send_key: "2", wait_for: "Counter: 1" }` -- decrement
  - `tui: { assert_screen: "Counter: 1", assert_absent: "Counter: 2" }` -- verify current state
  - `tui: { send_key: "4" }` with `capture: [{ name: exit_code, source: exit_code }]` -- quit and capture exit code
  - `expect: "Exit code is 0"` on the quit step
- `satisfaction_criteria`: "Menu navigation works, counter updates correctly, quit exits cleanly"

**3. Create `examples/tui-demo/scenarios/reset.yaml`**
Secondary scenario covering reset:
- `id: reset`, `type: functional`, `tier: 1`
- `setup`:
  - `tui: { command: "./app", wait_for: "Counter: 0" }`
- `steps`:
  - `tui: { send_key: "1", wait_for: "Counter: 1" }` -- increment
  - `tui: { send_key: "1", wait_for: "Counter: 2" }` -- increment again
  - `tui: { send_key: "3", wait_for: "Counter: 0" }` -- reset
  - `tui: { assert_screen: "Counter: 0", assert_absent: "Counter: 2" }` -- verify reset
  - `tui: { send_key: "4" }` with capture of exit_code
- `satisfaction_criteria`: "Reset returns counter to zero after incrementing"

**4. Modify `scripts/e2e-test.py`**
- Add `"tui"` to `AVAILABLE_SUITES` tuple (line 35)
- Add `suite_tui` function using `_run_convergence("tui-demo-basic", "examples/tui-demo/spec.md", "examples/tui-demo/scenarios/")`
- Register `"tui": suite_tui` in `SUITE_MAP`
- TUI suite is separate from `suite_basic` so it can be skipped independently

## Review Findings
- Errors: 0
- Warnings: 1
- Nits: 5
- Assessment: **NEEDS CHANGES** (warning #2 — silent TUI omission on Windows could mask lint issues)
